### PR TITLE
Do not assume a service token is always provided with a user

### DIFF
--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/IdentityTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/IdentityTest.java
@@ -113,7 +113,7 @@ public class IdentityTest {
 
 		api.identifyUser(mockRequest, mockResponse);
 
-		verify(serviceStore, times(1)).get("123");
+		verify(serviceStore, times(0)).get("123");
 		verify(authorisationService, times(1)).identifyUser(FLORENCE_TOKEN);
 		verifyResponseInteractions(identity, SC_OK);
 	}


### PR DESCRIPTION
### What

The identity endpoint was always expecting a service token to be present before attempting to check for a `X-Florence-Token`. Florence only sends an `X-Florence-Token` without a service token. This change is to handle this scenario.

### How to review

Review changes / test

### Who can review

Anyone
