### PR TITLE
default to index.html, and support spaces in URIs for data vis

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/CollectionReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/CollectionReader.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.reader;
 
 import com.github.onsdigital.zebedee.content.dynamic.browse.ContentNode;
 import com.github.onsdigital.zebedee.content.page.base.Page;
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.reader.data.language.ContentLanguage;
@@ -59,7 +60,11 @@ public abstract class CollectionReader {
 
 
     public Resource getResource(String path) throws ZebedeeException, IOException {
-        return findResource(path);
+        try {
+            return findResource(path);
+        } catch (BadRequestException e) {
+            return findResource(path + "/index.html");
+        }
     }
 
     public long getContentLength(String path) throws ZebedeeException, IOException {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/CollectionReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/CollectionReader.java
@@ -63,7 +63,10 @@ public abstract class CollectionReader {
         try {
             return findResource(path);
         } catch (BadRequestException e) {
-            return findResource(path + "/index.html");
+            if(path.startsWith("/visualisations/")) {
+                return findResource(path + "/index.html");
+            }
+            throw e;
         }
     }
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/ZebedeeReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/ZebedeeReader.java
@@ -124,7 +124,10 @@ public class ZebedeeReader {
         try {
             return publishedContentReader.getResource(path);
         } catch (BadRequestException e) {
-            return publishedContentReader.getResource(path + "/index.html");
+            if(path.startsWith("/visualisations/")) {
+                return publishedContentReader.getResource(path + "/index.html");
+            }
+            throw e;
         }
     }
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/ZebedeeReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/ZebedeeReader.java
@@ -13,6 +13,7 @@ import com.github.onsdigital.zebedee.reader.data.language.ContentLanguage;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -120,7 +121,11 @@ public class ZebedeeReader {
      * @throws IOException
      */
     public Resource getPublishedResource(String path) throws ZebedeeException, IOException {
-        return publishedContentReader.getResource(path);
+        try {
+            return publishedContentReader.getResource(path);
+        } catch (BadRequestException e) {
+            return publishedContentReader.getResource(path + "/index.html");
+        }
     }
 
     /**

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandler.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandler.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,7 +119,7 @@ public class ReadRequestHandler {
      * @throws IOException
      */
     public Resource findResource(HttpServletRequest request) throws ZebedeeException, IOException {
-        String uri = extractUri(request);
+        String uri = URLDecoder.decode(extractUri(request), "UTF-8");
         String collectionId = getCollectionId(request);
         if (collectionId != null) {
             try {

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandlerTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandlerTest.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.zebedee.content.dynamic.browse.ContentNode;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.reader.FakeCollectionReaderFactory;
+import com.github.onsdigital.zebedee.reader.Resource;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration;
 import com.github.onsdigital.zebedee.reader.data.filter.DataFilter;
@@ -141,5 +142,19 @@ public class ReadRequestHandlerTest {
     @Test
     public void testSetAuthorisationHandler() throws Exception {
 
+    }
+
+    @Test
+    public void testIndexFile() throws Exception {
+        when(request.getParameter("uri")).thenReturn("/visualisations/test/content");
+        Resource resource = readRequestHandler.findResource(request);
+        assertEquals("/visualisations/test/content/index.html", resource.getUri().toString());
+    }
+
+    @Test
+    public void testURIWithSpaces() throws Exception {
+        when(request.getParameter("uri")).thenReturn("/visualisations/test/content/has spaces");
+        Resource resource = readRequestHandler.findResource(request);
+        assertEquals("/visualisations/test/content/has%20spaces/index.html", resource.getUri().toString());
     }
 }

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandlerTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandlerTest.java
@@ -98,7 +98,7 @@ public class ReadRequestHandlerTest {
 
     private void shouldResolveTaxonomyFirstLevel() throws Exception {
         Collection<ContentNode> children = readRequestHandler.getTaxonomy(request, 1);
-        assertTrue(children.size() == 4);
+        assertTrue(children.size() == 5);
         ContentNode child = children.iterator().next();
         assertNull(child.getChildren());
         assertEquals("Economy", child.getDescription().getTitle());

--- a/zebedee-reader/target/test-classes/test-content/zebedee/master/visualisations/test/content/has spaces/index.html
+++ b/zebedee-reader/target/test-classes/test-content/zebedee/master/visualisations/test/content/has spaces/index.html
@@ -1,0 +1,1 @@
+Test visualisation with spaces in URI

--- a/zebedee-reader/target/test-classes/test-content/zebedee/master/visualisations/test/content/index.html
+++ b/zebedee-reader/target/test-classes/test-content/zebedee/master/visualisations/test/content/index.html
@@ -1,0 +1,1 @@
+Test visualisation


### PR DESCRIPTION
### What

Updates to data visualisation URI handling:

* Default to `index.html` if the URI doesn't include a filename
* Support spaces in directory/file names

### How to review

* Start babbage/zebedee
* Create a visualisation (`content/visualisations/test/content/index.html`)
* Check http://localhost:8080/visualisations/test/ works
* Create a visualisation with spaces (`content/visualisations/has spaces/content/index.html`)
* Check http://localhost:8080/visualisations/has%20spaces/ works

### Who can review

Anyone except @ian-kent