### PR TITLE
Feature/content in another collection logging

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -204,6 +204,14 @@ public class Zebedee {
         return result;
     }
 
+
+    public Optional<Collection> isContentInAnotherCollection(Collection target, String uri) throws IOException {
+        return collections.list()
+                .stream()
+                .filter(c -> c.isInCollection(uri) && !target.getDescription().id.equals(c.getDescription().id))
+                .findFirst();
+    }
+
     public void checkAllCollectionsForDeleteMarker(String uri) throws IOException, DeleteContentRequestDeniedException {
         Path searchValue = Paths.get(uri);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -205,7 +205,7 @@ public class Zebedee {
     }
 
 
-    public Optional<Collection> getBlockingCollectionIfExists(Collection workingCollection, String uri) throws IOException {
+    public Optional<Collection> checkForCollectionBlockingChange(Collection workingCollection, String uri) throws IOException {
         return collections.list()
                 .stream()
                 .filter(c -> c.isInCollection(uri) && !workingCollection.getDescription().id.equals(c.getDescription().id))

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -205,10 +205,10 @@ public class Zebedee {
     }
 
 
-    public Optional<Collection> isContentInAnotherCollection(Collection target, String uri) throws IOException {
+    public Optional<Collection> getBlockingCollectionIfExists(Collection workingCollection, String uri) throws IOException {
         return collections.list()
                 .stream()
-                .filter(c -> c.isInCollection(uri) && !target.getDescription().id.equals(c.getDescription().id))
+                .filter(c -> c.isInCollection(uri) && !workingCollection.getDescription().id.equals(c.getDescription().id))
                 .findFirst();
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
@@ -15,11 +15,19 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 
 import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.function.BiFunction;
 
 /**
  * Created by dave on 5/5/16.
  */
 public class ZebedeeLogBuilder extends LogMessageBuilder {
+
+    private static BiFunction<String, String, String> COLLECTION_CONTENT_PATH = (collectioName, uri) -> {
+        uri = uri.startsWith("/") ? uri.substring(1) : uri;
+        return Paths.get(collectioName).resolve("inprogress").resolve(uri).toString();
+    };
 
     public static final String LOG_NAME = "com.github.onsdigital.zebedee";
     private static final String ZEBEDEE_EXCEPTION = "Zebedee Exception";
@@ -35,6 +43,10 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
     private static final String PATH = "path";
     private static final String ROW = "row";
     private static final String CELL = "cell";
+    private static final String BLOCKING_PATH = "blockingPath";
+    private static final String BLOCKING_COLLECTION = "blockingCollection";
+    private static final String TARGET_PATH = "targetPath";
+    private static final String TARGET_COLLECTION = "targetCollection";
 
     private ZebedeeLogBuilder(String description) {
         super(description);
@@ -176,6 +188,21 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
     public ZebedeeLogBuilder cell(Cell cell) {
         if (cell != null) {
             addParameter(CELL, cell.getColumnIndex());
+        }
+        return this;
+    }
+
+    public ZebedeeLogBuilder saveOrEditConflict(Collection targetCollection, Collection blockingCollection, String targetURI) throws IOException {
+        if (targetCollection != null) {
+            String name = targetCollection.getDescription().name;
+            addParameter(TARGET_PATH, COLLECTION_CONTENT_PATH.apply(name, targetURI));
+            addParameter(TARGET_COLLECTION, name);
+        }
+        if (blockingCollection != null) {
+            String name = blockingCollection.getDescription().name;
+
+            addParameter(BLOCKING_PATH, COLLECTION_CONTENT_PATH.apply(name, targetURI));
+            addParameter(BLOCKING_COLLECTION, name);
         }
         return this;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -589,7 +589,7 @@ public class Collection {
 
         Path source = find(uri);
 
-        Optional<Collection> blockingCollection = zebedee.isContentInAnotherCollection(this, uri);
+        Optional<Collection> blockingCollection = zebedee.getBlockingCollectionIfExists(this, uri);
         if (blockingCollection.isPresent()) {
             Collection collection = blockingCollection.get();
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -498,6 +498,11 @@ public class Collections {
     ) throws IOException, ZebedeeException, FileUploadException {
 
         CollectionWriter collectionWriter = new ZebedeeCollectionWriter(zebedee, collection, session);
+        logInfo("Attempting to write content.")
+                .collectionName(collection)
+                .path(uri)
+                .user(session.email)
+                .log();
 
         if (collection.description.approvalStatus == ApprovalStatus.COMPLETE) {
             throw new BadRequestException("This collection has been approved and cannot be saved to.");
@@ -535,6 +540,7 @@ public class Collections {
         }
 
         collection.save();
+        logInfo("content save successful.").collectionName(collection).path(uri).user(session.email).log();
 
         path = collection.getInProgressPath(uri);
         if (!Files.exists(path)) {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/Builder.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/Builder.java
@@ -31,6 +31,9 @@ import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logDebug;
  */
 public class Builder {
 
+    public static final String COLLECTION_ONE_NAME = "inflationq22015";
+    public static final String COLLECTION_TWO_NAME = "labourmarketq22015";
+
     private static int teamId;
     private static User administratorTemplate;
     private static User publisher1Template;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -215,7 +215,7 @@ public class ZebedeeTest {
 
 		Session session = new Session();
 		session.email = "makingData@greatagain.com";
-		Optional<Collection> blockingCollection = zebedee.getBlockingCollectionIfExists(collectionOne, contentPath);
+		Optional<Collection> blockingCollection = zebedee.checkForCollectionBlockingChange(collectionOne, contentPath);
 
 		assertThat(blockingCollection.isPresent(), is(true));
 		assertThat(blockingCollection.get().getDescription().name, equalTo(collectionTwo.getDescription().name));
@@ -232,7 +232,7 @@ public class ZebedeeTest {
 
 		Session session = new Session();
 		session.email = "makingData@greatagain.com";
-		Optional<Collection> blockingCollection = zebedee.getBlockingCollectionIfExists(collectionOne, contentPath);
+		Optional<Collection> blockingCollection = zebedee.checkForCollectionBlockingChange(collectionOne, contentPath);
 		assertThat(blockingCollection.isPresent(), is(false));
 
 		Collection collectionTwo = zebedee.getCollections().getCollectionByName(COLLECTION_TWO_NAME);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -920,6 +921,7 @@ public class CollectionsTest {
 
         Collection collection = new Collection(builder.collections.get(0), zebedee);
 
+
         builder.createPublishedFile(uri);
         zebedee.getCollections().createContent(collection, uri, null, null, null, null, validateJson);
     }
@@ -929,9 +931,18 @@ public class CollectionsTest {
         String uri = "/this/is/a/directory/file.json";
 
         Collection collection = new Collection(builder.collections.get(0), zebedee);
+        Collection blockingCollection = new Collection(builder.collections.get(1), zebedee);
 
         builder.createInProgressFile(uri);
-        zebedee.getCollections().createContent(collection, uri, null, null, null, null, validateJson);
+        Session session = new Session();
+        session.email = "makingdata@greatagain.com";
+        zebedee.getCollections().createContent(collection, uri, session, null, null, null, validateJson);
+
+        assertThat(collection.inProgressUris().contains(uri), is(false));
+        assertThat(blockingCollection.inProgressUris().contains(uri), is(true));
+
+        assertThat(collection.reviewedUris().contains(uri), is(false));
+        assertThat(collection.completeUris().contains(uri), is(false));
     }
 
     @Test


### PR DESCRIPTION
Added additional logging when a collection cannot save as its being edited in another collection. Log will output the collection & path of the content that is 'blocking' the save as well as the collection & path of the content that is attempting to be saved.
