### PR TITLE
Add edition confirmed state and ensure its serialised in the format the

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/model/State.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/model/State.java
@@ -1,7 +1,18 @@
 package com.github.onsdigital.zebedee.dataset.api.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum State {
-    created,
-    associated,
-    published,
+
+    @SerializedName("created")
+    CREATED,
+
+    @SerializedName("edition-confirmed")
+    EDITION_CONFIRMED,
+
+    @SerializedName("associated")
+    ASSOCIATED,
+
+    @SerializedName("published")
+    PUBLISHED,
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -54,15 +54,15 @@ public class ZebedeeDatasetService implements DatasetService {
         collectionDataset.setTitle(dataset.getTitle());
         collectionDataset.setUri(dataset.getLinks().getSelf().getHref());
 
-        if (dataset.getState().equals(State.created)) {
+        if (dataset.getState().equals(State.CREATED)) {
             // the dataset has just been added to the collection, so update collection ID on the dataset
             Dataset datasetUpdate = new Dataset();
             datasetUpdate.setCollection_id(collectionID);
-            datasetUpdate.setState(State.associated);
+            datasetUpdate.setState(State.ASSOCIATED);
             datasetClient.updateDataset(datasetID, datasetUpdate);
         }
 
-        if (dataset.getState().equals(State.associated)
+        if (dataset.getState().equals(State.ASSOCIATED)
                 && !dataset.getCollection_id().equals(collectionID)) {
             throw new ConflictException("cannot add dataset " + datasetID
                     + " to collection " + collectionID
@@ -105,15 +105,15 @@ public class ZebedeeDatasetService implements DatasetService {
         Dataset dataset = datasetClient.getDataset(datasetID);
         DatasetVersion datasetVersion = datasetClient.getDatasetVersion(datasetID, edition, version);
 
-        if (datasetVersion.getState().equals(State.created)) {
+        if (datasetVersion.getState().equals(State.CREATED)) {
             // the dataset version has just been added to the collection, so update collection ID and set state
             DatasetVersion versionUpdate = new DatasetVersion();
             versionUpdate.setCollection_id(collectionID);
-            versionUpdate.setState(State.associated);
+            versionUpdate.setState(State.ASSOCIATED);
             datasetClient.updateDatasetVersion(datasetID, edition, version, versionUpdate);
         }
 
-        if (datasetVersion.getState().equals(State.associated)
+        if (datasetVersion.getState().equals(State.ASSOCIATED)
                 && !datasetVersion.getCollection_id().equals(collectionID)) {
             throw new ConflictException("cannot add dataset " + datasetID
                     + " to collection " + collectionID
@@ -143,7 +143,7 @@ public class ZebedeeDatasetService implements DatasetService {
 
         Dataset datasetUpdate = new Dataset();
         datasetUpdate.setCollection_id("");
-        datasetUpdate.setState(State.created);
+        datasetUpdate.setState(State.CREATED);
         datasetClient.updateDataset(datasetID, datasetUpdate);
 
         collection.getDescription().removeDataset(existingDataset.get());
@@ -169,7 +169,7 @@ public class ZebedeeDatasetService implements DatasetService {
         // update the dataset version in the dataset API with a reverted state and blank collection ID.
         DatasetVersion versionUpdate = new DatasetVersion();
         versionUpdate.setCollection_id("");
-        versionUpdate.setState(State.created);
+        versionUpdate.setState(State.CREATED);
         datasetClient.updateDatasetVersion(datasetID, edition, version, versionUpdate);
 
         collection.getDescription().removeDatasetVersion(existingDataset.get());

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
@@ -55,7 +55,7 @@ public class ZebedeeDatasetServiceTest {
 
         DatasetVersion datasetVersion = new DatasetVersion();
         datasetVersion.setCollection_id(collectionID);
-        datasetVersion.setState(State.created);
+        datasetVersion.setState(State.CREATED);
         when(mockDatasetAPI.getDatasetVersion(datasetID, edition, version))
                 .thenReturn(datasetVersion);
 
@@ -96,7 +96,7 @@ public class ZebedeeDatasetServiceTest {
         ArgumentCaptor<Dataset> datasetArgumentCaptor = ArgumentCaptor.forClass(Dataset.class);
         verify(mockDatasetAPI, times(1)).updateDataset(anyString(), datasetArgumentCaptor.capture());
         Assert.assertEquals(datasetArgumentCaptor.getAllValues().get(0).getCollection_id(), collectionID);
-        Assert.assertEquals(datasetArgumentCaptor.getAllValues().get(0).getState(), State.associated);
+        Assert.assertEquals(datasetArgumentCaptor.getAllValues().get(0).getState(), State.ASSOCIATED);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class ZebedeeDatasetServiceTest {
 
         Dataset dataset = createDataset();
         dataset.setCollection_id(collectionID);
-        dataset.setState(State.associated);
+        dataset.setState(State.ASSOCIATED);
         when(mockDatasetAPI.getDataset(datasetID)).thenReturn(dataset);
 
         // When updateDatasetInCollection is called
@@ -124,7 +124,7 @@ public class ZebedeeDatasetServiceTest {
         DatasetService service = new ZebedeeDatasetService(mockDatasetAPI, mockZebedee);
 
         Dataset dataset = createDataset();
-        dataset.setState(State.associated);
+        dataset.setState(State.ASSOCIATED);
         dataset.setCollection_id("someOtherCollectionID");
         when(mockDatasetAPI.getDataset(datasetID)).thenReturn(dataset);
 
@@ -147,7 +147,7 @@ public class ZebedeeDatasetServiceTest {
         ArgumentCaptor<DatasetVersion> argumentCaptor = ArgumentCaptor.forClass(DatasetVersion.class);
         verify(mockDatasetAPI, times(1)).updateDatasetVersion(anyString(), anyString(), anyString(), argumentCaptor.capture());
         Assert.assertEquals(argumentCaptor.getAllValues().get(0).getCollection_id(), collectionID);
-        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.associated);
+        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.ASSOCIATED);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class ZebedeeDatasetServiceTest {
 
         DatasetVersion datasetVersion = new DatasetVersion();
         datasetVersion.setCollection_id(collectionID);
-        datasetVersion.setState(State.associated);
+        datasetVersion.setState(State.ASSOCIATED);
         when(mockDatasetAPI.getDatasetVersion(datasetID, edition, version)).thenReturn(datasetVersion);
 
         // When updateDatasetInCollection is called
@@ -178,7 +178,7 @@ public class ZebedeeDatasetServiceTest {
                 .thenReturn(Optional.of(new CollectionDatasetVersion()));
 
         DatasetVersion datasetVersion = new DatasetVersion();
-        datasetVersion.setState(State.associated);
+        datasetVersion.setState(State.ASSOCIATED);
         datasetVersion.setCollection_id("someOtherCollectionID");
         when(mockDatasetAPI.getDatasetVersion(datasetID, edition, version)).thenReturn(datasetVersion);
 
@@ -269,7 +269,7 @@ public class ZebedeeDatasetServiceTest {
         ArgumentCaptor<Dataset> argumentCaptor = ArgumentCaptor.forClass(Dataset.class);
         verify(mockDatasetAPI, times(1)).updateDataset(anyString(), argumentCaptor.capture());
         Assert.assertEquals(argumentCaptor.getAllValues().get(0).getCollection_id(), "");
-        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.created);
+        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.CREATED);
 
         // Then the collection is prompted to delete the dataset and save.
         verify(mockCollectionDescription, times(1)).removeDataset(collectionDataset);
@@ -294,7 +294,7 @@ public class ZebedeeDatasetServiceTest {
         ArgumentCaptor<DatasetVersion> argumentCaptor = ArgumentCaptor.forClass(DatasetVersion.class);
         verify(mockDatasetAPI, times(1)).updateDatasetVersion(anyString(), anyString(), anyString(), argumentCaptor.capture());
         Assert.assertEquals(argumentCaptor.getAllValues().get(0).getCollection_id(), "");
-        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.created);
+        Assert.assertEquals(argumentCaptor.getAllValues().get(0).getState(), State.CREATED);
 
         // Then the collection is prompted to delete the dataset and save.
         verify(mockCollectionDescription, times(1)).removeDatasetVersion(datasetVersion);
@@ -341,7 +341,7 @@ public class ZebedeeDatasetServiceTest {
         Dataset dataset = new Dataset();
         dataset.setId(datasetID);
         dataset.setTitle("Dataset title");
-        dataset.setState(State.created);
+        dataset.setState(State.CREATED);
         Dataset.DatasetLinks links = new Dataset.DatasetLinks();
         Link self = new Link();
         self.setHref("/the/dataset/uri");


### PR DESCRIPTION
### What

Added the 'edition-confirmed' state to the list of states recognised from the dataset-API. 

I needed to add the annotations as I could not create a constant with a hyphen. I also changed the existing constants to uppercase to be consistent with Java style.

### How to review

See changes.

### Who can review

@Matt-Guest 
