### PR TITLE
First Letter analysis was including the return characters.

### DIFF
--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -82,9 +82,9 @@ analysis :
                       "production"
                    ]
     first_letter :
-      type : pattern_replace
-      pattern: "^[^a-zA-Z]*(.).*"
-      replacement: "$1"
+      type : pattern_capture
+      preserve_original: false
+      patterns : ["^[^a-zA-Z]*([a-zA-Z]).*"]
     ons_synonyms :
       type : synonym
       # stores synonyms for search engine


### PR DESCRIPTION
Swapped replacement with character capture to ensure ignoring of characters that do not match.

### What

Current __live__ implementation uses a Pattern replacement filter which means characters that are not matched are retained.
```
"first_letter": {
               "pattern": "^[^a-zA-Z]*(.).*",
               "replacement": "$1",
               "type": "pattern_replace"
```
which resulted in the following characters being captured;
```
{
  "took" : 9,
  "timed_out" : false,
  "_shards" : {
    "total" : 5,
    "successful" : 5,
    "failed" : 0
  },
  "hits" : {
    "total" : 49039,
    "max_score" : 0.0,
    "hits" : [ ]
  },
  "aggregations" : {
    "fieldTerms" : {
      "doc_count_error_upper_bound" : 0,
      "sum_other_doc_count" : 0,
      "buckets" : [ {
        "key" : "c",
        "doc_count" : 11147
      }, {
        "key" : "g",
        "doc_count" : 6744
      }, {
        "key" : "b",
        "doc_count" : 4884
      }, {
        "key" : "i",
        "doc_count" : 3582
      }, {
        "key" : "r",
        "doc_count" : 2710
      }, {
        "key" : "e",
        "doc_count" : 2693
      }, {
        "key" : "p",
        "doc_count" : 2276
      }, {
        "key" : "n",
        "doc_count" : 2167
      }, {
        "key" : "u",
        "doc_count" : 1923
      }, {
        "key" : "t",
        "doc_count" : 1511
      }, {
        "key" : "s",
        "doc_count" : 1193
      }, {
        "key" : "f",
        "doc_count" : 1118
      }, {
        "key" : "l",
        "doc_count" : 1071
      }, {
        "key" : "m",
        "doc_count" : 997
      }, {
        "key" : "o",
        "doc_count" : 988
      }, {
        "key" : "h",
        "doc_count" : 967
      }, {
        "key" : "a",
        "doc_count" : 751
      }, {
        "key" : "d",
        "doc_count" : 733
      }, {
        "key" : "w",
        "doc_count" : 264
      }, {
        "key" : "q",
        "doc_count" : 86
      }, {
        "key" : "v",
        "doc_count" : 76
      }, {
        "key" : "j",
        "doc_count" : 57
      }, {
        "key" : "k",
        "doc_count" : 42
      }, {
        "key" : "y",
        "doc_count" : 26
      }, {
        "key" : "i\n",
        "doc_count" : 21
      }, {
        "key" : "z",
        "doc_count" : 19
      }, {
        "key" : "x",
        "doc_count" : 8
      }, {
        "key" : "g\n",
        "doc_count" : 6
      }, {
        "key" : "c\n",
        "doc_count" : 1
      }, {
        "key" : "d\n",
        "doc_count" : 1
      }, {
        "key" : "s\n",
        "doc_count" : 1
      } ]
    }
  }
}
```
This has been changed to Pattern capture.
```
 first_letter :
      type : pattern_capture
      preserve_original: false
      patterns : ["^[^a-zA-Z]*([a-zA-Z]).*"]
```
Which results in a local analysis of:
```
{
  "took" : 6,
  "timed_out" : false,
  "_shards" : {
    "total" : 3,
    "successful" : 3,
    "failed" : 0
  },
  "hits" : {
    "total" : 53698,
    "max_score" : 0.0,
    "hits" : [ ]
  },
  "aggregations" : {
    "fieldTerms" : {
      "doc_count_error_upper_bound" : 0,
      "sum_other_doc_count" : 0,
      "buckets" : [ {
        "key" : "c",
        "doc_count" : 11454
      }, {
        "key" : "g",
        "doc_count" : 6895
      }, {
        "key" : "b",
        "doc_count" : 4956
      }, {
        "key" : "i",
        "doc_count" : 3760
      }, {
        "key" : "e",
        "doc_count" : 2932
      }, {
        "key" : "r",
        "doc_count" : 2876
      }, {
        "key" : "n",
        "doc_count" : 2523
      }, {
        "key" : "p",
        "doc_count" : 2444
      }, {
        "key" : "u",
        "doc_count" : 2393
      }, {
        "key" : "l",
        "doc_count" : 2206
      }, {
        "key" : "t",
        "doc_count" : 1642
      }, {
        "key" : "s",
        "doc_count" : 1344
      }, {
        "key" : "f",
        "doc_count" : 1242
      }, {
        "key" : "m",
        "doc_count" : 1132
      }, {
        "key" : "o",
        "doc_count" : 1047
      }, {
        "key" : "h",
        "doc_count" : 1034
      }, {
        "key" : "d",
        "doc_count" : 921
      }, {
        "key" : "a",
        "doc_count" : 920
      }, {
        "key" : "w",
        "doc_count" : 323
      }, {
        "key" : "q",
        "doc_count" : 101
      }, {
        "key" : "v",
        "doc_count" : 92
      }, {
        "key" : "y",
        "doc_count" : 61
      }, {
        "key" : "j",
        "doc_count" : 58
      }, {
        "key" : "k",
        "doc_count" : 47
      }, {
        "key" : "z",
        "doc_count" : 21
      }, {
        "key" : "x",
        "doc_count" : 9
      } ]
    }
  }
}
```


### How to review

Drop the ONS index in elastic (presumably this is local) and then restart Zebedee (or you can use the reindex api)
` curl -XDELETE localhost:9200/*`
then Start Zebedee and when indexing is complete check the '_terms_' in the `description.title.title_first_letter` using the following query
```
 curl -XPOST  localhost:9200/ons/_search?pretty -d '{
  "size":0,
  "aggs": {
    "fieldTerms": {
      "terms": {
        "field": "description.title.title_first_letter",
        "size":100
      }
    }
  }
}'
```
### Who can review

James Fawke implemented it.