### PR TITLE
Revert previous change to add the homepage URI to the publish notific…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -18,7 +18,6 @@ public class Configuration {
     private static final String INFLUXDB_URL = "http://influxdb:8086";
     private static final String AUDIT_DB_ENABLED_ENV_VAR = "audit_db_enabled";
     private static final String MATHJAX_SERVICE_URL = "http://localhost:8888";
-    private static final String HOMEPAGE_URI = "";
 
     private static final int VERIFY_RETRTY_DELAY = 5000; //milliseconds
     private static final int VERIFY_RETRTY_COUNT = 10;
@@ -73,10 +72,6 @@ public class Configuration {
 
     public static String getMathjaxServiceUrl() {
         return StringUtils.defaultIfBlank(getValue("MATHJAX_SERVICE_URL"), MATHJAX_SERVICE_URL);
-    }
-
-    public static String getHomepageUri() {
-        return StringUtils.defaultIfBlank(getValue("HOMEPAGE_URI"), HOMEPAGE_URI);
     }
 
     public static String[] getTheTrainUrls() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.zebedee.model.approval;
 
-import com.github.onsdigital.zebedee.configuration.Configuration;
 import com.github.onsdigital.zebedee.data.DataPublisher;
 import com.github.onsdigital.zebedee.data.importing.CsvTimeseriesUpdateImporter;
 import com.github.onsdigital.zebedee.data.importing.TimeseriesUpdateCommand;
@@ -99,11 +98,6 @@ public class ApproveTask implements Callable<Boolean> {
 
     public static PublishNotification createPublishNotification(CollectionReader collectionReader, Collection collection) {
         List<String> uriList = collectionReader.getReviewed().listUris();
-
-        String homepageUri = Configuration.getHomepageUri();
-        if (!uriList.contains(homepageUri)) {
-            uriList.add(homepageUri);
-        }
 
         // only provide relevent uri's
         //  - remove versioned uris

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -36,20 +36,4 @@ public class ApproveTaskTest {
         Assert.assertNotNull(publishNotification);
         Assert.assertTrue(publishNotification.hasUriToDelete(uriToDelete));
     }
-
-    @Test
-    public void createPublishNotificationShouldIncludeHomepageUri() throws Exception {
-
-        // Given a collection
-        Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        CollectionReader collectionReader = new DummyCollectionReader(collectionPath);
-        Collection collection = CollectionTest.CreateCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
-
-        // When the publish notification is created as part of the approval process.
-        PublishNotification publishNotification = ApproveTask.createPublishNotification(collectionReader, collection);
-
-        // Then the publish notification contains the homepage uri.
-        Assert.assertNotNull(publishNotification);
-        Assert.assertTrue(publishNotification.hasUriToUpdate(""));
-    }
 }


### PR DESCRIPTION
### What

Revert previous change to add the homepage URI to the publish notification. Instead of adding the homepage URI to the publish notification, it will determine how to cache the homepage in babbage.

### How to review

Ensure the homepage URI is not added to the PublishNotification if the homepage is not contained in the collection.

### Who can review

@daiLlew 
