### PR TITLE
make auditdb configurable from environment variables

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,6 @@ export audit_db_enabled=true
 mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \
 java $JAVA_OPTS \
  -Dlogback.configurationFile=zebedee-cms/target/classes/logback.xml \
- -Dcolour_logging_enabled=$colour_logging_enabled \
  -Ddb_audit_url=$db_audit_url \
  -Daudit_db_enabled=$audit_db_enabled \
  -Ddb_audit_username=$db_audit_username \

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -117,6 +117,12 @@ public class Configuration {
     public static String getAuditDBURL() {
         return StringUtils.defaultIfBlank(getValue("db_audit_url"), "");
     }
+    public static String getAuditDBUsername() {
+        return StringUtils.defaultIfBlank(getValue("db_audit_username"), "");
+    }
+    public static String getAuditDBPassword() {
+        return StringUtils.defaultIfBlank(getValue("db_audit_password"), "");
+    }
 
     /**
      * Gets a configured value for the given key from either the system

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/HibernateServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/HibernateServiceImpl.java
@@ -27,7 +27,14 @@ public class HibernateServiceImpl implements HibernateService {
     private static SessionFactory buildSessionFactory() {
         try {
             // Create the SessionFactory from hibernate.cfg.xml
-            return new Configuration().configure().buildSessionFactory();
+            Configuration config = new Configuration();
+            config.configure();
+
+            config.setProperty("hibernate.connection.url", com.github.onsdigital.zebedee.configuration.Configuration.getAuditDBURL());
+            config.setProperty("hibernate.connection.username", com.github.onsdigital.zebedee.configuration.Configuration.getAuditDBUsername());
+            config.setProperty("hibernate.connection.password", com.github.onsdigital.zebedee.configuration.Configuration.getAuditDBPassword());
+
+            return config.buildSessionFactory();
         }
         catch (Throwable ex) {
             // Make sure you log the exception, as it might be swallowed


### PR DESCRIPTION
### What

- allow auditdb to be configured from environment variables
- removes unused config option from run.sh

### How to review

- start zebedee, get postgres connection errors
- set `db_audit_url`, `db_audit_username` and `db_audit_password`
- start zebedee, don't get postgres connection errors

### Who can review

Anyone except @ian-kent