### PR TITLE
Feature/delete marker logging

### DIFF
--- a/export-default-env-vars.sh
+++ b/export-default-env-vars.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo 'setting default env vars...'
+
+: ${db_audit_url='jdbc:postgresql://localhost:5432/audit'} # set the default connection url if its not already defined.
+: ${db_audit_username='postgres'} # set the default connection url if its not already defined.
+: ${db_audit_password='mysecretpassword'} # set the default connection url if its not already defined.
+
+export db_audit_url
+export db_audit_username
+export db_audit_password

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ export PORT="8082"
 export RESTOLINO_STATIC="src/main/resources/files"
 export RESTOLINO_CLASSES="zebedee-cms/target/classes"
 export PACKAGE_PREFIX=com.github.onsdigital.zebedee
-export audit_db_enabled=true
+export audit_db_enabled=false
 
 # Development: reloadable
 mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ./export-default-env-vars.sh
+
 export JAVA_OPTS=" -Xmx512m -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
 export PORT="8082"
 
@@ -7,7 +9,7 @@ export PORT="8082"
 export RESTOLINO_STATIC="src/main/resources/files"
 export RESTOLINO_CLASSES="zebedee-cms/target/classes"
 export PACKAGE_PREFIX=com.github.onsdigital.zebedee
-export audit_db_enabled=false
+export audit_db_enabled=true
 
 # Development: reloadable
 mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \

--- a/update-database.sh
+++ b/update-database.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+source ./export-default-env-vars.sh
+
 mvn -f zebedee-cms/pom.xml liquibase:update

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DeleteContent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DeleteContent.java
@@ -97,7 +97,7 @@ public class DeleteContent {
             return new DeleteContentResponse(HttpStatus.SC_BAD_REQUEST);
         }
 
-        deleteService.cancelPendingDelete(collection, contentUri.get());
+        deleteService.cancelPendingDelete(collection, session, contentUri.get());
         return new DeleteContentResponse(HttpStatus.SC_OK);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/audit/Audit.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/audit/Audit.java
