### PR TITLE
Synonyms and stemmer changes

### DIFF
--- a/zebedee-reader/src/main/resources/search/boost.txt
+++ b/zebedee-reader/src/main/resources/search/boost.txt
@@ -12,6 +12,11 @@
 # /economy/grossdomesticproductgdp/bulletins/grossdomesticproductpreliminaryestimate/2015-10-27 => preliminary, estimates
 
 
+########### NOTES ###########
+# Spaces at the beginning or end of the `uri` are ignored and do not affect the matching
+# Spaces in and around the terms is ignored does not affect the setting of the search boost fields
+# Check the root [base] of the content path; if the content path has a 'master' root directory include this in the CONTENT_DIR env variable i.e. CONTENT_DIR=c:\temp\content\master
+#           essentially the URI are matched to the folder structure under $CONTENT_PATH therefore $CONTENT_PATH/<URI> must be valid
 ##########MAPPING#############
 
 #/peoplepopulationandcommunity/populationandmigration/populationprojections/bulletins/nationalpopulationprojections/* => poopulation, projection, age

--- a/zebedee-reader/src/main/resources/search/boost.txt
+++ b/zebedee-reader/src/main/resources/search/boost.txt
@@ -19,16 +19,14 @@
 #           essentially the URI are matched to the folder structure under $CONTENT_PATH therefore $CONTENT_PATH/<URI> must be valid
 ##########MAPPING#############
 
-#/peoplepopulationandcommunity/populationandmigration/populationprojections/bulletins/nationalpopulationprojections/* => poopulation, projection, age
 /census=>census
