### PR TITLE
Add teams with IDs to collectionDetails endpoint

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -79,17 +79,7 @@ public class CollectionDetails {
         addEventsForDetails(result.reviewed, result, collection);
 
         Set<Integer> teamIds = Root.zebedee.getPermissionsService().listViewerTeams(collection.description, session);
-        List<Team> teams = Root.zebedee.getTeamsService().resolveTeams(teamIds);
-
-        // The members property will always be empty because we're using the Team class, rather than creating a new one
-        // that doesn't include members
-        result.teamsDetails = teams.stream().map(team -> {
-            Team resultTeam = new Team();
-            resultTeam.setId(team.getId());
-            resultTeam.setName(team.getName());
-            return resultTeam;
-        }).collect(Collectors.toList());
-
+        result.teamsDetails = Root.zebedee.getTeamsService().resolveTeamDetails(teamIds);
         return result;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -19,6 +19,7 @@ import javax.ws.rs.GET;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Api
 public class CollectionDetails {
@@ -79,9 +80,15 @@ public class CollectionDetails {
 
         Set<Integer> teamIds = Root.zebedee.getPermissionsService().listViewerTeams(collection.description, session);
         List<Team> teams = Root.zebedee.getTeamsService().resolveTeams(teamIds);
-        teams.forEach(team -> {
-            collection.description.teams.add(team.getName());
-        });
+
+        // The members property will always be empty because we're using the Team class, rather than creating a new one
+        // that doesn't include members
+        result.teamsDetails = teams.stream().map(team -> {
+            Team resultTeam = new Team();
+            resultTeam.setId(team.getId());
+            resultTeam.setName(team.getName());
+            return resultTeam;
+        }).collect(Collectors.toList());
 
         return result;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.json;
 
 import com.github.onsdigital.zebedee.model.CollectionOwner;
+import com.github.onsdigital.zebedee.teams.model.Team;
 
 import java.util.List;
 
@@ -11,6 +12,7 @@ public class CollectionDetail extends CollectionBase {
     public List<String> timeseriesImportFiles;
     public ApprovalStatus approvalStatus;
     public List<PendingDelete> pendingDeletes;
+    public List<Team> teamsDetails;
 
     public Events events;
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsService.java
@@ -29,6 +29,12 @@ public interface TeamsService {
     List<Team> resolveTeams(Set<Integer> teamIds) throws IOException;
 
     /**
+     * Return a list of {@link Team} matching the IDS provided containing only the team name & ID.
+     * @param teamIds the ID of the {@link Team}s to get
+     */
+    List<Team> resolveTeamDetails(Set<Integer> teamIds) throws IOException;
+
+    /**
      * Find a team by name.
      *
      * @param teamName the name of the team to search for.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
@@ -1,6 +1,10 @@
 package com.github.onsdigital.zebedee.teams.service;
 
-import com.github.onsdigital.zebedee.exceptions.*;
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.exceptions.NotFoundException;
+import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -71,6 +75,13 @@ public class TeamsServiceImpl implements TeamsService {
         return listTeams()
                 .parallelStream()
                 .filter(t -> teamIds.contains(t.getId()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Team> resolveTeamDetails(Set<Integer> teamIds) throws IOException {
+        return resolveTeams(teamIds).stream()
+                .map(team -> new Team().setId(team.getId()).setName(team.getName()))
                 .collect(Collectors.toList());
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -101,6 +102,29 @@ public class TeamsServiceImplTest {
         List<Team> expected = new ArrayList<>();
         expected.add(teamA);
         expected.add(teamB);
+
+        assertThat(result, equalTo(expected));
+
+        verify(teamsStore, times(1)).listTeams();
+    }
+
+    @Test
+    public void resolveTeamDetails_success() throws Exception {
+        Set<Integer> requestedTeamIDs = new HashSet<>();
+        requestedTeamIDs.add(teamA.getId());
+        requestedTeamIDs.add(teamB.getId());
+
+        teamsList.add(teamA);
+        teamsList.add(teamB);
+
+        List<Team> expected = teamsList.stream()
+                .map(team -> new Team().setName(team.getName()).setId(team.getId()))
+                .collect(Collectors.toList());
+
+        when(teamsStore.listTeams())
+                .thenReturn(teamsList);
+
+        List<Team> result = service.resolveTeamDetails(requestedTeamIDs);
 
         assertThat(result, equalTo(expected));
 


### PR DESCRIPTION
### What

Includes two changes:
1) Add teams with IDs to collectionDetails endpoint for the refactored Florence collections screen.
2) Remove the bug where team names were duplicated in the 'teams' property on the collectionDetails response.

### How to review

1) Switch to branch `feature/add-teams-details-to-collection` on Zebedee.
2) Ensure you have a collection with at least one team added to it.
3) Ensure the added teams has at least one member.
4) Get a response from the `collectionDetails` endpoint on Zebedee for that collection (e.g. `/collectionDetails/mycollection-mycollectionsuid`).
5) Check that the `teams` property only has one entry for each added team, not two.
6) Check that the `teamsDetails` property has an array for object with the same teams but instead including the team ID and an empty members array.

### Who can review

Probably @daiLlew, but maybe @ian-kent?
