### PR TITLE
Blank out timeseries values where the value has been suppressed.

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataMerge.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataMerge.java
@@ -4,7 +4,9 @@ import com.github.onsdigital.zebedee.content.page.statistics.data.timeseries.Tim
 import com.github.onsdigital.zebedee.content.page.statistics.data.timeseries.TimeSeriesValue;
 import com.github.onsdigital.zebedee.content.util.ContentUtil;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created by thomasridd on 1/21/16.
@@ -66,6 +68,14 @@ public class DataMerge {
                 this.insertions += 1;
             }
         }
+
+        // Find values that have been suppressed, i.e, they are in the current values but not in the updated values
+        List<TimeSeriesValue> suppressed = currentValues.stream()
+                .filter(current -> !updateValues.contains(current))
+                .collect(Collectors.toList());
+
+        suppressed.forEach(current -> current.value = "");
+        this.corrections += suppressed.size();
     }
 
     /**

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataMergeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataMergeTest.java
@@ -20,7 +20,6 @@ public class DataMergeTest {
 
     @Before
     public void setUp() throws Exception {
-
         generator = new DataPagesGenerator();
     }
 
@@ -80,7 +79,7 @@ public class DataMergeTest {
         // Then
         // we expect the merge to include 3 points including 2003
         assertEquals(3, merged.years.size());
-        assertEquals(1, dataMerge.corrections);
+        assertEquals(3, dataMerge.corrections);
         assertEquals("4", valueForTime("2002", merged).value);
     }
 
@@ -101,10 +100,30 @@ public class DataMergeTest {
         // we expect the merge to include 3 points including 2003
         assertEquals(4, merged.years.size());
         assertEquals(1, dataMerge.insertions);
-        assertEquals("1", valueForTime("2000", merged).value);
-        assertEquals("2", valueForTime("2001", merged).value);
-        assertEquals("3", valueForTime("2002", merged).value);
+        assertEquals("", valueForTime("2000", merged).value);
+        assertEquals("", valueForTime("2001", merged).value);
+        assertEquals("", valueForTime("2002", merged).value);
         assertEquals("4", valueForTime("2003", merged).value);
+    }
+
+    @Test
+    public void mergeValues_overExistingTimeSeries_shouldBlankOutSuppressedValues() throws IOException {
+        // Given a timeseries for 2000-2002 and an set of updates that suppresses the 2002 value
+        TimeSeries initial = simplifyTimeSeries(generator.exampleTimeseries("cdid", "dataset"));
+        TimeSeries updates = simplifyTimeSeries(generator.exampleTimeseries("cdid", "dataset"));
+
+        TimeSeriesValue suppressedEntry = updates.years.last();
+        updates.years.remove(suppressedEntry);
+
+        // When a merge is done
+        DataMerge dataMerge = new DataMerge();
+        TimeSeries merged = dataMerge.merge(initial, updates, "update");
+
+        // Then the merged data should have a blank value for the suppressed 2002 entry
+        // counted as a correction.
+        assertEquals(3, merged.years.size());
+        assertEquals("", valueForTime("2002", merged).value);
+        assertEquals(1, dataMerge.corrections);
     }
 
 


### PR DESCRIPTION
### What

When a CSDB file is processed it generates a set of time series objects. These are compared with any existing time series files to determine the final update file. It is common for a value to be 'suppressed' in the CSDB file. This means a particular value was published in a previous release but has now been removed. In this case we need to ensure that the suppressed value is reflected in the time series update. Currently the previous value persists and does not get suppressed, requiring a data fix to remove those values.

### How to review

Check that time series values are updated to a blank string where they have been suppressed in the CSDB file.

### Who can review

Anyone