-/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/*=>Flow of funds
-/economy/inflationandpriceindices/timeseries/chaw/mm23=>RPI
-/economy/inflationandpriceindices/timeseries/czbh/mm23=>RPI
-/economy/inflationandpriceindices/bulletins/consumerpriceinflation/*=>RPI
-/economy/inflationandpriceindices/bulletins/producerpriceinflation/*=>Producer Price Indices
-/economy/inflationandpriceindices/timeseries/chmk=>rpix
-/economy/inflationandpriceindices/timeseries/cdkq=>rpix
-/economy/inflationandpriceindices/datasets/consumerpriceinflation=>RPI
+/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/*=>flow of funds
+/economy/inflationandpriceindices/bulletins/consumerpriceinflation/*=>rpi, inflation
+/businessindustryandtrade/retailindustry/bulletins/retailsales/*=>retail
+/economy/inflationandpriceindices/bulletins/producerpriceinflation/*=>psi
+/economy/inflationandpriceindices/datasets/consumerpriceinflation=>rpi
+/economy/inflationandpriceindices/timeseries/chaw/*=>rpi
+/economy/inflationandpriceindices/timeseries/czbh/*=>rpi
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/*=>average earnings index,Labour Force Survey,unemployment,labour market statistics,employment,Claimant Count,average weekly earnings
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/datasets/summaryoflabourmarketstatistics=>unemployment,employment
 /employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/averageweeklyearningsearn01=>average earnings index
@@ -43,3 +41,4 @@
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/regionallabourmarket/*=>regional labour, regional unemployment, regional employment
 /employmentandlabourmarket/peopleinwork/labourproductivity/bulletins/labourproductivity/*=>productivity
 /aboutus/whatwedo/statistics/requestingstatistics=>adhoc, ad-hoc, ad hoc, user requested data
+/economy/grossdomesticproductgdp/bulletins/*=>gdp

--- a/zebedee-reader/src/main/resources/search/default-mapping.json
+++ b/zebedee-reader/src/main/resources/search/default-mapping.json
@@ -76,7 +76,8 @@
       },
       "searchBoost": {
         "type": "string",
-        "analyzer": "ons_stem",
+        "analyzer": "ons_synonym_stem",
+        "search_analyzer": "ons_stem",
         "norms": {
           "enabled": false
         }

--- a/zebedee-reader/src/main/resources/search/default-mapping.json
+++ b/zebedee-reader/src/main/resources/search/default-mapping.json
@@ -21,13 +21,15 @@
           "title": {
             "type": "string",
             "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem",
             "fields": {
               "title_raw": {
                 "type": "string"
               },
               "title_no_stem" : {
                 "type" : "string",
-                "analyzer" : "ons_synonym"
+                "analyzer" : "ons_synonym",
+                "search_analyzer" : "ons_standard"
               },
               "title_no_synonym_no_stem" : {
                 "type" : "string",
@@ -35,7 +37,8 @@
               },
               "title_no_dates": {
                 "type": "string",
-                "analyzer": "ons_synonym_stem_clear_dates"
+                "analyzer": "ons_synonym_stem_clear_dates",
+                "search_analyzer": "ons_stem_clear_dates"
               },
               "title_first_letter": {
                 "type": "string",
@@ -45,7 +48,8 @@
           },
           "edition": {
             "type": "string",
-            "analyzer": "ons_synonym_stem"
+            "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem"
           },
           "metaDescription": {
             "type": "string",
@@ -58,6 +62,7 @@
           "keywords": {
             "type": "string",
             "analyzer": "ons_synonym_stem",
+            "search_analyzer": "ons_stem",
             "fields": {
               "keywords_raw": {
                 "type": "string"

--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -76,6 +76,7 @@ analysis :
   filter :
     stem_exclusion :
         type : keyword_marker
+        # Add words to the 'keywords' array below to stop the words being stemmed and to keep the words in thier original form
         keywords : [
                       "productivity",
                       "production"

--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -26,6 +26,7 @@ analysis :
         - ons_synonyms
         - standard
         - stop
+        - stem_exclusion
         - snowball
     ons_synonym :
       tokenizer : standard
@@ -40,6 +41,7 @@ analysis :
         - lowercase
         - standard
         - stop
+        - stem_exclusion
         - snowball
     ons_synonym_stem_clear_dates : #used for clearing out dates from title, moving title into another field in content wasn't doable, this is the ultimate hacky solution
       tokenizer : standard
@@ -49,6 +51,7 @@ analysis :
         - ons_synonyms
         - standard
         - stop
+        - stem_exclusion
         - snowball
     ons_stem_clear_dates : #used for clearing out dates from title, moving title into another field in content wasn't doable, this is the ultimate hacky solution
       tokenizer : standard
@@ -57,6 +60,7 @@ analysis :
         - lowercase
         - standard
         - stop
+        - stem_exclusion
         - snowball
     first_letter :
       #Extracts first letter, elastic search does not seem to have a prefix aggregation, as a workaround first letter is indexed for a to z tool
@@ -70,6 +74,12 @@ analysis :
       type: pattern_replace
       pattern : "([1|2]\\d{3})|((?i)january|february|march|april|may|june|july|august|september|october|november|december)"
   filter :
+    stem_exclusion :
+        type : keyword_marker
+        keywords : [
+                      "productivity",
+                      "production"
+                   ]
     first_letter :
       type : pattern_replace
       pattern: "^[^a-zA-Z]*(.).*"
@@ -80,7 +90,7 @@ analysis :
       # there are 2 possible formats
       # 1. term => another term = items on lhs are mapped to items on rhs
       # 2. term,another term,and another term = all terms are synonymous with each other,
-      #careful with the second one, messes up relevancy by creating same words multiple times in the index, try direct mapping of abbreveation to what it stands for
+      #careful with the second one, messes up relevancy by creating same words multiple times in the index, try direct mapping of abbreviation to what it stands for
       synonyms :
         - "cpi, consumer price inflation, consumer price index"
         - "rpi,  retail price index"

--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -162,7 +162,7 @@ analysis :
         - "oa, output area"
         - "wz, workplace zone"
         - "npp, national population projections"
-        - "snpp, sub national population projections"
+        - "snpp, subnational population projections"
         - "suid, sudden unexpected/unexplained infant deaths"
         - "drd, drug related deaths"
         - "c diff, clostridium difficile"

--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -1,3 +1,6 @@
+index :
+    number_of_shards : 3
+    number_of_replicas : 0
 analysis :
   analyzer :
     #Overwriting default index analyzer
@@ -23,7 +26,7 @@ analysis :
         - ons_synonyms
         - standard
         - stop
-        - porter_stem
+        - snowball
     ons_synonym :
       tokenizer : standard
       filter :
@@ -37,7 +40,7 @@ analysis :
         - lowercase
         - standard
         - stop
-        - porter_stem
+        - snowball
     ons_synonym_stem_clear_dates : #used for clearing out dates from title, moving title into another field in content wasn't doable, this is the ultimate hacky solution
       tokenizer : standard
       char_filter : clear_dates
@@ -46,7 +49,15 @@ analysis :
         - ons_synonyms
         - standard
         - stop
-        - porter_stem
+        - snowball
+    ons_stem_clear_dates : #used for clearing out dates from title, moving title into another field in content wasn't doable, this is the ultimate hacky solution
+      tokenizer : standard
+      char_filter : clear_dates
+      filter :
+        - lowercase
+        - standard
+        - stop
+        - snowball
     first_letter :
       #Extracts first letter, elastic search does not seem to have a prefix aggregation, as a workaround first letter is indexed for a to z tool
       #Not that the pattern skips any non-letter character at the beginning

--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -91,7 +91,8 @@ analysis :
       # there are 2 possible formats
       # 1. term => another term = items on lhs are mapped to items on rhs
       # 2. term,another term,and another term = all terms are synonymous with each other,
-      #careful with the second one, messes up relevancy by creating same words multiple times in the index, try direct mapping of abbreviation to what it stands for
+      # careful with the second one, messes up relevancy by creating same words multiple times in the index, try direct mapping of abbreviation to what it stands for
+      # Spacing between terms in a phrase is not important in the synonyms list
       synonyms :
         - "cpi, consumer price inflation, consumer price index"
         - "rpi,  retail price index"
@@ -124,7 +125,7 @@ analysis :
         - "msoa,  middle layer super output areas"
         - "aei,  average earnings index"
         - "soc,  standard occupational classification"
-        - "jsa,  jobseeskers allowance"
+        - "jsa,  jobseekers allowance"
         - "vat,  value added tax"
         - "hmrc,  hm revenue and customs published"
         - "ltim,  long term international migration"
@@ -139,7 +140,7 @@ analysis :
         - "ict,  information and communication technology"
         - "gfcf,  gross fixed capital formation"
         - "esa,  european system of accounts"
-        - "aps,  annual poopulation survey"
+        - "aps,  annual population survey"
         - "eu,  european union"
         - "m&a, mergers and acquisitions"
         - "itis, international trade in services"


### PR DESCRIPTION
Synonyms and stemmer changes
Altered Synonym's configuration to expand synonyms only at index time; disabling query time expansion.
Changed stemmer to use newer snowball stem instead of less accruate porter stemmer.

Limited to two files: 
index-config.yml
+ changed porter_stem filter to snowball filter
+ added new analyzer to be used when querying (to exclude synonym expansion)
+ set replicas to 0 as only one node in each production cluster
+ set number of shards to 3 (default is 5) as we only have one node in production,
       but 3 shards would give the opportunity to spread index over a max 3 nodes 

default-mapping.json
+ update mappings where fields use the synonym to use a new search_analyzer that does not have an Analyzer.