### PR TITLE
Always take the title from the CSDB when generating timeseries.

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataProcessor.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataProcessor.java
@@ -184,14 +184,7 @@ public class DataProcessor {
             logInfo("Error copying metadata in data publisher").log();
         }
         inProgress.getDescription().setCdid(newSeries.getDescription().getCdid());
-
-        // Copy across the title if it is currently blank (so if it has been set manually do not overwrite)
-        if (inProgress.getDescription().getTitle() == null || inProgress.getDescription().getTitle().equalsIgnoreCase("")) {
-            inProgress.getDescription().setTitle(newSeries.getDescription().getTitle());
-        } else if (inProgress.getDescription().getTitle().equalsIgnoreCase(inProgress.getCdid())) {
-            inProgress.getDescription().setTitle(newSeries.getDescription().getTitle());
-        }
-
+        inProgress.getDescription().setTitle(newSeries.getDescription().getTitle());
         inProgress.getDescription().setDate(newSeries.getDescription().getDate());
         inProgress.getDescription().setNumber(newSeries.getDescription().getNumber());
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTest.java
@@ -307,30 +307,6 @@ public class DataProcessorTest {
     }
 
     @Test
-    public void syncMetadata_overExistingTimeSeries_shouldNotTransferNameIfNameExists() throws IOException, ParseException, URISyntaxException, ZebedeeException {
-        // Given
-        // We create a publish over an existing dataset
-        DataPagesSet republish = generator.generateDataPagesSet("dataprocessor", "published", 2016, 2, "");
-        dataBuilder.addReviewedDataPagesSet(republish, collection, collectionWriter);
-
-        DataPublicationDetails details = republish.getDetails(publishedReader, collectionReader.getReviewed());
-        TimeSeries timeSeries = republish.timeSeriesList.get(0);
-        TimeSeries publishedTimeseries = published.timeSeriesList.get(0);
-
-        DataProcessor processor = new DataProcessor();
-        TimeSeries initial = processor.initialTimeseries(timeSeries, publishedReader, details, zebedee.getDataIndex());
-
-        // When
-        // we sync details
-        TimeSeries synced = processor.syncLandingPageMetadata(initial, details);
-        synced = processor.syncTimeSeriesMetadata(synced, timeSeries);
-
-        // Then
-        // we expect the name to come from the old timeseries
-        assertEquals(publishedTimeseries.getDescription().getTitle(), synced.getDescription().getTitle());
-    }
-
-    @Test
     public void syncMetadata_overExistingTimeSeries_shouldTransferDatasetUri() throws IOException, ParseException, URISyntaxException, ZebedeeException {
         // Given
         // We create a publish over an existing dataset

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTest.java
@@ -4,6 +4,7 @@ import com.github.davidcarboni.cryptolite.Random;
 import com.github.onsdigital.zebedee.Builder;
 import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.content.page.base.Page;
+import com.github.onsdigital.zebedee.content.page.base.PageDescription;
 import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.content.page.statistics.data.timeseries.TimeSeries;
 import com.github.onsdigital.zebedee.data.framework.DataBuilder;
@@ -22,6 +23,7 @@ import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -405,6 +407,28 @@ public class DataProcessorTest {
         // Then
         // we expect the title to be that of the update command.
         assertEquals(title, processor.timeSeries.getDescription().getTitle());
+    }
+
+    @Test
+    public void metadataIsSynced() {
+
+        // Given an existing timeseries
+        TimeSeries existingSeries = new TimeSeries();
+        existingSeries.setDescription(new PageDescription());
+        existingSeries.getDescription().setTitle("oldTitle");
+
+        // and a new time series with a new title
+        TimeSeries newSeries = new TimeSeries();
+        newSeries.setDescription(new PageDescription());
+        newSeries.getDescription().setTitle("newTitle");
+        newSeries.getDescription().setCdid("WUT");
+
+        // When sync is called
+        new DataProcessor().syncTimeSeriesMetadata(existingSeries, newSeries);
+
+        // Then the title is updated.
+        Assert.assertEquals("newTitle", existingSeries.getDescription().getTitle());
+        Assert.assertEquals("WUT", existingSeries.getDescription().getCdid());
     }
 
     /**


### PR DESCRIPTION
### What

Currently when time series are generated on approval the title is not updated from the CSDB input. Now that the CSDB system has been updated to support longer titles we now want to use the titles provided by CSDB.

### How to review

Ensure that the titles provided from a CSDB file are applied to updated time series. 

### Who can review

@daiLlew 
