### PR TITLE
Update search terms to include productivity

### DIFF
--- a/zebedee-reader/src/main/resources/search/boost.txt
+++ b/zebedee-reader/src/main/resources/search/boost.txt
@@ -36,4 +36,5 @@
 /peoplepopulationandcommunity/populationandmigration/internationalmigration/*=>immigration,emigration
 /peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/*=>child mortality
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/regionallabourmarket/*=>regional labour, regional unemployment, regional employment
+/employmentandlabourmarket/peopleinwork/labourproductivity/bulletins/labourproductivity/*=>productivity
 /aboutus/whatwedo/statistics/requestingstatistics=>adhoc, ad-hoc, ad hoc, user requested data


### PR DESCRIPTION
### What

Update to terms to include 'productivity'. Fix for issue where labour productivity bulletin appears on the second page.

### How to review

Search for 'productivity', Labour productivity bulletins should be returned first

### Who can review

Anyone.
