### PR TITLE
Check for 'edition-confirmed' state before updating the dataset version

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/dataset/api/DatasetAPIClient.java
@@ -11,6 +11,7 @@ import com.github.onsdigital.zebedee.dataset.api.model.Dataset;
 import com.github.onsdigital.zebedee.dataset.api.model.DatasetResponse;
 import com.github.onsdigital.zebedee.dataset.api.model.DatasetVersion;
 import com.github.onsdigital.zebedee.dataset.api.model.Instance;
+import com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -86,8 +87,8 @@ public class DatasetAPIClient implements DatasetClient {
         }
 
         logInfo("Calling dataset API")
-                .addParameter("uri", uri)
                 .addParameter("method", "GET")
+                .addParameter("uri", uri)
                 .log();
 
         HttpGet httpget = new HttpGet(uri);
@@ -95,14 +96,25 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse response = client.execute(httpget)) {
 
+            ZebedeeLogBuilder logBuilder = logInfo("Dataset API response")
+                    .addParameter("method", "GET")
+                    .addParameter("uri", uri)
+                    .addParameter("status", response.getStatusLine());
+
             switch (response.getStatusLine().getStatusCode()) {
+
                 case HttpStatus.SC_OK:
                     String responseString = EntityUtils.toString(response.getEntity());
+                    logBuilder.addParameter("response_body", responseString).log();
                     DatasetResponse datasetResponse = ContentUtil.deserialise(responseString, DatasetResponse.class);
                     return datasetResponse.getNext();
+
                 case HttpStatus.SC_NOT_FOUND:
+                    logBuilder.log();
                     throw new DatasetNotFoundException("The dataset API returned 404 for " + path);
+
                 default:
+                    logBuilder.log();
                     throw new UnexpectedResponseException(
                             String.format("The dataset API returned a %s response for %s",
                                     response.getStatusLine().getStatusCode(),
@@ -139,8 +151,8 @@ public class DatasetAPIClient implements DatasetClient {
         }
 
         logInfo("Calling dataset API")
-                .addParameter("uri", uri)
                 .addParameter("method", "GET")
+                .addParameter("uri", uri)
                 .log();
 
         HttpGet httpget = new HttpGet(uri);
@@ -148,13 +160,24 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse response = client.execute(httpget)) {
 
+            ZebedeeLogBuilder logBuilder = logInfo("Dataset API response")
+                    .addParameter("method", "GET")
+                    .addParameter("uri", uri)
+                    .addParameter("status", response.getStatusLine());
+
             switch (response.getStatusLine().getStatusCode()) {
+
                 case HttpStatus.SC_OK:
                     String responseString = EntityUtils.toString(response.getEntity());
+                    logBuilder.addParameter("response_body", responseString).log();
                     return ContentUtil.deserialise(responseString, DatasetVersion.class);
+
                 case HttpStatus.SC_NOT_FOUND:
+                    logBuilder.log();
                     throw new DatasetNotFoundException("The dataset API returned 404 for " + path);
+
                 default:
+                    logBuilder.log();
                     throw new UnexpectedResponseException(
                             String.format("The dataset API returned a %s response for %s",
                                     response.getStatusLine().getStatusCode(),
@@ -188,8 +211,8 @@ public class DatasetAPIClient implements DatasetClient {
         }
 
         logInfo("Calling dataset API")
-                .addParameter("uri", uri)
                 .addParameter("method", "GET")
+                .addParameter("uri", uri)
                 .log();
 
         HttpGet httpget = new HttpGet(uri);
@@ -197,13 +220,24 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse response = client.execute(httpget)) {
 
+            ZebedeeLogBuilder logBuilder = logInfo("Dataset API response")
+                    .addParameter("method", "GET")
+                    .addParameter("uri", uri)
+                    .addParameter("status", response.getStatusLine());
+
             switch (response.getStatusLine().getStatusCode()) {
+
                 case HttpStatus.SC_OK:
                     String responseString = EntityUtils.toString(response.getEntity());
+                    logBuilder.addParameter("response_body", responseString).log();
                     return ContentUtil.deserialise(responseString, Instance.class);
+
                 case HttpStatus.SC_NOT_FOUND:
+                    logBuilder.log();
                     throw new InstanceNotFoundException("The dataset API returned 404 for " + path);
+
                 default:
+                    logBuilder.log();
                     throw new UnexpectedResponseException(
                             String.format("The dataset API returned a %s response for %s",
                                     response.getStatusLine().getStatusCode(),
@@ -238,8 +272,8 @@ public class DatasetAPIClient implements DatasetClient {
         String datasetJson = ContentUtil.serialise(dataset);
 
         logInfo("Calling dataset API")
-                .addParameter("uri", uri)
                 .addParameter("method", "PUT")
+                .addParameter("uri", uri)
                 .addParameter("body", datasetJson)
                 .log();
 
@@ -252,13 +286,25 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse response = client.execute(httpPut)) {
 
+            ZebedeeLogBuilder logBuilder = logInfo("Dataset API response")
+                    .addParameter("method", "PUT")
+                    .addParameter("uri", uri)
+                    .addParameter("body", datasetJson)
+                    .addParameter("status", response.getStatusLine());
+
             switch (response.getStatusLine().getStatusCode()) {
+
                 case HttpStatus.SC_OK:
                     String responseString = EntityUtils.toString(response.getEntity());
+                    logBuilder.addParameter("response_body", responseString).log();
                     return ContentUtil.deserialise(responseString, Dataset.class);
+
                 case HttpStatus.SC_NOT_FOUND:
+                    logBuilder.log();
                     throw new DatasetNotFoundException("The dataset API returned 404 for " + path);
+
                 default:
+                    logBuilder.log();
                     throw new UnexpectedResponseException(
                             String.format("The dataset API returned a %s response for %s",
                                     response.getStatusLine().getStatusCode(),
@@ -291,8 +337,8 @@ public class DatasetAPIClient implements DatasetClient {
         String datasetJson = ContentUtil.serialise(datasetVersion);
 
         logInfo("Calling dataset API")
-                .addParameter("uri", uri)
                 .addParameter("method", "PUT")
+                .addParameter("uri", uri)
                 .addParameter("body", datasetJson)
                 .log();
 
@@ -305,13 +351,24 @@ public class DatasetAPIClient implements DatasetClient {
 
         try (CloseableHttpResponse response = client.execute(httpPut)) {
 
+            ZebedeeLogBuilder logBuilder = logInfo("Dataset API response")
+                    .addParameter("uri", uri)
+                    .addParameter("method", "PUT")
+                    .addParameter("body", datasetJson)
+                    .addParameter("status", response.getStatusLine());
+
             switch (response.getStatusLine().getStatusCode()) {
                 case HttpStatus.SC_OK:
                     String responseString = EntityUtils.toString(response.getEntity());
+                    logBuilder.addParameter("response_body", responseString).log();
                     return ContentUtil.deserialise(responseString, Dataset.class);
+
                 case HttpStatus.SC_NOT_FOUND:
+                    logBuilder.log();
                     throw new DatasetNotFoundException("The dataset API returned 404 for " + path);
+
                 default:
+                    logBuilder.log();
                     throw new UnexpectedResponseException(
                             String.format("The dataset API returned a %s response for %s",
                                     response.getStatusLine().getStatusCode(),

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -122,7 +122,7 @@ public class ZebedeeDatasetService implements DatasetService {
         Dataset dataset = datasetClient.getDataset(datasetID);
         DatasetVersion datasetVersion = datasetClient.getDatasetVersion(datasetID, edition, version);
 
-        if (State.CREATED.equals(datasetVersion.getState())) {
+        if (State.EDITION_CONFIRMED.equals(datasetVersion.getState())) {
             // the dataset version has just been added to the collection, so update collection ID and set state
             DatasetVersion versionUpdate = new DatasetVersion();
             versionUpdate.setCollection_id(collectionID);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetServiceTest.java
@@ -361,7 +361,7 @@ public class ZebedeeDatasetServiceTest {
 
         DatasetVersion datasetVersion = new DatasetVersion();
         datasetVersion.setCollection_id(collectionID);
-        datasetVersion.setState(State.CREATED);
+        datasetVersion.setState(State.EDITION_CONFIRMED);
         DatasetLinks versionLinks = new DatasetLinks();
         Link self = new Link();
         self.setHref(datasetVersionUrl);


### PR DESCRIPTION
### What

* Check for 'edition-confirmed' state before updating the dataset version on the dataset API. This was previously checking for the state of 'created' but now should always be edition-confirmed.
* Improved logging to include response status + body when calling the dataset API.

### How to review

* Review code
* Check the build is passing in concourse for this branch please

### Who can review

Anyone