### PR TITLE
allow PORT env var to be replaced by caller

### DIFF
--- a/run-reader.sh
+++ b/run-reader.sh
@@ -3,7 +3,7 @@
 source ./export-default-env-vars.sh
 
 export JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
-export PORT="8082"
+export PORT="${PORT:-8082}"
 
 # Restolino configuration
 export RESTOLINO_CLASSES="zebedee-reader/target/classes"

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 source ./export-default-env-vars.sh
 
 export JAVA_OPTS=" -Xmx512m -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
-export PORT="8082"
+export PORT="${PORT:-8082}"
 
 # Restolino configuration
 export RESTOLINO_STATIC="src/main/resources/files"


### PR DESCRIPTION
### What

Allows PORT env var to be overridden outside run scripts

### How to review

* run `./run-reader.sh`, should start up on 8082
* run `./run.sh`, should start up on 8082
* run `PORT=44444 ./run-reader.sh`, should start up on 44444
* run `PORT=44444 ./run.sh`, should start up on 44444

### Who can review

Anyone except @ian-kent