### PR TITLE
Wrapper around Serialiser to silently handle & log execeptions.

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImpl.java
@@ -4,6 +4,7 @@ import com.github.davidcarboni.restolino.json.Serialiser;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.model.PathUtils;
 import com.github.onsdigital.zebedee.teams.model.Team;
+import com.github.onsdigital.zebedee.util.serialiser.JSONSerialiser;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ public class TeamsStoreFileSystemImpl implements TeamsStore {
 
     private Path teamsPath;
     private ReadWriteLock teamLock = new ReentrantReadWriteLock();
+    private JSONSerialiser<Team> teamJSONSerialiser;
 
     /**
      * Return true if the {@link Path} is not null and ends with '.json'.
@@ -41,6 +43,7 @@ public class TeamsStoreFileSystemImpl implements TeamsStore {
      */
     public TeamsStoreFileSystemImpl(Path teamsPath) {
         this.teamsPath = teamsPath;
+        this.teamJSONSerialiser = new JSONSerialiser(Team.class);
     }
 
     @Override
@@ -96,7 +99,10 @@ public class TeamsStoreFileSystemImpl implements TeamsStore {
 
             for (Path path : teams) {
                 try (InputStream input = Files.newInputStream(path)) {
-                    result.add(Serialiser.deserialise(input, Team.class));
+                    Team t = teamJSONSerialiser.deserialiseQuietly(input, path);
+                    if (t != null) {
+                        result.add(t);
+                    }
                 }
             }
         } finally {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/CustomListCollector.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/CustomListCollector.java
@@ -25,7 +25,11 @@ public abstract class CustomListCollector<T, R> implements Collector<T, Immutabl
 
     @Override
     public BiConsumer<ImmutableList.Builder<T>, T> accumulator() {
-        return (builder, item) -> builder.add(item);
+        return (builder, item) -> {
+            if (item != null) {
+                builder.add(item);
+            }
+        };
     }
 
     @Override

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiser.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiser.java
@@ -1,0 +1,61 @@
+package com.github.onsdigital.zebedee.util.serialiser;
+
+import com.github.davidcarboni.restolino.json.Serialiser;
+import com.github.onsdigital.zebedee.user.model.User;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
+
+/**
+ * Created by dave on 04/07/2017.
+ */
+public class JSONSerialiser<T> {
+
+    protected static final String DESERIALISE_ERROR_DETAILS_MSG = "Warning Corrupt JSON file encountered. JSON could " +
+            "not be deserialised. It is highly recommended that you investigate this cause of thus issue";
+
+    protected static final String DESERIALISE_ERROR_DETAILS_KEY = "details";
+    protected static final String DESERIALISATIOBN_ERROR_MSG = "Failed to deserialise JSON";
+
+    protected Class<T> t;
+
+    public JSONSerialiser(Class<T> t) {
+        this.t = t;
+    }
+
+    public T deserialiseQuietly(Path p) {
+        try {
+            return Serialiser.deserialise(p, t);
+        } catch (Exception e) {
+            logError(e, DESERIALISATIOBN_ERROR_MSG)
+                    .addParameter(DESERIALISE_ERROR_DETAILS_KEY, DESERIALISE_ERROR_DETAILS_MSG)
+                    .path(p.toString())
+                    .log();
+            return null;
+        }
+    }
+
+    public T deserialiseQuietly(InputStream inputStream, Path p) {
+        try {
+            return Serialiser.deserialise(inputStream, t);
+        } catch (Exception e) {
+            logError(e, DESERIALISATIOBN_ERROR_MSG)
+                    .addParameter(DESERIALISE_ERROR_DETAILS_KEY, DESERIALISE_ERROR_DETAILS_MSG)
+                    .path(p.toString())
+                    .log();
+            return null;
+        }
+    }
+
+    public T deserialise(Path p) throws IOException {
+        return Serialiser.deserialise(p, t);
+    }
+
+    public void serialise(Path p, T t) throws IOException {
+        Serialiser.serialise(p, t);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiser.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiser.java
@@ -1,11 +1,9 @@
 package com.github.onsdigital.zebedee.util.serialiser;
 
 import com.github.davidcarboni.restolino.json.Serialiser;
-import com.github.onsdigital.zebedee.user.model.User;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
@@ -16,10 +14,10 @@ import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 public class JSONSerialiser<T> {
 
     protected static final String DESERIALISE_ERROR_DETAILS_MSG = "Warning Corrupt JSON file encountered. JSON could " +
-            "not be deserialised. It is highly recommended that you investigate this cause of thus issue";
+            "not be deserialised. It is highly recommended that you investigate the cause of this issue";
 
     protected static final String DESERIALISE_ERROR_DETAILS_KEY = "details";
-    protected static final String DESERIALISATIOBN_ERROR_MSG = "Failed to deserialise JSON";
+    protected static final String DESERIALISATION_ERROR_MSG = "Failed to deserialise JSON";
 
     protected Class<T> t;
 
@@ -31,7 +29,7 @@ public class JSONSerialiser<T> {
         try {
             return Serialiser.deserialise(p, t);
         } catch (Exception e) {
-            logError(e, DESERIALISATIOBN_ERROR_MSG)
+            logError(e, DESERIALISATION_ERROR_MSG)
                     .addParameter(DESERIALISE_ERROR_DETAILS_KEY, DESERIALISE_ERROR_DETAILS_MSG)
                     .path(p.toString())
                     .log();
@@ -43,7 +41,7 @@ public class JSONSerialiser<T> {
         try {
             return Serialiser.deserialise(inputStream, t);
         } catch (Exception e) {
-            logError(e, DESERIALISATIOBN_ERROR_MSG)
+            logError(e, DESERIALISATION_ERROR_MSG)
                     .addParameter(DESERIALISE_ERROR_DETAILS_KEY, DESERIALISE_ERROR_DETAILS_MSG)
                     .path(p.toString())
                     .log();

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiserTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/serialiser/JSONSerialiserTest.java
@@ -1,0 +1,97 @@
+package com.github.onsdigital.zebedee.util.serialiser;
+
+import com.github.onsdigital.zebedee.user.model.User;
+import com.github.onsdigital.zebedee.util.serialiser.JSONSerialiser;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by dave on 04/07/2017.
+ */
+public class JSONSerialiserTest {
+
+    @Rule
+    public TemporaryFolder root = new TemporaryFolder();
+
+    private JSONSerialiser<User> serialiser;
+    private File usersDir;
+
+    @Before
+    public void setUp() throws Exception {
+        root.create();
+        usersDir = root.newFolder("user");
+        serialiser = new JSONSerialiser(User.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        root.delete();
+    }
+
+    @Test
+    public void deserialiseQuietly_ShouldReturnNullIfFailsToDeserialise() throws Exception {
+        Path userPath = usersDir.toPath().resolve("corrupt_user.json");
+        userPath.toFile().createNewFile();
+
+        Files.write(userPath, "abcdefghijklmnopqrstuvwxyz".getBytes(), StandardOpenOption.APPEND);
+
+        assertThat(serialiser.deserialiseQuietly(userPath), equalTo(null));
+    }
+
+    @Test
+    public void deserialiseQuietly_ShouldDeserialiseSuccessfully() throws IOException {
+        User user = new User();
+        user.setEmail("motherOfDragons@ons.gov.uk");
+        user.setName("Daenerys Targaryen");
+        user.setLastAdmin("admin@ons.gov.uk");
+        user.setInactive(false);
+        user.setTemporaryPassword(false);
+
+        Path userPath = usersDir.toPath().resolve("motherOfDragonsons.gov.uk");
+        userPath.toFile().createNewFile();
+
+        Files.write(userPath, new Gson().toJson(user).getBytes(), StandardOpenOption.APPEND);
+
+        assertThat(serialiser.deserialiseQuietly(userPath), equalTo(user));
+    }
+
+    @Test (expected = JsonSyntaxException.class)
+    public void deserialise_ShouldProgegateExceptions() throws Exception {
+        Path userPath = usersDir.toPath().resolve("corrupt_user.json");
+        userPath.toFile().createNewFile();
+        Files.write(userPath, "abcdefghijklmnopqrstuvwxyz".getBytes(), StandardOpenOption.APPEND);
+
+        serialiser.deserialise(userPath);
+    }
+
+    @Test
+    public void deserialise_ShouldDeserialiseSuccessfully() throws Exception {
+        User user = new User();
+        user.setEmail("motherOfDragons@ons.gov.uk");
+        user.setName("Daenerys Targaryen");
+        user.setLastAdmin("admin@ons.gov.uk");
+        user.setInactive(false);
+        user.setTemporaryPassword(false);
+
+        Path userPath = usersDir.toPath().resolve("motherOfDragonsons.gov.uk");
+        userPath.toFile().createNewFile();
+
+        Files.write(userPath, new Gson().toJson(user).getBytes(), StandardOpenOption.APPEND);
+
+        assertThat(serialiser.deserialise(userPath), equalTo(user));
+    }
+}


### PR DESCRIPTION
Added wrapper around deserialiser class to give the option of suppressing & logging errors & if required.

Previously calling list users/sessions/teams would make the entire application fall over if one of the users/teams/sessions could not be deserialised.

This change means these errors are now caught and logged but not propagated allowing the application to carry on -> if one user file is corrupt the other users are no longer affected.