### PR TITLE
Feature/data file generator test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ David
 zebedee_root    /Users/thomasridd/Documents/onswebsite
 brian_url   http://localhost:8083/
 use_beta_publisher   false
+

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataFileGeneratorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataFileGeneratorTest.java
@@ -6,7 +6,6 @@ import com.github.onsdigital.zebedee.content.page.statistics.data.timeseries.Tim
 import com.github.onsdigital.zebedee.data.json.TimeSerieses;
 import com.github.onsdigital.zebedee.data.processing.xls.TimeSeriesCellWriter;
 import com.github.onsdigital.zebedee.model.ContentWriter;
-import org.apache.commons.io.FileUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFRow;
@@ -132,6 +131,8 @@ public class DataFileGeneratorTest {
         this.timeSeriesList.add(timeSeries);
         this.dataGrid = new DataGrid(timeSeriesList);
         this.dataFileGenerator = new DataFileGenerator(null);
+        //reset xslCellWriter.. some how as its static it gets substituted for an invalid one.
+        DataFileGenerator.xlsCellWriter  = TimeSeriesCellWriter.getInstance();
         this.xlsExpectations = XLSExpectations.get(timeSeries);
     }
 


### PR DESCRIPTION
### What

Very simple re-setting of xlsCellWriter prior to the test running
```
+        //reset xslCellWriter.. some how as its static it gets substituted for an invalid one.
+        DataFileGenerator.xlsCellWriter  = TimeSeriesCellWriter.getInstance();
```
### How to review

on Linux mvn clean install all tests should now pass

### Who can review
Anybody
