### PR TITLE
Fix for browse tree defect

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -9,17 +9,23 @@ import com.google.gson.JsonSyntaxException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
+import static com.github.onsdigital.zebedee.model.PathUtils.findByCriteria;
 
 public class Content {
 
@@ -49,6 +55,7 @@ public class Content {
 
     /**
      * Create a new instance using an injected publishedContentPath.
+     *
      * @param path
      * @param publishedContentPath
      */
@@ -57,8 +64,10 @@ public class Content {
         this.publishedContentPath = publishedContentPath;
     }
 
-    private static boolean isNotTimeseries(Path p) {
-        return !p.getFileName().toString().contains(TIME_SERIES_KEYWORD);
+    private static boolean isTimeseries(Path path) {
+        return findByCriteria(path, p -> {
+            return p.toFile().isDirectory() && TIME_SERIES_KEYWORD.equals(p.getFileName().toString());
+        });
     }
 
     private static boolean isDataVisualisation(Path p) {
@@ -408,16 +417,16 @@ public class Content {
         return false;
     }
 
-    private boolean isVisibleForCollectionOwner(CollectionOwner collectionOwner, Path entry) {
+    static boolean isVisibleForCollectionOwner(CollectionOwner collectionOwner, Path entry) {
         if (collectionOwner.equals(CollectionOwner.DATA_VISUALISATION)) {
             return Files.isDirectory(entry)
                     && isDataVisualisation(entry)
-                    && isNotTimeseries(entry)
+                    && !isTimeseries(entry)
                     && isNotPreviousVersions(entry);
         } else {
             // PUBLISHING SUPPORT
             return Files.isDirectory(entry)
-                    && isNotTimeseries(entry)
+                    && !isTimeseries(entry)
                     && isNotPreviousVersions(entry)
                     && !isDataVisualisation(entry);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/PathUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/PathUtils.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Predicate;
 
 public class PathUtils {
     static final int MAX_LENGTH = 255;
@@ -181,5 +182,29 @@ public class PathUtils {
             uri = "/" + uri;
         }
         return uri;
+    }
+
+    /**
+     * Starting with the child directory/file applies the test criteria acsending the path until the criteria is
+     * satisfied. Will return true at the first level to meet the criteria. If no match is found or if there are no
+     * levels to ascend to then returns false.
+     *
+     * @param path     the {@link Path} to apply the test criteria to.
+     * @param criteria {@link Predicate} defining the criteria to apply.
+     * @return returns true at the the first directory to meet the criteria, false otherwise.
+     */
+    public static boolean findByCriteria(Path path, Predicate<Path> criteria) {
+        if (path == null) {
+            return false;
+        }
+
+        Path dir = path;
+        while (dir != null && dir.getParent() != null) {
+            if (criteria.test(dir)) {
+                return true;
+            }
+            dir = dir.getParent();
+        }
+        return false;
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
@@ -244,6 +244,8 @@ public class ContentTest {
         Path zebedeeURI = Files.createTempDirectory("master");
         zebedeeURI = zebedeeURI.resolve("timeseries");
         zebedeeURI.toFile().mkdir();
+        zebedeeURI = zebedeeURI.resolve("nested");
+        zebedeeURI.toFile().mkdir();
 
         assertThat(isVisibleForCollectionOwner(CollectionOwner.PUBLISHING_SUPPORT, zebedeeURI), is(false));
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
@@ -15,6 +15,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static com.github.onsdigital.zebedee.model.Content.isVisibleForCollectionOwner;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class ContentTest {
@@ -226,5 +228,43 @@ public class ContentTest {
         // The result has the expected values
         assertEquals(1, results.size());
         assertTrue(results.contains("/somedirectory/" + jsonFile));
+    }
+
+    @Test
+    public void isVisibleForCollectionOwner_ShouldReturnFalseIfPathEndsWithTimeseriesDir() throws Exception {
+        Path p = Files.createTempDirectory("master");
+        p = p.resolve("timeseries");
+        p.toFile().mkdir();
+
+        assertThat(isVisibleForCollectionOwner(CollectionOwner.PUBLISHING_SUPPORT, p), is(false));
+    }
+
+    @Test
+    public void isVisibleForCollectionOwner_ShouldReturnFalseIfPathContainsTimeseriesDir() throws Exception {
+        Path zebedeeURI = Files.createTempDirectory("master");
+        zebedeeURI = zebedeeURI.resolve("timeseries");
+        zebedeeURI.toFile().mkdir();
+
+        assertThat(isVisibleForCollectionOwner(CollectionOwner.PUBLISHING_SUPPORT, zebedeeURI), is(false));
+    }
+
+    @Test
+    public void isVisibleForCollectionOwner_ShouldReturnTrueIfPathDoesNotConatinTimeseriesDir() throws Exception {
+        Path p = Files.createTempDirectory("master");
+        p = p.resolve("datasets");
+        p.toFile().mkdir();
+
+        assertThat(isVisibleForCollectionOwner(CollectionOwner.PUBLISHING_SUPPORT, p), is(true));
+    }
+
+
+    @Test
+    public void isVisibleForCollectionOwner_ShouldReturnTrueIfPathContainsDirWhereTimeseriesIsASubStringOfTheDirName() throws Exception {
+        Path p = Files.createTempDirectory("master");
+        p = p.resolve("thisisnotatimeseriesdir");
+        p.toFile().mkdir();
+
+        boolean result = isVisibleForCollectionOwner(CollectionOwner.PUBLISHING_SUPPORT, p);
+        assertThat(result, is(true));
     }
 }


### PR DESCRIPTION
Fix for browse tree defect.
Correct behaviour is that timeseries directories are left out of the browse tree however in the  current impl it is excluding any directory that has a path containing the substring "timeseries". This means that several TS dataset landing pages are not showing up. Fix address this issue.
