### PR TITLE
Increase the size and quality of PNG files generated from SVG.

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/SvgService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/SvgService.java
@@ -25,7 +25,7 @@ public class SvgService {
     public static void convertSvgToPng(InputStream inputStream, OutputStream outputStream) throws TranscoderException {
         Transcoder transcoder = new PNGTranscoder();
 
-        transcoder.addTranscodingHint(ImageTranscoder.KEY_PIXEL_UNIT_TO_MILLIMETER, new Float(0.2f));
+        transcoder.addTranscodingHint(ImageTranscoder.KEY_PIXEL_UNIT_TO_MILLIMETER, new Float(0.08f));
 
         TranscoderInput transcoderInput = new TranscoderInput(inputStream);
         TranscoderOutput transcoderOutput = new TranscoderOutput(outputStream);


### PR DESCRIPTION
### What

When equations were rendered to PNG they were very small and low quality. I have tweaked the values given to the transcoder so that the PNG images are an appropriate size and quality to be put into PDF's.

### How to review

Add an equation to a bulletin page and approve the collection causing the PDF to be generated. Open the PDF and check that the equations are a reasonable size and quality.

### Who can review

