### PR TITLE
Add HTTP PUT and DELETE endpoint for adding instances to a collection.

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -5,11 +5,11 @@ import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDetail;
 import com.github.onsdigital.zebedee.json.ContentDetail;
 import com.github.onsdigital.zebedee.json.Events;
-import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.model.ZebedeeCollectionReader;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.service.ContentDeleteService;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.util.ContentDetailUtil;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -82,6 +82,8 @@ public class CollectionDetails {
         teams.forEach(team -> {
             collection.description.teams.add(team.getName());
         });
+
+        result.instances = collection.description.getInstances();
 
         return result;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -48,7 +48,7 @@ public class CollectionDetails {
         }
 
         Session session = Root.zebedee.getSessionsService().get(request);
-        if (!Root.zebedee.getPermissionsService().canView(session.getEmail(), collection.description)) {
+        if (!Root.zebedee.getPermissionsService().canView(session.getEmail(), collection.getDescription())) {
             response.setStatus(HttpStatus.UNAUTHORIZED_401);
             return null;
         }
@@ -56,34 +56,32 @@ public class CollectionDetails {
         CollectionReader collectionReader = new ZebedeeCollectionReader(Root.zebedee, collection, session);
 
         CollectionDetail result = new CollectionDetail();
-        result.id = collection.description.id;
-        result.name = collection.description.name;
-        result.type = collection.description.type;
-        result.publishDate = collection.description.publishDate;
-        result.teams = collection.description.teams;
-        result.releaseUri = collection.description.releaseUri;
-        result.collectionOwner = collection.description.collectionOwner;
+        result.id = collection.getDescription().id;
+        result.name = collection.getDescription().name;
+        result.type = collection.getDescription().type;
+        result.publishDate = collection.getDescription().publishDate;
+        result.teams = collection.getDescription().teams;
+        result.releaseUri = collection.getDescription().releaseUri;
+        result.collectionOwner = collection.getDescription().collectionOwner;
         result.pendingDeletes = contentDeleteService.getDeleteItemsByCollection(collection);
 
         result.inProgress = ContentDetailUtil.resolveDetails(collection.inProgress, collectionReader.getInProgress());
         result.complete = ContentDetailUtil.resolveDetails(collection.complete, collectionReader.getComplete());
         result.reviewed = ContentDetailUtil.resolveDetails(collection.reviewed, collectionReader.getReviewed());
 
-        result.approvalStatus = collection.description.approvalStatus;
-        result.events = collection.description.events;
-        result.timeseriesImportFiles = collection.description.timeseriesImportFiles;
+        result.approvalStatus = collection.getDescription().approvalStatus;
+        result.events = collection.getDescription().events;
+        result.timeseriesImportFiles = collection.getDescription().timeseriesImportFiles;
 
-        addEventsForDetails(result.inProgress, result, collection);
-        addEventsForDetails(result.complete, result, collection);
-        addEventsForDetails(result.reviewed, result, collection);
+        addEventsForDetails(result.inProgress, collection);
+        addEventsForDetails(result.complete, collection);
+        addEventsForDetails(result.reviewed, collection);
 
-        Set<Integer> teamIds = Root.zebedee.getPermissionsService().listViewerTeams(collection.description, session);
+        Set<Integer> teamIds = Root.zebedee.getPermissionsService().listViewerTeams(collection.getDescription(), session);
         List<Team> teams = Root.zebedee.getTeamsService().resolveTeams(teamIds);
-        teams.forEach(team -> {
-            collection.description.teams.add(team.getName());
-        });
+        teams.forEach(team -> collection.getDescription().teams.add(team.getName()));
 
-        result.instances = collection.description.getInstances();
+        result.instances = collection.getDescription().getInstances();
 
         return result;
     }
@@ -91,7 +89,6 @@ public class CollectionDetails {
 
     private void addEventsForDetails(
             List<ContentDetail> detailsToAddEventsFor,
-            CollectionDetail result,
             com.github.onsdigital.zebedee.model.Collection collection
     ) {
 
@@ -102,8 +99,8 @@ public class CollectionDetails {
             } else {
                 language = "_" + contentDetail.description.language;
             }
-            if (collection.description.eventsByUri != null) {
-                Events eventsForFile = collection.description.eventsByUri.get(contentDetail.uri + "/data" + language + ".json");
+            if (collection.getDescription().eventsByUri != null) {
+                Events eventsForFile = collection.getDescription().eventsByUri.get(contentDetail.uri + "/data" + language + ".json");
                 contentDetail.events = eventsForFile;
             } else {
                 contentDetail.events = new Events();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -114,14 +114,7 @@ public class Collections {
         Path path = Path.newInstance(request);
         List<String> segments = path.segments();
 
-        // /collections/{collection_id}/instances/{instance_id}
-        if (segments.size() < 4 ||
-                !segments.get(2).equalsIgnoreCase("instances")) {
-
-            logInfo("Endpoint for colletions not found").addParameter("path", path).log();
-            response.setStatus(HttpStatus.SC_NOT_FOUND);
-            return;
-        }
+        if (!isValidPath(response, path, segments)) return;
 
         String collectionID = segments.get(1);
         String instanceID = segments.get(3);
@@ -151,14 +144,7 @@ public class Collections {
         Path path = Path.newInstance(request);
         List<String> segments = path.segments();
 
-        // /collections/{collection_id}/instances/{instance_id}
-        if (segments.size() < 4 ||
-                !segments.get(2).equalsIgnoreCase("instances")) {
-
-            logInfo("Endpoint for colletions not found").addParameter("path", path).log();
-            response.setStatus(HttpStatus.SC_NOT_FOUND);
-            return;
-        }
+        if (!isValidPath(response, path, segments)) return;
 
         String collectionID = segments.get(1);
         String instanceID = segments.get(3);
@@ -169,6 +155,20 @@ public class Collections {
                 .log();
 
         datasetService.deleteInstanceFromCollection(collectionID, instanceID);
+    }
+
+    private boolean isValidPath(HttpServletResponse response, Path path, List<String> segments) {
+
+        // /collections/{collection_id}/instances/{instance_id}
+        if (segments.size() < 4 ||
+                !segments.get(2).equalsIgnoreCase("instances")) {
+
+            logInfo("Endpoint for colletions not found").addParameter("path", path).log();
+            response.setStatus(HttpStatus.SC_NOT_FOUND);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -3,6 +3,10 @@ package com.github.onsdigital.zebedee.api;
 import com.github.davidcarboni.restolino.framework.Api;
 import com.github.davidcarboni.restolino.helpers.Path;
 import com.github.onsdigital.zebedee.dataset.api.DatasetAPIClient;
+import com.github.onsdigital.zebedee.dataset.api.exception.DatasetNotFoundException;
+import com.github.onsdigital.zebedee.dataset.api.exception.UnexpectedResponseException;
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnexpectedErrorException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
@@ -15,6 +19,7 @@ import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 import org.apache.http.HttpStatus;
 
+import javax.management.InstanceNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -124,7 +129,15 @@ public class Collections {
                 .addParameter("instanceID", instanceID)
                 .log();
 
-        datasetService.addInstanceToCollection(collectionID, instanceID);
+        try {
+            datasetService.addInstanceToCollection(collectionID, instanceID);
+        } catch (UnexpectedResponseException e) {
+            throw new UnexpectedErrorException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        } catch (InstanceNotFoundException | DatasetNotFoundException e) {
+            throw new NotFoundException(e.getMessage());
+        } catch (com.github.onsdigital.zebedee.dataset.api.exception.BadRequestException e) {
+            throw new BadRequestException(e.getMessage());
+        }
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -18,6 +18,7 @@ public class Configuration {
     private static final String INFLUXDB_URL = "http://influxdb:8086";
     private static final String AUDIT_DB_ENABLED_ENV_VAR = "audit_db_enabled";
     private static final String MATHJAX_SERVICE_URL = "http://localhost:8888";
+    private static final String DATASET_API_URL = "http://localhost:22000";
 
     private static final int VERIFY_RETRTY_DELAY = 5000; //milliseconds
     private static final int VERIFY_RETRTY_COUNT = 10;
@@ -72,6 +73,10 @@ public class Configuration {
 
     public static String getMathjaxServiceUrl() {
         return StringUtils.defaultIfBlank(getValue("MATHJAX_SERVICE_URL"), MATHJAX_SERVICE_URL);
+    }
+
+    public static String getDatasetAPIURL() {
+        return StringUtils.defaultIfBlank(getValue("DATASET_API_URL"), DATASET_API_URL);
     }
 
     public static String[] getTheTrainUrls() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Dataset.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Dataset.java
@@ -1,0 +1,36 @@
+package com.github.onsdigital.zebedee.dataset.api;
+
+/**
+ * The model of a dataset as provided by the dataset API.
+ */
+public class Dataset {
+
+    private String id;
+    private String title;
+    private String uri;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}
+

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
@@ -1,0 +1,87 @@
+package com.github.onsdigital.zebedee.dataset.api;
+
+import com.github.onsdigital.zebedee.configuration.Configuration;
+import com.github.onsdigital.zebedee.content.util.ContentUtil;
+import com.github.onsdigital.zebedee.verification.http.ClientConfiguration;
+import com.github.onsdigital.zebedee.verification.http.PooledHttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+
+import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
+
+/**
+ * HTTP DatasetAPIClient for the dataset API.
+ */
+public class DatasetAPIClient implements DatasetClient {
+
+    private static DatasetClient instance;
+    private static String datasetAPIURL = Configuration.getDatasetAPIURL();
+    private static PooledHttpClient client;
+
+    private DatasetAPIClient() {
+        // private constructor - use getInstance()
+    }
+
+    /**
+     * Get the singleton instance of the DatasetAPIClient.
+     *
+     * @return
+     */
+    public static DatasetClient getInstance() {
+
+        if (DatasetAPIClient.instance == null) {
+            synchronized (DatasetAPIClient.class) {
+                if (DatasetAPIClient.instance == null) {
+                    DatasetAPIClient.instance = new DatasetAPIClient();
+                    DatasetAPIClient.client = new PooledHttpClient(DatasetAPIClient.datasetAPIURL, new ClientConfiguration());
+                }
+            }
+        }
+        return DatasetAPIClient.instance;
+    }
+
+    /**
+     * Get the dataset for the given dataset ID.
+     *
+     * @param datasetID
+     * @return
+     */
+    @Override
+    public Dataset getDataset(String datasetID) throws IOException {
+
+        String path = "/datasets/" + datasetID;
+
+        logInfo("Calling dataset API").addParameter("path", path).log();
+
+        try (CloseableHttpResponse response = client.sendGet(path, null, null)) {
+            String responseString = EntityUtils.toString(response.getEntity());
+            return ContentUtil.deserialise(responseString, Dataset.class);
+        }
+    }
+
+    /**
+     * Get the instance for the given instance ID.
+     *
+     * @param instanceID
+     * @return
+     */
+    @Override
+    public Instance getInstance(String instanceID) throws IOException {
+
+        String path = "/instances/" + instanceID;
+
+        logInfo("Calling dataset API").addParameter("path", path).log();
+
+        try (CloseableHttpResponse response = client.sendGet(path, null, null)) {
+            String responseString = EntityUtils.toString(response.getEntity());
+            return ContentUtil.deserialise(responseString, Instance.class);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        Instance instance = DatasetAPIClient.getInstance().getInstance("763e0c3f-02e9-4261-bf50-1727e5a6bd25");
+        System.out.println("Instance! " + instance.getId());
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
@@ -2,8 +2,10 @@ package com.github.onsdigital.zebedee.dataset.api;
 
 import com.github.onsdigital.zebedee.configuration.Configuration;
 import com.github.onsdigital.zebedee.content.util.ContentUtil;
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.verification.http.ClientConfiguration;
 import com.github.onsdigital.zebedee.verification.http.PooledHttpClient;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
 
@@ -49,7 +51,11 @@ public class DatasetAPIClient implements DatasetClient {
      * @return
      */
     @Override
-    public Dataset getDataset(String datasetID) throws IOException {
+    public Dataset getDataset(String datasetID) throws IOException, BadRequestException {
+
+        if (StringUtils.isEmpty(datasetID)) {
+            throw new BadRequestException("A dataset ID must be provided.");
+        }
 
         String path = "/datasets/" + datasetID;
 
@@ -68,7 +74,11 @@ public class DatasetAPIClient implements DatasetClient {
      * @return
      */
     @Override
-    public Instance getInstance(String instanceID) throws IOException {
+    public Instance getInstance(String instanceID) throws IOException, BadRequestException {
+
+        if (StringUtils.isEmpty(instanceID)) {
+            throw new BadRequestException("An instance ID must be provided.");
+        }
 
         String path = "/instances/" + instanceID;
 
@@ -78,10 +88,5 @@ public class DatasetAPIClient implements DatasetClient {
             String responseString = EntityUtils.toString(response.getEntity());
             return ContentUtil.deserialise(responseString, Instance.class);
         }
-    }
-
-    public static void main(String[] args) throws IOException {
-        Instance instance = DatasetAPIClient.getInstance().getInstance("763e0c3f-02e9-4261-bf50-1727e5a6bd25");
-        System.out.println("Instance! " + instance.getId());
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
@@ -1,7 +1,10 @@
 package com.github.onsdigital.zebedee.dataset.api;
 
-import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.dataset.api.exception.BadRequestException;
+import com.github.onsdigital.zebedee.dataset.api.exception.DatasetNotFoundException;
+import com.github.onsdigital.zebedee.dataset.api.exception.UnexpectedResponseException;
 
+import javax.management.InstanceNotFoundException;
 import java.io.IOException;
 
 public interface DatasetClient {
@@ -12,7 +15,7 @@ public interface DatasetClient {
      * @param datasetID
      * @return
      */
-    Dataset getDataset(String datasetID) throws IOException, BadRequestException;
+    Dataset getDataset(String datasetID) throws IOException, DatasetNotFoundException, UnexpectedResponseException, BadRequestException;
 
     /**
      * Get the instance for the given instance ID.
@@ -20,5 +23,5 @@ public interface DatasetClient {
      * @param instanceID
      * @return
      */
-    Instance getInstance(String instanceID) throws IOException, BadRequestException;
+    Instance getInstance(String instanceID) throws IOException, InstanceNotFoundException, UnexpectedResponseException, BadRequestException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
@@ -1,0 +1,22 @@
+package com.github.onsdigital.zebedee.dataset.api;
+
+import java.io.IOException;
+
+public interface DatasetClient {
+
+    /**
+     * Get the dataset for the given dataset ID.
+     *
+     * @param datasetID
+     * @return
+     */
+    Dataset getDataset(String datasetID) throws IOException;
+
+    /**
+     * Get the instance for the given instance ID.
+     *
+     * @param instanceID
+     * @return
+     */
+    Instance getInstance(String instanceID) throws IOException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetClient.java
@@ -1,5 +1,7 @@
 package com.github.onsdigital.zebedee.dataset.api;
 
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+
 import java.io.IOException;
 
 public interface DatasetClient {
@@ -10,7 +12,7 @@ public interface DatasetClient {
      * @param datasetID
      * @return
      */
-    Dataset getDataset(String datasetID) throws IOException;
+    Dataset getDataset(String datasetID) throws IOException, BadRequestException;
 
     /**
      * Get the instance for the given instance ID.
@@ -18,5 +20,5 @@ public interface DatasetClient {
      * @param instanceID
      * @return
      */
-    Instance getInstance(String instanceID) throws IOException;
+    Instance getInstance(String instanceID) throws IOException, BadRequestException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Instance.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Instance.java
@@ -1,0 +1,48 @@
+package com.github.onsdigital.zebedee.dataset.api;
+
+/**
+ * The model of an instance as provided by the dataset API.
+ */
+public class Instance {
+
+    private String id;
+    private String edition;
+    private String version;
+    private Links links;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEdition() {
+        return edition;
+    }
+
+    public void setEdition(String edition) {
+        this.edition = edition;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public static class Links {
+        public Link dataset;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Link.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/Link.java
@@ -1,0 +1,26 @@
+package com.github.onsdigital.zebedee.dataset.api;
+
+/**
+ * The link structure used by the dataset API.
+ */
+public class Link {
+
+    private String id;
+    private String href;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/BadRequestException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.github.onsdigital.zebedee.dataset.api.exception;
+
+public class BadRequestException extends Exception {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/BadRequestException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/BadRequestException.java
@@ -1,6 +1,6 @@
 package com.github.onsdigital.zebedee.dataset.api.exception;
 
-public class BadRequestException extends Exception {
+public class BadRequestException extends DatasetAPIException {
 
     public BadRequestException(String message) {
         super(message);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetAPIException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetAPIException.java
@@ -1,0 +1,8 @@
+package com.github.onsdigital.zebedee.dataset.api.exception;
+
+public abstract class DatasetAPIException extends Exception {
+
+    public DatasetAPIException(String message) {
+        super(message);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetNotFoundException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetNotFoundException.java
@@ -1,6 +1,6 @@
 package com.github.onsdigital.zebedee.dataset.api.exception;
 
-public class DatasetNotFoundException extends Exception {
+public class DatasetNotFoundException extends DatasetAPIException {
 
     public DatasetNotFoundException(String message) {
         super(message);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetNotFoundException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/DatasetNotFoundException.java
@@ -1,0 +1,8 @@
+package com.github.onsdigital.zebedee.dataset.api.exception;
+
+public class DatasetNotFoundException extends Exception {
+
+    public DatasetNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/InstanceNotFoundException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/InstanceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.github.onsdigital.zebedee.dataset.api.exception;
+
+public class InstanceNotFoundException extends Exception {
+
+    public InstanceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/InstanceNotFoundException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/InstanceNotFoundException.java
@@ -1,6 +1,6 @@
 package com.github.onsdigital.zebedee.dataset.api.exception;
 
-public class InstanceNotFoundException extends Exception {
+public class InstanceNotFoundException extends DatasetAPIException {
 
     public InstanceNotFoundException(String message) {
         super(message);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/UnexpectedResponseException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/UnexpectedResponseException.java
@@ -1,6 +1,6 @@
 package com.github.onsdigital.zebedee.dataset.api.exception;
 
-public class UnexpectedResponseException extends Exception {
+public class UnexpectedResponseException extends DatasetAPIException {
 
     public UnexpectedResponseException(String message) {
         super(message);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/UnexpectedResponseException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/exception/UnexpectedResponseException.java
@@ -1,0 +1,8 @@
+package com.github.onsdigital.zebedee.dataset.api.exception;
+
+public class UnexpectedResponseException extends Exception {
+
+    public UnexpectedResponseException(String message) {
+        super(message);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
@@ -5,8 +5,11 @@ import com.github.onsdigital.zebedee.model.CollectionOwner;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.github.onsdigital.zebedee.model.CollectionOwner.PUBLISHING_SUPPORT;
@@ -28,6 +31,7 @@ public class CollectionDescription extends CollectionBase {
     public Date publishEndDate; // The date the publish process ended.
     public boolean isEncrypted;
     private List<PendingDelete> pendingDeletes;
+    private Set<CollectionInstance> instances;
 
     // Default to PUBLISHING_SUPPORT_TEAM
     public CollectionOwner collectionOwner = PUBLISHING_SUPPORT;
@@ -161,5 +165,37 @@ public class CollectionDescription extends CollectionBase {
 
     public void setApprovalStatus(ApprovalStatus approvalStatus) {
         this.approvalStatus = approvalStatus;
+    }
+
+    public Set<CollectionInstance> getInstances() {
+
+        if (this.instances == null) {
+            this.instances = new HashSet<>();
+        }
+
+        return instances;
+    }
+
+    public Optional<CollectionInstance> getInstance(String instanceID) {
+
+        if (this.instances == null)
+            return Optional.empty();
+
+        return this.instances.stream()
+                .filter(i -> i.getId().equals(instanceID)).findFirst();
+    }
+
+    public void addInstance(CollectionInstance instance) {
+        if (this.instances == null)
+            this.instances = new HashSet<>();
+
+        this.instances.add(instance);
+    }
+
+    public void deleteInstance(CollectionInstance instance) {
+        if (this.instances == null)
+            return;
+
+        this.instances.remove(instance);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
@@ -178,23 +178,26 @@ public class CollectionDescription extends CollectionBase {
 
     public Optional<CollectionInstance> getInstance(String instanceID) {
 
-        if (this.instances == null)
+        if (this.instances == null) {
             return Optional.empty();
+        }
 
         return this.instances.stream()
                 .filter(i -> i.getId().equals(instanceID)).findFirst();
     }
 
     public void addInstance(CollectionInstance instance) {
-        if (this.instances == null)
+
+        if (this.instances == null) {
             this.instances = new HashSet<>();
+        }
 
         this.instances.add(instance);
     }
 
     public void deleteInstance(CollectionInstance instance) {
-        if (this.instances == null)
-            return;
+
+        if (this.instances == null) return;
 
         this.instances.remove(instance);
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.json;
 import com.github.onsdigital.zebedee.model.CollectionOwner;
 
 import java.util.List;
+import java.util.Set;
 
 public class CollectionDetail extends CollectionBase {
     public List<ContentDetail> inProgress;
@@ -11,8 +12,7 @@ public class CollectionDetail extends CollectionBase {
     public List<String> timeseriesImportFiles;
     public ApprovalStatus approvalStatus;
     public List<PendingDelete> pendingDeletes;
-
     public Events events;
-
     public CollectionOwner collectionOwner; // What team created the collection (eg PST or Data vis)
+    public Set<CollectionInstance> instances;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInstance.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInstance.java
@@ -1,0 +1,62 @@
+package com.github.onsdigital.zebedee.json;
+
+public class CollectionInstance {
+
+    private String id;
+    private String edition;
+    private String version;
+    private CollectionDataset dataset;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEdition() {
+        return edition;
+    }
+
+    public void setEdition(String edition) {
+        this.edition = edition;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public CollectionDataset getDataset() {
+        return dataset;
+    }
+
+    public void setDataset(CollectionDataset dataset) {
+        this.dataset = dataset;
+    }
+
+    public static class CollectionDataset {
+        public String id;
+        public String title;
+        public String href;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CollectionInstance instance = (CollectionInstance) o;
+
+        return getId().equals(instance.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -16,25 +16,26 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionInstance;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.ContentDetail;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Events;
-import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDao;
-import com.github.onsdigital.zebedee.service.ServiceSupplier;
-import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.model.approval.tasks.ReleasePopulator;
 import com.github.onsdigital.zebedee.model.content.item.ContentItemVersion;
 import com.github.onsdigital.zebedee.model.content.item.VersionedContentItem;
 import com.github.onsdigital.zebedee.model.publishing.scheduled.Scheduler;
+import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDao;
 import com.github.onsdigital.zebedee.persistence.model.CollectionHistoryEvent;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
 import com.github.onsdigital.zebedee.reader.Resource;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
+import com.github.onsdigital.zebedee.service.ServiceSupplier;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
@@ -1188,6 +1189,18 @@ public class Collection {
 
     public Content getInProgress() {
         return inProgress;
+    }
+
+    public Optional<CollectionInstance> getInstance(String instanceID) {
+        return this.description.getInstance(instanceID);
+    }
+
+    public void addInstance(CollectionInstance instance) {
+        this.description.addInstance(instance);
+    }
+
+    public void deleteInstance(CollectionInstance instance) {
+        this.description.deleteInstance(instance);
     }
 }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/DatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/DatasetService.java
@@ -1,8 +1,12 @@
 package com.github.onsdigital.zebedee.service;
 
+import com.github.onsdigital.zebedee.dataset.api.exception.BadRequestException;
+import com.github.onsdigital.zebedee.dataset.api.exception.DatasetNotFoundException;
+import com.github.onsdigital.zebedee.dataset.api.exception.UnexpectedResponseException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionInstance;
 
+import javax.management.InstanceNotFoundException;
 import java.io.IOException;
 
 public interface DatasetService {
@@ -15,7 +19,7 @@ public interface DatasetService {
      * @throws ZebedeeException
      * @throws IOException
      */
-    CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException;
+    CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException, UnexpectedResponseException, InstanceNotFoundException, BadRequestException, DatasetNotFoundException;
 
     /**
      * Delete the instance for the given instanceID from the collection for the collectionID.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/DatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/DatasetService.java
@@ -1,0 +1,28 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionInstance;
+
+import java.io.IOException;
+
+public interface DatasetService {
+
+    /**
+     * Add an instance for the given instanceID to the collection for the collectionID.
+     * @param collectionID
+     * @param instanceID
+     * @return
+     * @throws ZebedeeException
+     * @throws IOException
+     */
+    CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException;
+
+    /**
+     * Delete the instance for the given instanceID from the collection for the collectionID.
+     * @param collectionID
+     * @param instanceID
+     * @throws ZebedeeException
+     * @throws IOException
+     */
+    void deleteInstanceFromCollection(String collectionID, String instanceID) throws ZebedeeException, IOException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -3,11 +3,15 @@ package com.github.onsdigital.zebedee.service;
 import com.github.onsdigital.zebedee.dataset.api.Dataset;
 import com.github.onsdigital.zebedee.dataset.api.DatasetClient;
 import com.github.onsdigital.zebedee.dataset.api.Instance;
+import com.github.onsdigital.zebedee.dataset.api.exception.BadRequestException;
+import com.github.onsdigital.zebedee.dataset.api.exception.DatasetNotFoundException;
+import com.github.onsdigital.zebedee.dataset.api.exception.UnexpectedResponseException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionInstance;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 
+import javax.management.InstanceNotFoundException;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -34,7 +38,7 @@ public class ZebedeeDatasetService implements DatasetService {
      * @throws IOException
      */
     @Override
-    public CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException {
+    public CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException, UnexpectedResponseException, InstanceNotFoundException, BadRequestException, DatasetNotFoundException {
 
         Collection collection = zebedeeCms.getCollection(collectionID);
 
@@ -55,6 +59,7 @@ public class ZebedeeDatasetService implements DatasetService {
         collection.save();
 
         return collectionInstance;
+
     }
 
     // take the instance and dataset model from the dataset API and map the values onto the CollectionInstance model.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -1,0 +1,103 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.dataset.api.Dataset;
+import com.github.onsdigital.zebedee.dataset.api.DatasetClient;
+import com.github.onsdigital.zebedee.dataset.api.Instance;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionInstance;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Dataset related services
+ */
+public class ZebedeeDatasetService implements DatasetService {
+
+    private DatasetClient datasetClient;
+    private ZebedeeCmsService zebedeeCms;
+
+    public ZebedeeDatasetService(DatasetClient datasetClient, ZebedeeCmsService zebedeeCms) {
+        this.datasetClient = datasetClient;
+        this.zebedeeCms = zebedeeCms;
+    }
+
+    /**
+     * Add an instance for the given instanceID to the collection for the collectionID.
+     *
+     * @param collectionID
+     * @param instanceID
+     * @return
+     * @throws ZebedeeException
+     * @throws IOException
+     */
+    @Override
+    public CollectionInstance addInstanceToCollection(String collectionID, String instanceID) throws ZebedeeException, IOException {
+
+        Collection collection = zebedeeCms.getCollection(collectionID);
+
+        // if its already been added return.
+        Optional<CollectionInstance> existingInstance = collection.getInstance(instanceID);
+        if (existingInstance.isPresent()) {
+            return existingInstance.get();
+        }
+
+        // Get the instance only to determine the dataset ID.
+        Instance instance = datasetClient.getInstance(instanceID);
+        String datasetID = instance.getLinks().dataset.getId();
+        Dataset dataset = datasetClient.getDataset(datasetID);
+
+        CollectionInstance collectionInstance = mapToCollectionInstance(instance, dataset);
+
+        collection.addInstance(collectionInstance);
+        collection.save();
+
+        return collectionInstance;
+    }
+
+    // take the instance and dataset model from the dataset API and map the values onto the CollectionInstance model.
+    private CollectionInstance mapToCollectionInstance(Instance instance, Dataset dataset) {
+
+        CollectionInstance collectionInstance =
+                new CollectionInstance();
+
+        collectionInstance.setId(instance.getId());
+        collectionInstance.setEdition(instance.getEdition());
+        collectionInstance.setVersion(instance.getVersion());
+
+        CollectionInstance.CollectionDataset instanceDataset =
+                new CollectionInstance.CollectionDataset();
+
+        instanceDataset.id = dataset.getId();
+        instanceDataset.title = dataset.getTitle();
+        instanceDataset.href = dataset.getUri();
+
+        collectionInstance.setDataset(instanceDataset);
+        return collectionInstance;
+    }
+
+    /**
+     * Delete the instance for the given instanceID from the collection for the collectionID.
+     *
+     * @param collectionID
+     * @param instanceID
+     * @throws ZebedeeException
+     * @throws IOException
+     */
+    @Override
+    public void deleteInstanceFromCollection(String collectionID, String instanceID) throws ZebedeeException, IOException {
+
+        Collection collection = zebedeeCms.getCollection(collectionID);
+
+        // if its already been added return.
+        Optional<CollectionInstance> existingInstance = collection.getInstance(instanceID);
+        if (!existingInstance.isPresent()) {
+            return;
+        }
+
+        collection.deleteInstance(existingInstance.get());
+        collection.save();
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -1,0 +1,173 @@
+package com.github.onsdigital.zebedee.api;
+
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.service.DatasetService;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CollectionsTest {
+
+    private ZebedeeCmsService mockZebedee = mock(ZebedeeCmsService.class);
+    private DatasetService mockDatasetService = mock(DatasetService.class);
+
+    private HttpServletRequest request = mock(HttpServletRequest.class);
+    private HttpServletResponse response = mock(HttpServletResponse.class);
+
+    private Collections collections = new Collections(mockZebedee, mockDatasetService);
+    private String collectionID = "123";
+    private String instanceID = "345";
+
+    @Test
+    public void TestPut() throws Exception {
+
+        // Given a PUT request with a valid URL
+        String url = String.format("/collections/%s/instances/%s", collectionID, instanceID);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).addInstanceToCollection(collectionID, instanceID);
+    }
+
+    @Test
+    public void TestPut_Forbidden() throws Exception {
+
+        // Given a PUT request with a valid URL
+        String url = String.format("/collections/%s/instances/%s", collectionID, instanceID);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, false);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // a HTTP 403 is set on the response
+        verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void TestPut_ReturnBadRequest_URLSegments() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains less than the expected number of segments
+        String url = "/collections/123/instances";
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestPut_ReturnBadRequest_NotInstanceEndpoint() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains something other than /collections/{}/instances/{}
+        String url = "/collections/123/datasets/345";
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestDelete_ReturnBadRequest_URLSegments() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains less than the expected number of segments
+        String url = "/collections/123/instances";
+
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestDelete_ReturnBadRequest_NotInstanceEndpoint() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains something other than /collections/{}/instances/{}
+        String url = "/collections/123/datasets/345";
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestDelete() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/instances/%s", collectionID, instanceID);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).deleteInstanceFromCollection(collectionID, instanceID);
+    }
+
+    @Test
+    public void TestDelete_Forbidden() throws Exception {
+
+        // Given a PUT request with a valid URL
+        String url = String.format("/collections/%s/instances/%s", collectionID, instanceID);
+
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, false);
+
+        // When the put method is called
+        collections.delete(request, response);
+
+        // a HTTP 403 is set on the response
+        verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
+    }
+
+    // mock the authorisation for the given request to authorise the request is the authorise param is true.
+    private void shouldAuthorise(HttpServletRequest request, boolean authorise) throws ZebedeeException, IOException {
+
+        Session session = mock(Session.class);
+        when(mockZebedee.getSession(request)).thenReturn(session);
+
+        PermissionsService permissionsService = mock(PermissionsService.class);
+        when(mockZebedee.getPermissions()).thenReturn(permissionsService);
+
+        when(permissionsService.canEdit(session)).thenReturn(authorise);
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/DatasetServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/DatasetServiceTest.java
@@ -1,0 +1,124 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.dataset.api.Dataset;
+import com.github.onsdigital.zebedee.dataset.api.DatasetClient;
+import com.github.onsdigital.zebedee.dataset.api.Instance;
+import com.github.onsdigital.zebedee.dataset.api.Link;
+import com.github.onsdigital.zebedee.json.CollectionInstance;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+public class DatasetServiceTest {
+
+    String instanceID = "123";
+    String datasetID = "321";
+    String collectionID = "345";
+
+    Instance instance = new Instance();
+    Dataset dataset = new Dataset();
+
+    DatasetClient mockDatasetAPI = mock(DatasetClient.class);
+    ZebedeeCmsService mockZebedee = mock(ZebedeeCmsService.class);
+    Collection mockCollection = mock(Collection.class);
+
+    @Before
+    public void setUp() throws Exception {
+
+        instance.setId(instanceID);
+        instance.setLinks(new Instance.Links());
+        instance.getLinks().dataset = new Link();
+        instance.getLinks().dataset.setId(datasetID);
+
+        dataset.setId(datasetID);
+        dataset.setTitle("Dataset title");
+        dataset.setUri("/the/dataset/uri");
+
+        when(mockDatasetAPI.getInstance(instanceID)).thenReturn(instance);
+        when(mockDatasetAPI.getDataset(datasetID)).thenReturn(dataset);
+        when(mockZebedee.getCollection(collectionID)).thenReturn(mockCollection);
+    }
+
+    @Test
+    public void TestDatasetService_addInstanceToCollection_ReturnsIfAlreadyInCollection() throws Exception {
+
+        // Given a mockCollection that already contains the instance
+        when(mockCollection.getInstance(instanceID)).thenReturn(Optional.of(new CollectionInstance()));
+
+        DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
+
+        // When addInstanceToCollection is called
+        service.addInstanceToCollection(collectionID, instanceID);
+
+        // The function does not call the dataset API as it sees that its already been added.
+        verify(mockDatasetAPI, times(0)).getInstance(instanceID);
+        verify(mockDatasetAPI, times(0)).getDataset(datasetID);
+    }
+
+    @Test
+    public void TestDatasetService_addInstanceToCollection() throws Exception {
+
+        // Given a mockCollection that contains no instances
+        when(mockCollection.getInstance(instanceID)).thenReturn(Optional.empty());
+        DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
+
+        // When addInstanceToCollection is called
+        CollectionInstance actualInstance = service.addInstanceToCollection(collectionID, instanceID);
+
+        // Then the dataset API is called to populate the instance data, and its added to the mockCollection.
+        verify(mockDatasetAPI, times(1)).getInstance(instanceID);
+        verify(mockDatasetAPI, times(1)).getDataset(datasetID);
+        verify(mockCollection, times(1)).addInstance(actualInstance);
+        verify(mockCollection, times(1)).save();
+
+        // The returned instance has the expected values.
+        Assert.assertEquals(instance.getId(), actualInstance.getId());
+        Assert.assertEquals(instance.getEdition(), actualInstance.getEdition());
+        Assert.assertEquals(instance.getVersion(), actualInstance.getVersion());
+        Assert.assertEquals(dataset.getId(), actualInstance.getDataset().id);
+        Assert.assertEquals(dataset.getTitle(), actualInstance.getDataset().title);
+        Assert.assertEquals(dataset.getUri(), actualInstance.getDataset().href);
+    }
+
+    @Test
+    public void TestDatasetService_deleteInstanceFromCollection() throws Exception {
+
+        CollectionInstance collectionInstance = new CollectionInstance();
+
+        // Given a mockCollection that does not contain the instance we try to delete
+        when(mockCollection.getInstance(instanceID)).thenReturn(Optional.of(collectionInstance));
+
+        DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
+
+        // When deleteInstanceFromCollection is called
+        service.deleteInstanceFromCollection(collectionID, instanceID);
+
+        // Then the collection is prompted to delete the instance and save.
+        verify(mockCollection, times(1)).deleteInstance(collectionInstance);
+        verify(mockCollection, times(1)).save();
+    }
+
+    @Test
+    public void TestDatasetService_deleteInstanceFromCollection_ReturnsIfNotInCollection() throws Exception {
+
+        CollectionInstance collectionInstance = new CollectionInstance();
+
+        // Given a mockCollection that does not contain the instance we try to delete
+        when(mockCollection.getInstance(instanceID)).thenReturn(Optional.empty());
+
+        DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
+
+        // When deleteInstanceFromCollection is called
+        service.deleteInstanceFromCollection(collectionID, instanceID);
+
+        // Then the delete function is not called, as the instance is not in the collection.
+        verify(mockCollection, times(0)).deleteInstance(collectionInstance);
+        verify(mockCollection, times(0)).save();
+    }
+}


### PR DESCRIPTION
### What

Add HTTP PUT and DELETE endpoint for adding instances to a collection.

When an instance is added to a collection Zebedee will call the dataset API to retrieve instance data. It calls both the instance endpoint and dataset endpoint on the dataset API. It expects the edition and version fields to be populated on the instance.

### How to review

Review code changes

### Who can review

Anyone
