### PR TITLE
Add mm23 to RPI time series as work around for search weirdness

### DIFF
--- a/zebedee-reader/src/main/resources/search/boost.txt
+++ b/zebedee-reader/src/main/resources/search/boost.txt
@@ -23,8 +23,8 @@
 /economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/*=>flow of funds
 /economy/inflationandpriceindices/bulletins/producerpriceinflation/*=>psi
 /economy/inflationandpriceindices/datasets/consumerpriceinflation=>rpi
-/economy/inflationandpriceindices/timeseries/chaw/*=>rpi
-/economy/inflationandpriceindices/timeseries/czbh/*=>rpi
+/economy/inflationandpriceindices/timeseries/chaw/mm23=>rpi
+/economy/inflationandpriceindices/timeseries/czbh/mm23=>rpi
 /businessindustryandtrade/retailindustry/bulletins/retailsales/*=>retail
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/*=>average earnings index,Labour Force Survey,unemployment,labour market statistics,employment,Claimant Count,average weekly earnings
 /employmentandlabourmarket/peopleinwork/employmentandemployeetypes/datasets/summaryoflabourmarketstatistics=>unemployment,employment


### PR DESCRIPTION
### What

Change discussed with Dave to fix issue with RPI time series not being boosted on publish

### How to review

-> Upload new version of mm23 dataset and check rpi time series are still in positions 2 and 3 on main site search for rpi.

### Who can review

Prob @daiLlew  :-)