### PR TITLE
remove 'members' from team list api output

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/TeamList.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/TeamList.java
@@ -1,14 +1,30 @@
 package com.github.onsdigital.zebedee.json;
 
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by david on 21/04/2015.
  */
 public class TeamList {
-    public List<Team> teams;
+    public class TeamListTeam {
+        public int id;
+        public String name;
+
+        public TeamListTeam(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    public List<TeamListTeam> teams;
+
     public TeamList(List<Team> teamList) {
-        this.teams = teamList;
+        teams = new ArrayList<>();
+        for (Team team : teamList) {
+            teams.add(new TeamListTeam(team.id, team.name));
+        }
     }
 }
+


### PR DESCRIPTION
### What

Remove `members` from the team list API since it's not required by Florence (and returns a huge amount of data in production)

### How to review

* Start publishing stack
* Login to Florence
* Create a team
* Add a user to the team
* Check Florence teams screen still works as expected
* Check the network tab
   * Team list shouldn't include members
   * Individual team should include members as before

### Who can review

Anyone except @ian-kent (@crispioso?)