### PR TITLE
Feature/dataset approve

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -88,7 +88,7 @@ public class CollectionDetails {
     }
 
     private void addEventsForDetails(
-            List<ContentDetail> detailsToAddEventsFor,
+            Iterable<ContentDetail> detailsToAddEventsFor,
             com.github.onsdigital.zebedee.model.Collection collection
     ) {
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDataset.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDataset.java
@@ -7,7 +7,7 @@ public class CollectionDataset {
 
     private String id;
     private String title;
-    private String state;
+    private ContentStatus state;
     private String uri;
 
     public String getId() {
@@ -26,11 +26,11 @@ public class CollectionDataset {
         this.title = title;
     }
 
-    public String getState() {
+    public ContentStatus getState() {
         return state;
     }
 
-    public void setState(String state) {
+    public void setState(ContentStatus state) {
         this.state = state;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDatasetVersion.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDatasetVersion.java
@@ -9,7 +9,7 @@ public class CollectionDatasetVersion {
     private String title;
     private String edition;
     private String version;
-    private String state;
+    private ContentStatus state;
 
     public String getId() {
         return id;
@@ -43,11 +43,11 @@ public class CollectionDatasetVersion {
         this.title = title;
     }
 
-    public String getState() {
+    public ContentStatus getState() {
         return state;
     }
 
-    public void setState(String state) {
+    public void setState(ContentStatus state) {
         this.state = state;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
@@ -6,9 +6,9 @@ import java.util.List;
 import java.util.Set;
 
 public class CollectionDetail extends CollectionBase {
-    public List<ContentDetail> inProgress;
-    public List<ContentDetail> complete;
-    public List<ContentDetail> reviewed;
+    public Set<ContentDetail> inProgress;
+    public Set<ContentDetail> complete;
+    public Set<ContentDetail> reviewed;
     public List<String> timeseriesImportFiles;
     public ApprovalStatus approvalStatus;
     public List<PendingDelete> pendingDeletes;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
@@ -167,7 +167,7 @@ public class ContentDetail {
      * @param toOverlay
      * @return
      */
-    public ContentDetail overlayDetails(List<ContentDetail> toOverlay) {
+    public ContentDetail overlayDetails(Iterable<ContentDetail> toOverlay) {
 
         for (ContentDetail contentDetail : toOverlay) {
             if (!this.containsDescendant(contentDetail)) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentStatus.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentStatus.java
@@ -1,0 +1,10 @@
+package com.github.onsdigital.zebedee.json;
+
+/**
+ * Enum to define the states of the content review process.
+ */
+public enum ContentStatus {
+    InProgress,
+    Complete,
+    Reviewed,
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -18,6 +18,7 @@ import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.ContentDetail;
+import com.github.onsdigital.zebedee.json.ContentStatus;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Events;
@@ -1188,6 +1189,24 @@ public class Collection {
 
     public Content getInProgress() {
         return inProgress;
+    }
+
+
+    /**
+     * Return true if this collection has had all of its content reviewed.
+     */
+    public boolean isAllContentReviewed() throws IOException {
+
+        boolean allDatasetsReviewed = description.getDatasets().stream()
+                .allMatch(ds -> ds.getState().equals(ContentStatus.Reviewed));
+
+        boolean allDatasetVersionsReviewed = description.getDatasetVersions().stream()
+                .allMatch(ds -> ds.getState().equals(ContentStatus.Reviewed));
+
+        return (inProgressUris().isEmpty()
+                && completeUris().isEmpty()
+                && allDatasetsReviewed
+                && allDatasetVersionsReviewed);
     }
 }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -16,14 +16,12 @@ import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Keyring;
-import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
-import com.github.onsdigital.zebedee.permissions.service.PermissionsServiceImpl;
-import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.model.approval.ApprovalQueue;
 import com.github.onsdigital.zebedee.model.approval.ApproveTask;
 import com.github.onsdigital.zebedee.model.publishing.PostPublisher;
 import com.github.onsdigital.zebedee.model.publishing.PublishNotification;
 import com.github.onsdigital.zebedee.model.publishing.Publisher;
+import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.persistence.CollectionEventType;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDao;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDaoFactory;
@@ -31,6 +29,7 @@ import com.github.onsdigital.zebedee.persistence.model.CollectionHistoryEvent;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
+import com.github.onsdigital.zebedee.session.model.Session;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.ProgressListener;
@@ -72,7 +71,6 @@ import static com.github.onsdigital.zebedee.persistence.CollectionEventType.COLL
 import static com.github.onsdigital.zebedee.persistence.CollectionEventType.DATA_VISUALISATION_COLLECTION_CONTENT_DELETED;
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.contentMoved;
 import static com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData.contentRenamed;
-import static java.util.Objects.requireNonNull;
 
 public class Collections {
 
@@ -290,9 +288,8 @@ public class Collections {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
-        // Everything is completed
-        if (!collection.inProgressUris().isEmpty()
-                || !collection.completeUris().isEmpty()) {
+        // Check everything is reviewed
+        if (!collection.isAllContentReviewed()) {
             throw new ConflictException(
                     "This collection can't be approved because it's not empty");
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -9,19 +9,14 @@ import com.google.gson.JsonSyntaxException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -139,9 +139,15 @@ public class ApproveTask implements Callable<Boolean> {
 
             List<ContentDetail> collectionContent = ContentDetailUtil.resolveDetails(collection.reviewed, collectionReader.getReviewed());
 
+            // todo - add dataset pages to collection content
+
             populateReleasePage(collectionContent);
+
             generateTimeseries(collection, publishedReader, collectionReader, collectionWriter, dataIndex);
             generatePdfFiles(collectionContent);
+
+            // todo - refactor below method to take collectionContent list and create a list of strings from it.
+            // todo - check the new list has the same format as the old list
 
             PublishNotification publishNotification = createPublishNotification(collectionReader, collection);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -38,7 +38,7 @@ public class CollectionPdfGenerator {
         this.pdfService = pdfService;
     }
 
-    public void generatePdfsInCollection(CollectionWriter collectionWriter, List<ContentDetail> collectionContent) {
+    public void generatePdfsInCollection(CollectionWriter collectionWriter, Iterable<ContentDetail> collectionContent) {
 
         for (ContentDetail contentDetail : collectionContent) {
             boolean pdfShouldBeAdded = pagesWithPdf.contains(PageType.valueOf(contentDetail.type));

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -12,7 +12,6 @@ import com.github.onsdigital.zebedee.reader.CollectionReader;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.List;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
@@ -26,7 +25,7 @@ public class ReleasePopulator {
      * @param release
      * @return
      */
-    public static Release populate(Release release, List<ContentDetail> collectionContent) throws IOException, ZebedeeException {
+    public static Release populate(Release release, Iterable<ContentDetail> collectionContent) throws IOException, ZebedeeException {
 
         release.setRelatedDatasets(new ArrayList<>());
         release.setRelatedDocuments(new ArrayList<>());
@@ -41,38 +40,49 @@ public class ReleasePopulator {
     }
 
     private static void addPageDetailToRelease(Release release, ContentDetail contentDetail) {
+
         if (contentDetail.type.equals(PageType.article.toString())
                 || contentDetail.type.equals(PageType.article_download.toString())
                 || contentDetail.type.equals(PageType.bulletin.toString())
                 || contentDetail.type.equals(PageType.compendium_landing_page.toString())) {
+
             logInfo("Adding document as a link to release")
                     .addParameter("contentTitle", contentDetail.description.title)
                     .addParameter("releaseTitle", release.getDescription().getTitle())
                     .log();
+
             addRelatedDocument(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.dataset_landing_page.toString())) {
+        if (contentDetail.type.equals(PageType.dataset_landing_page.toString())
+                || contentDetail.type.equals(PageType.api_dataset_landing_page.toString())) {
+
             logInfo("Adding dataset as a link to release")
                     .addParameter("contentTitle", contentDetail.description.title)
                     .addParameter("releaseTitle", release.getDescription().getTitle())
                     .log();
+
             addRelatedDataset(release, contentDetail);
         }
 
         if (contentDetail.type.equals(PageType.static_qmi.toString())) {
+
             logInfo("Adding qmi as a link to release")
                     .addParameter("contentTitle", contentDetail.description.title)
                     .addParameter("releaseTitle", release.getDescription().getTitle())
                     .log();
+
             addRelatedQMI(release, contentDetail);
         }
+
         if (contentDetail.type.equals(PageType.static_methodology.toString())
                 || contentDetail.type.equals(PageType.static_methodology_download.toString())) {
+
             logInfo("Adding methodology article as a link to release")
                     .addParameter("contentTitle", contentDetail.description.title)
                     .addParameter("releaseTitle", release.getDescription().getTitle())
                     .log();
+
             addRelatedMethodologyArticle(release, contentDetail);
         }
     }
@@ -81,7 +91,7 @@ public class ReleasePopulator {
         Link link = createLink(contentDetail);
 
         if (release.getRelatedDatasets() == null) {
-            release.setRelatedDatasets(new ArrayList<Link>());
+            release.setRelatedDatasets(new ArrayList<>());
         }
         release.getRelatedDatasets().add(link);
     }
@@ -89,7 +99,7 @@ public class ReleasePopulator {
     private static void addRelatedDocument(Release release, ContentDetail contentDetail) {
         Link link = createLink(contentDetail);
         if (release.getRelatedDocuments() == null) {
-            release.setRelatedDocuments(new ArrayList<Link>());
+            release.setRelatedDocuments(new ArrayList<>());
         }
         release.getRelatedDocuments().add(link);
     }
@@ -97,7 +107,7 @@ public class ReleasePopulator {
     private static void addRelatedMethodologyArticle(Release release, ContentDetail contentDetail) {
         Link link = createLink(contentDetail);
         if (release.getRelatedMethodologyArticle() == null) {
-            release.setRelatedMethodologyArticle(new ArrayList<Link>());
+            release.setRelatedMethodologyArticle(new ArrayList<>());
         }
         release.getRelatedMethodologyArticle().add(link);
     }
@@ -105,7 +115,7 @@ public class ReleasePopulator {
     private static void addRelatedQMI(Release release, ContentDetail contentDetail) {
         Link link = createLink(contentDetail);
         if (release.getRelatedMethodology() == null) {
-            release.setRelatedMethodology(new ArrayList<Link>());
+            release.setRelatedMethodology(new ArrayList<>());
         }
         release.getRelatedMethodology().add(link);
     }
@@ -119,7 +129,7 @@ public class ReleasePopulator {
     public static void populateQuietly(Collection collection,
                                        CollectionReader collectionReader,
                                        CollectionWriter collectionWriter,
-                                       List<ContentDetail> collectionContent) throws IOException {
+                                       Iterable<ContentDetail> collectionContent) throws IOException {
         if (collection.isRelease()) {
             logInfo("Release identified for collection, populating the page links")
                     .collectionName(collection)

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
@@ -230,7 +230,10 @@ public class CsdbImporter {
         DataIndex dataIndex = Root.zebedee.getDataIndex();
 
         ApproveTask.generateTimeseries(collection, publishedReader, collectionReader, collectionWriter, dataIndex);
-        PublishNotification publishNotification = ApproveTask.createPublishNotification(collectionReader, collection);
+
+        List<String> uriList = collectionReader.getReviewed().listUris();
+        PublishNotification publishNotification = ApproveTask.createPublishNotification(uriList, collection);
+
         compressZipFiles(collection, collectionReader, collectionWriter);
 
         // Send a notification to the website with the publish date for caching.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -11,7 +11,6 @@ import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -47,7 +46,7 @@ public class ZebedeeDatasetService implements DatasetService {
             collectionDataset.setId(datasetID);
         }
 
-        if (updatedDataset != null && StringUtils.isNotEmpty(updatedDataset.getState())) {
+        if (updatedDataset != null && updatedDataset.getState() != null) {
             collectionDataset.setState(updatedDataset.getState());
         }
 
@@ -99,7 +98,7 @@ public class ZebedeeDatasetService implements DatasetService {
             collectionDatasetVersion.setVersion(version);
         }
 
-        if (updatedVersion != null && StringUtils.isNotEmpty(updatedVersion.getState())) {
+        if (updatedVersion != null && updatedVersion.getState() != null) {
             collectionDatasetVersion.setState(updatedVersion.getState());
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
@@ -15,8 +15,8 @@ import com.github.onsdigital.zebedee.reader.Resource;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 import static com.github.onsdigital.zebedee.util.URIUtils.removeLastSegment;
@@ -28,9 +28,9 @@ import static org.apache.commons.lang3.StringUtils.removeEnd;
 public class ContentDetailUtil {
 
 
-    public static List<ContentDetail> resolveDetails(Content content, ContentReader reader) throws IOException, ZebedeeException {
+    public static Set<ContentDetail> resolveDetails(Content content, ContentReader reader) throws IOException, ZebedeeException {
 
-        List<ContentDetail> details = new ArrayList<>();
+        Set<ContentDetail> details = new HashSet<>();
 
         for (String uri : content.uris("*data*.json")) {
             if (!VersionedContentItem.isVersionedUri(uri)) {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -520,49 +520,21 @@ public class CollectionsTest {
     }
 
     @Test(expected = ConflictException.class)
-    public void shouldNotApproveIfAUriIsInProgress() throws IOException, ZebedeeException {
-        List<String> inProgressURIS = new ArrayList();
-        inProgressURIS.add("data.json");
-
-        when(permissionsServiceMock.canEdit(TEST_EMAIL))
-                .thenReturn(true);
-        when(collectionMock.inProgressUris())
-                .thenReturn(inProgressURIS);
-        when(collectionMock.completeUris())
-                .thenReturn(new ArrayList<String>());
-
-        try {
-            collections.approve(collectionMock, sessionMock);
-        } catch (ConflictException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(TEST_EMAIL);
-            verify(sessionMock, times(1)).getEmail();
-            verify(collectionMock, times(1)).inProgressUris();
-            verify(collectionReaderWriterFactoryMock, never()).getReader(any(), any(), any());
-            verify(collectionReaderWriterFactoryMock, never()).getWriter(any(), any(), any());
-            verify(collectionHistoryDaoMock, never()).saveCollectionHistoryEvent(any(CollectionHistoryEvent.class));
-            throw e;
-        }
-    }
-
-    @Test(expected = ConflictException.class)
-    public void shouldNotApproveIfAUriIsComplete() throws IOException, ZebedeeException {
+    public void shouldNotApproveIfContentIsNotReviewed() throws IOException, ZebedeeException {
         List<String> completeURIS = new ArrayList();
         completeURIS.add("data.json");
 
         when(permissionsServiceMock.canEdit(TEST_EMAIL))
                 .thenReturn(true);
-        when(collectionMock.inProgressUris())
-                .thenReturn(new ArrayList<String>());
-        when(collectionMock.completeUris())
-                .thenReturn(completeURIS);
+        when(collectionMock.isAllContentReviewed())
+                .thenReturn(false);
 
         try {
             collections.approve(collectionMock, sessionMock);
         } catch (ConflictException e) {
             verify(permissionsServiceMock, times(1)).canEdit(TEST_EMAIL);
             verify(sessionMock, times(1)).getEmail();
-            verify(collectionMock, times(1)).inProgressUris();
-            verify(collectionMock, times(1)).completeUris();
+            verify(collectionMock, times(1)).isAllContentReviewed();
             verify(collectionReaderWriterFactoryMock, never()).getReader(any(), any(), any());
             verify(collectionReaderWriterFactoryMock, never()).getWriter(any(), any(), any());
             throw e;
@@ -580,10 +552,8 @@ public class CollectionsTest {
 
         when(permissionsServiceMock.canEdit(TEST_EMAIL))
                 .thenReturn(true);
-        when(collectionMock.inProgressUris())
-                .thenReturn(new ArrayList<String>());
-        when(collectionMock.completeUris())
-                .thenReturn(new ArrayList<String>());
+        when(collectionMock.isAllContentReviewed())
+                .thenReturn(true);
         when(collectionReaderWriterFactoryMock.getReader(zebedeeMock, collectionMock, sessionMock))
                 .thenReturn(collectionReaderMock);
         when(collectionReaderWriterFactoryMock.getWriter(zebedeeMock, collectionMock, sessionMock))
@@ -592,8 +562,7 @@ public class CollectionsTest {
         assertThat(futureMock, equalTo(collections.approve(collectionMock, sessionMock)));
 
         verify(permissionsServiceMock, times(1)).canEdit(TEST_EMAIL);
-        verify(collectionMock, times(1)).inProgressUris();
-        verify(collectionMock, times(1)).completeUris();
+        verify(collectionMock, times(1)).isAllContentReviewed();
         verify(collectionReaderWriterFactoryMock, times(1)).getReader(zebedeeMock, collectionMock, sessionMock);
         verify(collectionReaderWriterFactoryMock, times(1)).getWriter(zebedeeMock, collectionMock, sessionMock);
         verify(collectionHistoryDaoMock, times(1)).saveCollectionHistoryEvent(any(), any(), any());

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -5,24 +5,21 @@ import com.github.onsdigital.zebedee.json.ContentDetail;
 import com.github.onsdigital.zebedee.json.PendingDelete;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.CollectionTest;
-import com.github.onsdigital.zebedee.model.DummyCollectionReader;
 import com.github.onsdigital.zebedee.model.publishing.PublishNotification;
-import com.github.onsdigital.zebedee.reader.CollectionReader;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 
 public class ApproveTaskTest {
 
     @Test
     public void createPublishNotificationShouldIncludePendingDeletes() throws Exception {
 
-
         // Given a collection that contains pending deletes.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        CollectionReader collectionReader = new DummyCollectionReader(collectionPath);
         Collection collection = CollectionTest.CreateCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
         String uriToDelete = "some/uri/to/check";
         ContentDetail contentDetail = new ContentDetail("Title", uriToDelete, "type");
@@ -30,7 +27,7 @@ public class ApproveTaskTest {
         collection.description.getPendingDeletes().add(pendingDelete);
 
         // When the publish notification is created as part of the approval process.
-        PublishNotification publishNotification = ApproveTask.createPublishNotification(collectionReader, collection);
+        PublishNotification publishNotification = ApproveTask.createPublishNotification(new ArrayList<>(), collection);
 
         // Then the publish notification contains the expected directory to delete.
         Assert.assertNotNull(publishNotification);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
@@ -9,6 +9,7 @@ import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.ContentStatus;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 import org.junit.Assert;
@@ -31,7 +32,7 @@ public class ZebedeeDatasetServiceTest {
     String edition = "2015";
     String version = "1";
     String collectionID = "345";
-    String initialState = "in-progress";
+    ContentStatus initialState = ContentStatus.InProgress;
 
     Dataset dataset = createDataset();
 
@@ -70,7 +71,7 @@ public class ZebedeeDatasetServiceTest {
         DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
 
         // When updateDatasetInCollection is called with an updated state
-        String state = "reviewed";
+        ContentStatus state = ContentStatus.Reviewed;
         collectionDataset.setState(state);
         CollectionDataset updated = service.updateDatasetInCollection(collectionID, datasetID, collectionDataset);
 
@@ -197,7 +198,7 @@ public class ZebedeeDatasetServiceTest {
         DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
 
         // When updateDatasetInCollection is called
-        String state = "reviewed";
+        ContentStatus state = ContentStatus.Reviewed;
         collectionDatasetVersion.setState(state);
         CollectionDatasetVersion updated = service.updateDatasetVersionInCollection(collectionID, datasetID, edition, version, collectionDatasetVersion);
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -36,6 +36,7 @@ public enum PageType {
     dataset("Dataset page"),
     dataset_landing_page("Dataset landing page"),
     api_dataset_landing_page("API Dataset landing page"),
+    api_dataset("API Dataset"),
     timeseries_dataset("Timeseries dataset page"),
     release("Release page"),
     reference_tables("Reference tables"),


### PR DESCRIPTION
### What

Updated the approval process to include CMD datasets / versions.

* add dataset landing pages to the release page when either the dataset or the dataset version is updated.
* add dataset / version URL's to the list sent to babbage to set cache headers.
* change the List<ContentDetail> to Set<ContentDetail> in the approve task to prevent duplicates. This had a number of dependent changes - hence a lot of changes from List<ContentDetail> to Iterable<ContentDetail>

### How to review

Review code + run tests

### Who can review

Anyone
