### PR TITLE
Feature/clear homepage cache

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -43,6 +43,8 @@ public class ApproveTask implements Callable<Boolean> {
     private final ContentReader publishedReader;
     private final DataIndex dataIndex;
 
+    private static final String HOMEPAGE_URI = "/";
+
     public ApproveTask(
             Collection collection,
             Session session,
@@ -99,6 +101,10 @@ public class ApproveTask implements Callable<Boolean> {
     public static PublishNotification createPublishNotification(CollectionReader collectionReader, Collection collection) {
         List<String> uriList = collectionReader.getReviewed().listUris();
 
+        if (!uriList.contains(HOMEPAGE_URI)) {
+            uriList.add(HOMEPAGE_URI);
+        }
+
         // only provide relevent uri's
         //  - remove versioned uris
         //  - add associated uris? /previous /data etc?
@@ -106,9 +112,7 @@ public class ApproveTask implements Callable<Boolean> {
         List<ContentDetail> contentToDelete = new ArrayList<>();
         List<PendingDelete> pendingDeletes = collection.getDescription().getPendingDeletes();
 
-
         for (PendingDelete pendingDelete : pendingDeletes) {
-
             ContentTreeNavigator.getInstance().search(pendingDelete.getRoot(), node -> {
                 logDebug("Adding uri to delete to the publish notification " + node.uri);
                 if (!contentToDelete.contains(node.uri)) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PublishNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PublishNotification.java
@@ -109,6 +109,15 @@ public class PublishNotification {
                 .isPresent();
     }
 
+    /**
+     * return true if this PublishNotification has the given URI to update.
+     * @param uri - the URI to check.
+     * @return - true if the URI is in the list of URI's to update
+     */
+    public boolean hasUriToUpdate(String uri) {
+        return this.payload.urisToUpdate.contains(uri);
+    }
+
     class NotificationPayload {
         public String collectionId;
         public String publishDate;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -36,4 +36,20 @@ public class ApproveTaskTest {
         Assert.assertNotNull(publishNotification);
         Assert.assertTrue(publishNotification.hasUriToDelete(uriToDelete));
     }
+
+    @Test
+    public void createPublishNotificationShouldIncludeHomepageUri() throws Exception {
+
+        // Given a collection
+        Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
+        CollectionReader collectionReader = new DummyCollectionReader(collectionPath);
+        Collection collection = CollectionTest.CreateCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
+
+        // When the publish notification is created as part of the approval process.
+        PublishNotification publishNotification = ApproveTask.createPublishNotification(collectionReader, collection);
+
+        // Then the publish notification contains the homepage uri.
+        Assert.assertNotNull(publishNotification);
+        Assert.assertTrue(publishNotification.hasUriToUpdate("/"));
+    }
 }


### PR DESCRIPTION
### What

Added the homepage URL to publish notifications, so that the homepage cache is cleared on each scheduled publish.

### How to review

Check the cache headers on the homepage when a publish is less than 15 minutes away.

### Who can review

Anyone
