### PR TITLE
Add isPrototypeArticle flag to Article page model

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/Article.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/Article.java
@@ -15,6 +15,7 @@ public class Article extends StatisticalDocument {
     /*Body*/
     private List<Link> relatedArticles;
     private List<DownloadSection> pdfTable;
+    private Boolean isPrototypeArticle;
 
 
     public List<DownloadSection> getPdfTable() {
@@ -36,5 +37,13 @@ public class Article extends StatisticalDocument {
 
     public List<Link> getRelatedArticles() {
         return relatedArticles;
+    }
+
+    public Boolean getPrototypeArticle() {
+        return isPrototypeArticle;
+    }
+
+    public void setPrototypeArticle(Boolean prototypeArticle) {
+        isPrototypeArticle = prototypeArticle;
     }
 }


### PR DESCRIPTION
### What

Added flag for toggling between "neutral"/"prototype"/"visual" and normal articles

### How to review

To run you'll need the following services and branches
Babbage - `feature/visual-article`
Florence - `feature/prototype-article`
Zebedee - `feature/prototype-article`
Sixteens - `feature/prototype-article`

### Who can review

Anyone but me