### PR TITLE
Change homepage URI value 

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -18,6 +18,7 @@ public class Configuration {
     private static final String INFLUXDB_URL = "http://influxdb:8086";
     private static final String AUDIT_DB_ENABLED_ENV_VAR = "audit_db_enabled";
     private static final String MATHJAX_SERVICE_URL = "http://localhost:8888";
+    private static final String HOMEPAGE_URI = "";
 
     private static final int VERIFY_RETRTY_DELAY = 5000; //milliseconds
     private static final int VERIFY_RETRTY_COUNT = 10;
@@ -70,9 +71,12 @@ public class Configuration {
         return StringUtils.defaultIfBlank(getValue("BABBAGE_URL"), DEFAULT_WEBSITE_URL);
     }
 
-
     public static String getMathjaxServiceUrl() {
         return StringUtils.defaultIfBlank(getValue("MATHJAX_SERVICE_URL"), MATHJAX_SERVICE_URL);
+    }
+
+    public static String getHomepageUri() {
+        return StringUtils.defaultIfBlank(getValue("HOMEPAGE_URI"), HOMEPAGE_URI);
     }
 
     public static String[] getTheTrainUrls() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.model.approval;
 
+import com.github.onsdigital.zebedee.configuration.Configuration;
 import com.github.onsdigital.zebedee.data.DataPublisher;
 import com.github.onsdigital.zebedee.data.importing.CsvTimeseriesUpdateImporter;
 import com.github.onsdigital.zebedee.data.importing.TimeseriesUpdateCommand;
@@ -42,8 +43,6 @@ public class ApproveTask implements Callable<Boolean> {
     private final CollectionWriter collectionWriter;
     private final ContentReader publishedReader;
     private final DataIndex dataIndex;
-
-    private static final String HOMEPAGE_URI = "/";
 
     public ApproveTask(
             Collection collection,
@@ -101,8 +100,9 @@ public class ApproveTask implements Callable<Boolean> {
     public static PublishNotification createPublishNotification(CollectionReader collectionReader, Collection collection) {
         List<String> uriList = collectionReader.getReviewed().listUris();
 
-        if (!uriList.contains(HOMEPAGE_URI)) {
-            uriList.add(HOMEPAGE_URI);
+        String homepageUri = Configuration.getHomepageUri();
+        if (!uriList.contains(homepageUri)) {
+            uriList.add(homepageUri);
         }
 
         // only provide relevent uri's

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -50,6 +50,6 @@ public class ApproveTaskTest {
 
         // Then the publish notification contains the homepage uri.
         Assert.assertNotNull(publishNotification);
-        Assert.assertTrue(publishNotification.hasUriToUpdate("/"));
+        Assert.assertTrue(publishNotification.hasUriToUpdate(""));
     }
 }


### PR DESCRIPTION
### What

to be an empty string instead of a forward slash. The homepage URI comes through as an empty string so is not currently being picked up when compared to a forward slash.