### PR TITLE
Return 201 + body for create page, and 204 for delete page

### DIFF
--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PageTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PageTest.java
@@ -86,6 +86,7 @@ public class PageTest extends ZebedeeAPIBaseTestCase {
 
         // Then collections.createContent is called
         verify(collections, times(1)).createContent(any(),any(),any(),any(),any(),any(),anyBoolean());
+        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_CREATED);
     }
 
     @Test
@@ -235,6 +236,7 @@ public class PageTest extends ZebedeeAPIBaseTestCase {
 
         // Then collections.createContent is called
         verify(collections, times(1)).deleteContent(any(),any(),any());
+        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_NO_CONTENT);
     }
 
     @Test
@@ -323,7 +325,7 @@ public class PageTest extends ZebedeeAPIBaseTestCase {
         page.deletePage(mockRequest, mockResponse);
 
         // Then no exceptions are thrown and no response status set, allowing the call to return as normal
-        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_OK);
+        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_NO_CONTENT);
     }
 
     @Test


### PR DESCRIPTION
### What

Zebedee was returning the default 200 response when a page was created or deleted, with no response body. This has been updated to be more technically correct, using a 201 response and json body for created pages, and a 204 response for deleted pages

### How to review

Review changes, run tests

### Who can review

Anyone
