### PR TITLE
Feature/add cmd page type

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
@@ -82,7 +82,7 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     private String provisionalDate;
     private String versionLabel;
     private String metaCmd;
-
+    private String apiDatasetId;
 
     public PageDescription() {
     }
@@ -445,5 +445,11 @@ public class PageDescription extends Content implements Comparable<PageDescripti
         this.metaCmd = metaCmd;
     }
 
-}
+    public String getapiDatasetId() {
+        return apiDatasetId;
+    }
 
+    public void setapiDatasetId(String apiDatasetId) {
+      this.apiDatasetId = apiDatasetId;
+    }
+}

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -35,6 +35,7 @@ public enum PageType {
     static_adhoc("Static adhoc page"),
     dataset("Dataset page"),
     dataset_landing_page("Dataset landing page"),
+    api_dataset_landing_page("API Dataset landing page"),
     timeseries_dataset("Timeseries dataset page"),
     release("Release page"),
     reference_tables("Reference tables"),

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ApiDatasetLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ApiDatasetLandingPage.java
@@ -1,0 +1,31 @@
+package com.github.onsdigital.zebedee.content.page.statistics.dataset;
+
+ import com.github.onsdigital.zebedee.content.page.base.PageType;
+ import com.github.onsdigital.zebedee.content.page.statistics.base.Statistics;
+ import com.github.onsdigital.zebedee.content.partial.Link;
+ import com.github.onsdigital.zebedee.content.partial.markdown.MarkdownSection;
+
+ import java.util.List;
+
+ /**
+  * Created by
+  */
+ public class ApiDatasetLandingPage extends Statistics {
+
+     /*Body*/
+     private String apiDatasetId;
+
+     @Override
+     public PageType getType() {
+         return PageType.api_dataset_landing_page;
+     }
+
+     public String getapiDatasetId() {
+         return apiDatasetId;
+     }
+
+     public void setapiDatasetId(String apiDatasetId) {
+         this.apiDatasetId = apiDatasetId;
+     }
+
+ }


### PR DESCRIPTION
### What

Added new page type for CMD dataset

### How to review

Run Florence and the recipe api. Create a new page and select the cmd dataset landing page. Click import and view the available data sets (should be only 1). Select the dataset and view the information in the details panel. Click create page. View the url with /data and see the dataset id added to the page data.

### Who can review

Anyone