@@ -107,7 +107,14 @@ public class Audit {
         /**
          * CSDB events.
          */
-        CSDB_NEW_FILE_NOTIFICATION("CSDB file notification received");
+        CSDB_NEW_FILE_NOTIFICATION("CSDB file notification received"),
+
+        /**
+         * Content Delete Markers
+         */
+        DELETE_MARKER_ADDED("Delete Marker added to content."),
+
+        DELETE_MARKER_REMOVED("Delete marker removed from content.");
 
         /**
          * The event description.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/EventType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/EventType.java
@@ -15,5 +15,6 @@ public enum EventType {
     VERSIONED,
     MOVED,
     RENAMED,
-    MARKED_DELETE
+    MARKED_DELETE,
+    DELETE_MARKER_REMOVED
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/EventType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/EventType.java
@@ -15,6 +15,6 @@ public enum EventType {
     VERSIONED,
     MOVED,
     RENAMED,
-    MARKED_DELETE,
+    DELETE_MARKER_ADDED,
     DELETE_MARKER_REMOVED
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/CollectionEventType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/CollectionEventType.java
@@ -129,7 +129,17 @@ public enum CollectionEventType {
     /**
      * Collection content moved.
      */
-    COLLECTION_CONTENT_MOVED("collection.content.moved.description");
+    COLLECTION_CONTENT_MOVED("collection.content.moved.description"),
+
+    /**
+     * Delete marker added to content.
+     */
+    DELETE_MARKED_ADDED("delete.marker.added.description"),
+
+    /**
+     * Delete marker removed from content.
+     */
+    DELETE_MARKED_REMOVED("delete.marker.removed.description");
 
     private final String descriptionKey;
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Provides functionality for created the necessary meta data items for each event history scenario.
@@ -48,6 +49,8 @@ public class CollectionEventMetaData {
     static final String INDEX_PAGE = "indexPage";
     static final String URI = "uri";
     static final String TABLE_MODIFICATIONS = "tableModifications";
+    static final String DELETE_MARKER_ADDED = "deleteMarkerAdded";
+    static final String DELETE_MARKER_REMOVED = "deleteMarkerRemoved";
 
     private static final String HTML = ".html";
     private static final String XLS = ".xls";
@@ -268,6 +271,20 @@ public class CollectionEventMetaData {
             return toArray(list);
         }
         return null;
+    }
+
+    public static CollectionEventMetaData[] deleteMarkerAdded(List<String> uris) {
+        return toArray(uris
+                .stream()
+                .map(uri -> new CollectionEventMetaData(DELETE_MARKER_ADDED, uri))
+                .collect(Collectors.toList()));
+    }
+
+    public static CollectionEventMetaData[] deleteMarkerRemoved(List<String> uris) {
+        return toArray(uris
+                .stream()
+                .map(uri -> new CollectionEventMetaData(DELETE_MARKER_REMOVED, uri))
+                .collect(Collectors.toList()));
     }
 
     private static String fileIndex(int index) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
@@ -11,6 +11,8 @@ import com.github.onsdigital.zebedee.json.Team;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -51,6 +53,8 @@ public class CollectionEventMetaData {
     static final String TABLE_MODIFICATIONS = "tableModifications";
     static final String DELETE_MARKER_ADDED = "deleteMarkerAdded";
     static final String DELETE_MARKER_REMOVED = "deleteMarkerRemoved";
+    static final String DELETE_ROOT = "deleteRoot";
+    static final String DELETE_ROOT_REMOVED = "deleteRootRemoved";
 
     private static final String HTML = ".html";
     private static final String XLS = ".xls";
@@ -273,18 +277,22 @@ public class CollectionEventMetaData {
         return null;
     }
 
-    public static CollectionEventMetaData[] deleteMarkerAdded(List<String> uris) {
-        return toArray(uris
-                .stream()
+    public static CollectionEventMetaData[] deleteMarkerAdded(String deleteRoot, List<String> uris) {
+        List<CollectionEventMetaData> markedDelete = new ArrayList<>();
+        markedDelete.add(create(DELETE_ROOT, deleteRoot));
+        markedDelete.addAll(uris.stream()
                 .map(uri -> new CollectionEventMetaData(DELETE_MARKER_ADDED, uri))
                 .collect(Collectors.toList()));
+        return toArray(markedDelete);
     }
 
-    public static CollectionEventMetaData[] deleteMarkerRemoved(List<String> uris) {
-        return toArray(uris
-                .stream()
+    public static CollectionEventMetaData[] deleteMarkerRemoved(String deleteRoot, List<String> uris) {
+        List<CollectionEventMetaData> markedDelete = new ArrayList<>();
+        markedDelete.add(create(DELETE_ROOT_REMOVED, deleteRoot));
+        markedDelete.addAll(uris.stream()
                 .map(uri -> new CollectionEventMetaData(DELETE_MARKER_REMOVED, uri))
                 .collect(Collectors.toList()));
+        return toArray(markedDelete);
     }
 
     private static String fileIndex(int index) {
@@ -304,5 +312,10 @@ public class CollectionEventMetaData {
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
@@ -12,6 +12,7 @@ import com.github.onsdigital.zebedee.json.Session;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.CollectionOwner;
 import com.github.onsdigital.zebedee.model.DeleteMarker;
+import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDao;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDaoFactory;
 import com.github.onsdigital.zebedee.service.content.navigation.ContentTreeNavigator;
 import com.github.onsdigital.zebedee.util.ContentTree;
@@ -51,6 +52,7 @@ public class ContentDeleteService {
     private static final String JSON_FILE_EXT = ".json";
     private static ZebedeeCmsService zebedeeCmsService = ZebedeeCmsService.getInstance();
     private static ContentTreeNavigator contentTreeNavigator = ContentTreeNavigator.getInstance();
+    private static CollectionHistoryDao collectionHistoryDao = CollectionHistoryDaoFactory.getCollectionHistoryDao();
 
     private static final ImmutableList<PageType> NON_DELETABLE_PAGE_TYPES =
             ImmutableList.of(home_page, taxonomy_landing_page, product_page);
@@ -121,8 +123,8 @@ public class ContentDeleteService {
         );
         collection.description.getPendingDeletes().add(new PendingDelete(marker.getUser(), deleteImpact));
         collection.addEvent(deleteImpact.contentPath, collectionEvent(session, MARKED_DELETE));
-        CollectionHistoryDaoFactory.getCollectionHistoryDao().saveCollectionHistoryEvent(collection, session,
-                DELETE_MARKED_ADDED, deleteMarkerAdded(deletedUris));
+        collectionHistoryDao.saveCollectionHistoryEvent(
+                collection, session, DELETE_MARKED_ADDED, deleteMarkerAdded(deleteImpact.contentPath, deletedUris));
         saveManifest(collection);
     }
 
@@ -151,8 +153,8 @@ public class ContentDeleteService {
 
         collection.description.cancelPendingDelete(contentUri);
         collection.addEvent(contentUri, collectionEvent(session, DELETE_MARKER_REMOVED));
-        CollectionHistoryDaoFactory.getCollectionHistoryDao().saveCollectionHistoryEvent(collection, session,
-                DELETE_MARKED_REMOVED, deleteMarkerRemoved(cancelledDeleteUris));
+        collectionHistoryDao.saveCollectionHistoryEvent(collection, session,
+                DELETE_MARKED_REMOVED, deleteMarkerRemoved(contentUri, cancelledDeleteUris));
         saveManifest(collection);
     }
 

--- a/zebedee-cms/src/main/resources/collection_event_history_en.properties
+++ b/zebedee-cms/src/main/resources/collection_event_history_en.properties
@@ -31,3 +31,6 @@ collection.manual.publish.failure.description=Manual publish was unsuccessfully.
 # Data visualisation events.
 data.visualisation.collection.content.deleted.description=Data visualisation collection content deleted.
 data.visualisation.zip.unpacked.description=Data visualisation zip unpacked.
+
+delete.marker.added.description=Delete marker added.
+delete.marker.removed.description=Delete marker removed.

--- a/zebedee-cms/src/main/resources/docker.txt
+++ b/zebedee-cms/src/main/resources/docker.txt
@@ -48,7 +48,7 @@ For my local dev environment I use docker to run the postgres database
 (4)
     To connect to the container to view/query the DB run:
 
-        $ docker run -it --rm --link some-postgres:postgres postgres psql -h postgres -U postgres
+        $ docker run -it --rm --link dpcompose_postgres_1:postgres --net dpcompose_default postgres psql -h postgres -U postgres
 
     You will need to create a database:
         $ CREATE DATABASE audit;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaDataTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaDataTest.java
@@ -4,17 +4,26 @@ import com.github.davidcarboni.cryptolite.Random;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.model.CollectionOwner;
+import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.COLLECTION_OWNER;
+import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.DELETE_MARKER_ADDED;
+import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.DELETE_MARKER_REMOVED;
+import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.DELETE_ROOT;
+import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.DELETE_ROOT_REMOVED;
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.PREVIOUS_PUBLISH_DATE;
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.PUBLISH_DATE;
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.PUBLISH_TYPE;
+import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.create;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Tests verify the correct {@link CollectionEventMetaData} objects are created for the values provided.
@@ -115,6 +124,46 @@ public class CollectionEventMetaDataTest {
 
         assertThat(results.length, equalTo(1));
         assertThat(results[0], equalTo(newPubDate));
+    }
+
+    @Test
+    public void shouldReturnListOfDeleteMarkerAddedValues() throws Exception {
+        List<String> uris = new ImmutableList.Builder<String>()
+                .add("one", "two", "three").build();
+
+        ImmutableList.Builder<CollectionEventMetaData> expectedListBuilder =
+                new ImmutableList.Builder<CollectionEventMetaData>().add(create(DELETE_ROOT, DELETE_ROOT));
+
+        expectedListBuilder.addAll(uris
+                .stream().map(uri -> CollectionEventMetaData.create(DELETE_MARKER_ADDED, uri))
+                .collect(Collectors.toList()));
+
+        CollectionEventMetaData[] expected = expectedListBuilder.build().toArray(new CollectionEventMetaData[uris.size()]);
+        CollectionEventMetaData[] results = CollectionEventMetaData.deleteMarkerAdded(DELETE_ROOT, uris);
+
+        assertThat("Result was null... not what I was expecting.", null == results, is(false));
+        assertThat("Expected results size to match that of the input list", results.length, equalTo(uris.size() + 1));
+        assertThat("Not as expected.", results, equalTo(expected));
+    }
+
+    @Test
+    public void shouldReturnListOfDeleteMarkerRemovedValues() throws Exception {
+        List<String> uris = new ImmutableList.Builder<String>()
+                .add("one", "two", "three").build();
+
+        ImmutableList.Builder<CollectionEventMetaData> expectedListBuilder =
+                new ImmutableList.Builder<CollectionEventMetaData>().add(create(DELETE_ROOT_REMOVED, DELETE_ROOT_REMOVED));
+
+        expectedListBuilder.addAll(uris
+                .stream().map(uri -> CollectionEventMetaData.create(DELETE_MARKER_REMOVED, uri))
+                .collect(Collectors.toList()));
+
+        CollectionEventMetaData[] expected = expectedListBuilder.build().toArray(new CollectionEventMetaData[uris.size()]);
+        CollectionEventMetaData[] results = CollectionEventMetaData.deleteMarkerRemoved(DELETE_ROOT_REMOVED, uris);
+
+        assertThat("Result was null... not what I was expecting.", null == results, is(false));
+        assertThat("Expected results size to match that of the input list", results.length, equalTo(uris.size() + 1));
+        assertThat("Not as expected.", results, equalTo(expected));
     }
 
 }


### PR DESCRIPTION
### What

Added collection event/collection history event/audit logging for adding/removing delete markers. This will enable us to reconstruct the delete marker history of a collection.

### How to review

Marking content for Delete/removing a delete should add collection events to the collection `.json` file. If you have the audit DB running it will have entries in the `collection_history` & `history_event_meta_data tables` - this reference table will contain a `deleteRoot` / `deleteRootRemoved` entry & entries for every child of the delete root each time content is marked/unmarked for delete.
Will also write to the Audit log.

### Who can review

@CarlHembrough @ian-kent @LloydGriffiths 