### PR TITLE
Feature/logging

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,17 @@
 
 source ./export-default-env-vars.sh
 
-export JAVA_OPTS=" -Xmx512m -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
+export JAVA_OPTS=" -Xmx1024m -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
 export PORT="${PORT:-8082}"
 
 # Restolino configuration
 export RESTOLINO_STATIC="src/main/resources/files"
 export RESTOLINO_CLASSES="zebedee-cms/target/classes"
 export PACKAGE_PREFIX=com.github.onsdigital.zebedee
-export audit_db_enabled=true
+export audit_db_enabled=false
+export DP_LOGGING_FORMAT=pretty_json
+export DP_COLOURED_LOGGING=true
+export enable_splunk_reporting=false
 
 # Development: reloadable
 mvn clean package dependency:copy-dependencies -Dmaven.test.skip=true && \

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -115,7 +115,7 @@ public class Root {
         //Setting zebedee root as system property for zebedee reader module, since zebedee root is not set as environment variable on develop environment
         System.setProperty(ZEBEDEE_ROOT, root.toString());
 
-        //SlackNotification.alarm("Zebedee has just started. Ensure an administrator has logged in.");
+        SlackNotification.alarm("Zebedee has just started. Ensure an administrator has logged in.");
 
         loadExistingCollectionsIntoScheduler();
         initialiseCsdbImportKeys();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -115,7 +115,7 @@ public class Root {
         //Setting zebedee root as system property for zebedee reader module, since zebedee root is not set as environment variable on develop environment
         System.setProperty(ZEBEDEE_ROOT, root.toString());
 
-        SlackNotification.alarm("Zebedee has just started. Ensure an administrator has logged in.");
+        //SlackNotification.alarm("Zebedee has just started. Ensure an administrator has logged in.");
 
         loadExistingCollectionsIntoScheduler();
         initialiseCsdbImportKeys();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -88,7 +88,7 @@ public class Configuration {
     }
 
     public static List<Host> getWebsiteHosts() {
-        return Arrays.asList(StringUtils.split(defaultIfBlank(getValue("website_url"), DEFAULT_TRAIN_URL), ","))
+        return Arrays.asList(StringUtils.split(defaultIfBlank(getValue("website_url"), DEFAULT_WEBSITE_URL), ","))
                 .stream()
                 .map(url -> new Host(url))
                 .collect(Collectors.toList());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -1,10 +1,16 @@
 package com.github.onsdigital.zebedee.configuration;
 
+import com.github.davidcarboni.httpino.Host;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 
 
 public class Configuration {
@@ -74,12 +80,18 @@ public class Configuration {
         return StringUtils.defaultIfBlank(getValue("MATHJAX_SERVICE_URL"), MATHJAX_SERVICE_URL);
     }
 
-    public static String[] getTheTrainUrls() {
-        return StringUtils.split(StringUtils.defaultIfBlank(getValue("publish_url"), DEFAULT_TRAIN_URL), ",");
+    public static List<Host> getTheTrainHosts() {
+        return Arrays.asList(StringUtils.split(defaultIfBlank(getValue("publish_url"), DEFAULT_TRAIN_URL), ","))
+                .stream()
+                .map(url -> new Host(url))
+                .collect(Collectors.toList());
     }
 
-    public static String[] getWebsiteUrls() {
-        return StringUtils.split(StringUtils.defaultIfBlank(getValue("website_url"), DEFAULT_WEBSITE_URL), ",");
+    public static List<Host> getWebsiteHosts() {
+        return Arrays.asList(StringUtils.split(defaultIfBlank(getValue("website_url"), DEFAULT_TRAIN_URL), ","))
+                .stream()
+                .map(url -> new Host(url))
+                .collect(Collectors.toList());
     }
 
     public static String getBrianUrl() {
@@ -117,9 +129,11 @@ public class Configuration {
     public static String getAuditDBURL() {
         return StringUtils.defaultIfBlank(getValue("db_audit_url"), "");
     }
+
     public static String getAuditDBUsername() {
         return StringUtils.defaultIfBlank(getValue("db_audit_username"), "");
     }
+
     public static String getAuditDBPassword() {
         return StringUtils.defaultIfBlank(getValue("db_audit_password"), "");
     }
@@ -148,8 +162,8 @@ public class Configuration {
         return session == null ? "Please log in" : "You do not have the right permission: " + session;
     }
 
-    public static class UserList   {
-        ArrayList<UserObject>   users;
+    public static class UserList {
+        ArrayList<UserObject> users;
     }
 
     public static class UserObject {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
@@ -76,6 +76,10 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
         return new ZebedeeLogBuilder(t, ZEBEDEE_EXCEPTION);
     }
 
+    public static ZebedeeLogBuilder logError(String description) {
+        return new ZebedeeLogBuilder(description, Level.ERROR);
+    }
+
     public static ZebedeeLogBuilder logError(Throwable t, String errorContext) {
         return new ZebedeeLogBuilder(t, ZEBEDEE_EXCEPTION + " " + errorContext);
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.logging;
 
 import ch.qos.logback.classic.Level;
+import com.github.davidcarboni.httpino.Host;
 import com.github.onsdigital.logging.builder.LogMessageBuilder;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.CollectionEventHistoryException;
@@ -11,13 +12,20 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.UnexpectedErrorException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.model.Collection;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.builder.ToStringStyle.NO_CLASS_NAME_STYLE;
 
 /**
  * Created by dave on 5/5/16.
@@ -47,6 +55,10 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
     private static final String BLOCKING_COLLECTION = "blockingCollection";
     private static final String TARGET_PATH = "targetPath";
     private static final String TARGET_COLLECTION = "targetCollection";
+    private static final String TRAIN_HOST = "trainHost";
+    private static final String TRAIN_HOSTS = "trainHosts";
+    private static final String TRANSACTION_ID = "transactionID";
+    private static final String TRANSACTION_IDS = "transactionIDS";
 
     private ZebedeeLogBuilder(String description) {
         super(description);
@@ -192,6 +204,29 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
         return this;
     }
 
+    public ZebedeeLogBuilder trainHost(Host trainHost) {
+        if (trainHost != null && StringUtils.isNotEmpty(trainHost.toString())) {
+            addParameter(TRAIN_HOST, trainHost.toString());
+        }
+        return this;
+    }
+
+    public ZebedeeLogBuilder transactionID(String transactionID) {
+        if (StringUtils.isNotEmpty(transactionID)) {
+            addParameter(TRANSACTION_ID, transactionID);
+        }
+        return this;
+    }
+
+    public ZebedeeLogBuilder hostToTransactionID(Map<String, String> mapping) {
+        if (mapping != null && !mapping.isEmpty()) {
+            addParameter(TRAIN_HOSTS, mapping.entrySet()
+                    .stream().map(e -> new TrainHost(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList()));
+        }
+        return this;
+    }
+
     public ZebedeeLogBuilder saveOrEditConflict(Collection targetCollection, Collection blockingCollection, String targetURI) throws IOException {
         if (targetCollection != null) {
             String name = targetCollection.getDescription().getName();
@@ -215,6 +250,32 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
     @Override
     public String getLoggerName() {
         return LOG_NAME;
+    }
+
+    private static class TrainHost {
+        private String host;
+        private String transactionID;
+
+        public String getHost() {
+            return host;
+        }
+
+        public String getTransactionID() {
+            return transactionID;
+        }
+
+        TrainHost(String host, String transactionID) {
+            this.host = host;
+            this.transactionID = transactionID;
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this, NO_CLASS_NAME_STYLE)
+                    .append("host", host)
+                    .append(TRANSACTION_ID, transactionID)
+                    .toString();
+        }
     }
 
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -384,7 +384,6 @@ public class Collections {
             logInfo("Breaking before publish").log();
             return true;
         }
-        logInfo("Going ahead with publish").log();
 
         Keyring keyring = zebedeeSupplier.get().getKeyringCache().get(session);
         if (keyring == null) throw new UnauthorizedException("No keyring is available for " + session.getEmail());
@@ -400,12 +399,14 @@ public class Collections {
 
             PostPublisher.postPublish(zebedeeSupplier.get(), collection, skipVerification, collectionReader);
 
-            logInfo("Collection postPublish process finished")
+            logInfo("collection post publish process completed")
                     .collectionName(collection)
+                    .collectionId(collection)
                     .timeTaken((System.currentTimeMillis() - onPublishCompleteStart))
                     .log();
-            logInfo("Collection publish complete.")
+            logInfo("collection publish complete")
                     .collectionName(collection)
+                    .collectionId(collection)
                     .timeTaken((System.currentTimeMillis() - publishStart))
                     .log();
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -364,7 +364,10 @@ public class PostPublisher {
 
     public static void copyFilesToMaster(Zebedee zebedee, Collection collection, CollectionReader collectionReader)
             throws IOException, ZebedeeException {
-        logInfo("Moving files from collection into master").collectionName(collection).log();
+        logInfo("Moving files from collection into master")
+                .collectionId(collection)
+                .collectionName(collection)
+                .log();
         // Move each item of content:
         for (String uri : collection.reviewed.uris()) {
             if (!VersionedContentItem.isVersionedUri(uri)
@@ -381,8 +384,11 @@ public class PostPublisher {
     }
 
     public static Path moveCollectionToArchive(Zebedee zebedee, Collection collection, CollectionReader collectionReader) throws IOException, ZebedeeException {
+        logInfo("moving collection files to archive for collection")
+                .collectionId(collection)
+                .collectionName(collection)
+                .log();
 
-        logInfo("Moving collection files to archive for collection").collectionName(collection).log();
         String filename = PathUtils.toFilename(collection.getDescription().getName());
         Path collectionJsonSource = zebedee.getCollections().path.resolve(filename + ".json");
         Path collectionFilesSource = collection.reviewed.path;
@@ -397,18 +403,24 @@ public class PostPublisher {
         Path collectionFilesDestination = logPath.resolve(directoryName);
         Path collectionJsonDestination = logPath.resolve(directoryName + ".json");
 
-        logInfo("Moving collection json").addParameter("from", collectionJsonSource.toString())
-                .addParameter("to", collectionJsonDestination.toString()).log();
+        logInfo("moving collection json")
+                .addParameter("from", collectionJsonSource.toString())
+                .addParameter("to", collectionJsonDestination.toString())
+                .log();
         Files.copy(collectionJsonSource, collectionJsonDestination);
 
         Path manifestDestination = collectionFilesDestination.resolve(Manifest.filename);
-        logInfo("Moving manifest json").addParameter("from", Manifest.getManifestPath(collection).toString())
-                .addParameter("to", manifestDestination.toString()).log();
+        logInfo("moving manifest json")
+                .addParameter("from", Manifest.getManifestPath(collection).toString())
+                .addParameter("to", manifestDestination.toString())
+                .log();
 
         FileUtils.copyFile(Manifest.getManifestPath(collection).toFile(), manifestDestination.toFile());
 
-        logInfo("Moving collection files").addParameter("from", collectionFilesSource.toString())
-                .addParameter("to", collectionFilesDestination.toString()).log();
+        logInfo("moving collection files")
+                .addParameter("from", collectionFilesSource.toString())
+                .addParameter("to", collectionFilesDestination.toString())
+                .log();
         for (String uri : collection.reviewed.uris()) {
             try (
                     Resource resource = collectionReader.getResource(uri);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logError;
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
+import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logWarn;
 
 
 public class Publisher {
@@ -46,12 +47,21 @@ public class Publisher {
     private static final List<Host> theTrainHosts;
     private static final ExecutorService pool = Executors.newFixedThreadPool(20);
 
+    // endpoints
+    private static final String BEGIN_ENDPOINT = "begin";
+    private static final String SEND_MANIFEST_ENDPOINT = "CommitManifest";
+    private static final String PUBLISH_ENDPOINT = "publish";
+    private static final String COMMIT_ENDPOINT = "commit";
+    private static final String ROLLBACK_ENDPOINT = "rollback";
+
+    // parameters
+    private static final String ENCRYPTION_PASSWORD_PARAM = "encryptionPassword";
+    private static final String TRANSACTION_ID_PARAM = "transactionId";
+    private static final String URI_PARAM = "uri";
+    private static final String ZIP_PARAM = "zip";
+
     static {
-        String[] theTrainUrls = Configuration.getTheTrainUrls();
-        theTrainHosts = new ArrayList<>();
-        for (String theTrainUrl : theTrainUrls) {
-            theTrainHosts.add(new Host(theTrainUrl));
-        }
+        theTrainHosts = Configuration.getTheTrainHosts();
         Runtime.getRuntime().addShutdownHook(new ShutDownPublisherThread(pool));
     }
 
@@ -60,9 +70,8 @@ public class Publisher {
 
         // First get the in-memory (within-JVM) lock.
         // This will block attempts to write to the collection during the publishing process
-        logInfo("Attempting to lock collection before publish.")
-                .addParameter("collectionId", collection.getDescription().getId())
-                .log();
+        logInfo("PUBLISH: attempting to lock collection for publish").collectionId(collection).log();
+
         Lock writeLock = collection.getWriteLock();
         writeLock.lock();
 
@@ -70,8 +79,10 @@ public class Publisher {
 
         try {
             // First check the state of the collection
-            if (collection.description.publishComplete) {
-                logInfo("Collection has already been published. Halting publish").collectionId(collection).log();
+            if (collection.getDescription().publishComplete) {
+                logInfo("PUBLISH: collection has already been published. Halting publish")
+                        .collectionId(collection)
+                        .log();
                 return publishComplete;
             }
 
@@ -84,37 +95,45 @@ public class Publisher {
             try (FileChannel channel = FileChannel.open(collection.path.resolve(".lock"), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
                  FileLock lock = channel.tryLock()) {
                 if (lock != null) {
-                    logInfo("Collection lock acquired").collectionId(collection).log();
+                    logInfo("PUBLISH: collection lock acquired").collectionId(collection).log();
 
                     collection.path.resolve("publish.lock");
 
-                    logInfo("Starting collection publish process").collectionName(collection).log();
-
-
-                    if (collection.description.approvalStatus != ApprovalStatus.COMPLETE) {
-                        logInfo("Collection cannot be published as it has not been approved").collectionName(collection).log();
+                    if (collection.getDescription().approvalStatus != ApprovalStatus.COMPLETE) {
+                        logInfo("PUBLISH: collection cannot be published as it has not been approved")
+                                .collectionName(collection)
+                                .log();
                         return false;
                     }
 
-                    publishComplete = PublishFilesToWebsite(collection, email, collectionReader);
+                    publishComplete = publishFilesToWebsite(collection, email, collectionReader);
 
-                    logInfo("Collectiom publish process finished").collectionName(collection)
-                            .timeTaken((System.currentTimeMillis() - publishStart)).log();
+                    logInfo("PUBLISH: collection publish process completed")
+                            .collectionName(collection)
+                            .collectionId(collection)
+                            .timeTaken((System.currentTimeMillis() - publishStart))
+                            .log();
 
                 } else {
-                    logInfo("Collection is already locked for publishing. Halting publish attempt").collectionId(collection).log();
+                    logInfo("PUBLISH: collection is already locked for publishing. Halting publish attempt")
+                            .collectionId(collection)
+                            .log();
                 }
 
             } finally {
                 // Save any updates to the collection
+                logInfo("PUBLISH: saving changes to collection")
+                        .collectionId(collection)
+                        .log();
                 collection.save();
             }
 
         } finally {
             writeLock.unlock();
-            logInfo("Collection lock released").collectionId(collection).log();
+            logInfo("PUBLISH: collection lock released")
+                    .collectionId(collection)
+                    .log();
         }
-
         return publishComplete;
     }
 
@@ -126,28 +145,38 @@ public class Publisher {
      * @return If publishing succeeded, true.
      * @throws IOException If a general error occurs.
      */
-    public static boolean PublishFilesToWebsite(Collection collection, String email, CollectionReader collectionReader) throws IOException {
-
+    public static boolean publishFilesToWebsite(Collection collection, String email, CollectionReader collectionReader) throws IOException {
         boolean publishComplete = false;
         String encryptionPassword = Random.password(100);
+
         try {
-            collection.description.publishStartDate = new Date();
-            BeginPublish(collection, encryptionPassword);
-            SendManifest(collection, encryptionPassword);
-            PublishFilteredCollectionFiles(collection, collectionReader, encryptionPassword);
-            publishComplete = CommitPublish(collection, email, encryptionPassword);
-            collection.description.publishEndDate = new Date();
+            collection.getDescription().publishStartDate = new Date();
+            createPublishingTransactions(collection, encryptionPassword);
+            sendManifest(collection, encryptionPassword);
+            publishFilteredCollectionFiles(collection, collectionReader, encryptionPassword);
+
+            publishComplete = commitPublish(collection, email, encryptionPassword);
+            collection.getDescription().publishEndDate = new Date();
 
         } catch (IOException e) {
-
             SlackNotification.alarm(String.format("Exception publishing collection: %s: %s",
                     collection.getDescription().getName(), e.getMessage()));
-            logError(e, "Exception publishing collection").collectionName(collection).log();
+
+            logError(e, "PUBLISH: Exception publishing collection")
+                    .collectionName(collection)
+                    .collectionId(collection)
+                    .log();
+
             // If an error was caught, attempt to roll back the transaction:
-            Map<String, String> transactionIds = collection.description.publishTransactionIds;
+            Map<String, String> transactionIds = collection.getDescription().publishTransactionIds;
             if (transactionIds != null && transactionIds.size() > 0) {
-                logInfo("Attempting rollback of collection publishing transaction").collectionName(collection).log();
-                rollbackPublish(collection.description.publishTransactionIds, encryptionPassword);
+                logInfo("PUBLISH: attempting rollback of collection publishing transaction")
+                        .collectionName(collection)
+                        .collectionId(collection)
+                        .hostToTransactionID(collection.getDescription().publishTransactionIds)
+                        .log();
+
+                rollbackPublish(collection, encryptionPassword);
             }
 
         } finally {
@@ -158,6 +187,55 @@ public class Publisher {
         return publishComplete;
     }
 
+    public static Map<String, String> createPublishingTransactions(Collection collection, String encryptionPassword)
+            throws IOException {
+        long start = System.currentTimeMillis();
+        Map<String, String> hostToTransactionIDMap = new ConcurrentHashMap<>();
+        List<Future<IOException>> results = new ArrayList<>();
+
+        try (Http http = new Http()) {
+
+            for (Host host : theTrainHosts) {
+                results.add(pool.submit(() -> {
+                    IOException result = null;
+                    try {
+                        logInfo("PRE-PUBLISH: creating new publishing transaction for collection")
+                                .trainHost(host)
+                                .collectionId(collection)
+                                .log();
+
+                        Endpoint begin = new Endpoint(host, BEGIN_ENDPOINT)
+                                .setParameter(ENCRYPTION_PASSWORD_PARAM, encryptionPassword);
+
+                        Response<Result> response = http.post(begin, Result.class);
+                        checkResponse(response);
+                        hostToTransactionIDMap.put(host.toString(), response.body.transaction.id);
+                    } catch (IOException e) {
+                        logError(e, "PUBLISH: error while attempting to create new publishing transactionn for collection")
+                                .trainHost(host)
+                                .collectionId(collection)
+                                .log();
+                        result = e;
+                    }
+                    return result;
+                }));
+            }
+        }
+
+        checkFutureResults(results, "error creating publishing transaction");
+
+        collection.getDescription().publishTransactionIds = hostToTransactionIDMap;
+        collection.save();
+
+        logInfo("PRE-PUBLISH: successfully created new publishing transactions for collection")
+                .collectionId(collection)
+                .hostToTransactionID(hostToTransactionIDMap)
+                .timeTaken(System.currentTimeMillis() - start)
+                .log();
+
+        return hostToTransactionIDMap;
+    }
+
     /**
      * Publish collection files with required filters applied.
      *
@@ -166,133 +244,171 @@ public class Publisher {
      * @param encryptionPassword
      * @throws IOException
      */
-    public static void PublishFilteredCollectionFiles(Collection collection, CollectionReader collectionReader, String encryptionPassword) throws IOException {
+    public static void publishFilteredCollectionFiles(Collection collection, CollectionReader collectionReader, String encryptionPassword) throws IOException {
         // We do not want to send versioned files. They have already been taken care of via the manifest.
         // Pass the function to filter files into the publish method.
         Function<String, Boolean> versionedUriFilter = uri -> VersionedContentItem.isVersionedUri(uri);
         Function<String, Boolean> timeseriesUriFilter = uri -> uri.contains("/timeseries/");
-        Publisher.PublishCollectionFiles(collection, collectionReader, encryptionPassword, versionedUriFilter, timeseriesUriFilter);
+
+        Function<String, Boolean>[] filters = new Function[]{versionedUriFilter, timeseriesUriFilter};
+        //Publisher.PublishCollectionFiles(collection, collectionReader, encryptionPassword, versionedUriFilter,timeseriesUriFilter);
+
+        List<Future<IOException>> results = new ArrayList<>();
+        long start = System.currentTimeMillis();
+
+        // Publish each item of content:
+        for (String uri : collection.reviewed.uris()) {
+            if (!shouldBeFiltered(filters, uri)) {
+                //publishFile(collection, encryptionPassword, results, uri, collectionReader);
+
+                Path source = collection.reviewed.get(uri);
+                if (source != null) {
+                    boolean zipped = false;
+                    String publishUri = uri;
+
+                    // if we have a recognised compressed file - set the zip header and set the correct uri so that the files
+                    // are unzipped to the correct place.
+                    if (source.getFileName().toString().equals("timeseries-to-publish.zip")) {
+                        zipped = true;
+                        publishUri = StringUtils.removeEnd(uri, "-to-publish.zip");
+                    }
+
+                    for (Map.Entry<String, String> entry : collection.getDescription().publishTransactionIds.entrySet()) {
+                        Host theTrainHost = new Host(entry.getKey());
+                        String transactionId = entry.getValue();
+
+                        results.add(publishFile(collection.getDescription().getId(), theTrainHost,
+                                transactionId, encryptionPassword, uri, publishUri, zipped, source, collectionReader));
+                    }
+                }
+            }
+        }
+
+        checkFutureResults(results, "error while attempting to publish file");
+
+        logInfo("PUBLISH: successfully sent all publish file requests to the train")
+                .collectionId(collection)
+                .hostToTransactionID(collection.getDescription().publishTransactionIds)
+                .timeTaken((System.currentTimeMillis() - start))
+                .log();
     }
 
-    public static void SendManifest(Collection collection, String encryptionPassword) throws IOException {
+    private static Future<IOException> publishFile(
+            final String collectionID,
+            final Host host,
+            final String transactionId,
+            final String encryptionPassword,
+            final String uri,
+            final String publishUri,
+            final boolean zipped,
+            final Path source,
+            final CollectionReader reader
+    ) {
+        return pool.submit(() -> {
+            IOException result = null;
+            try (Http http = new Http()) {
+                Endpoint publish = new Endpoint(host, PUBLISH_ENDPOINT)
+                        .setParameter(TRANSACTION_ID_PARAM, transactionId)
+                        .setParameter(ENCRYPTION_PASSWORD_PARAM, encryptionPassword)
+                        .setParameter(ZIP_PARAM, Boolean.toString(zipped))
+                        .setParameter(URI_PARAM, publishUri);
+                try (
+                        Resource resource = reader.getResource(uri);
+                        InputStream dataStream = resource.getData()
+                ) {
+                    logInfo("PUBLISH: sending publish collection file request to train host")
+                            .collectionId(collectionID)
+                            .transactionID(transactionId)
+                            .trainHost(host)
+                            .addParameter(URI_PARAM, uri)
+                            .addParameter("isZip", zipped)
+                            .log();
 
+                    Response<Result> response = http.post(publish, dataStream, source.getFileName().toString(), Result.class);
+                    checkResponse(response);
+                }
+            } catch (IOException e) {
+                logError(e, "PUBLISH: error while sending publish file request to train host")
+                        .collectionId(collectionID)
+                        .transactionID(transactionId)
+                        .trainHost(host)
+                        .addParameter(URI_PARAM, uri)
+                        .addParameter("isZip", zipped)
+                        .log();
+                result = e;
+            }
+            return result;
+        });
+    }
+
+    public static void sendManifest(Collection collection, String encryptionPassword) throws IOException {
         Manifest manifest = Manifest.get(collection);
-
-        long start = System.currentTimeMillis();
         List<Future<IOException>> futures = new ArrayList<>();
+        long start = System.currentTimeMillis();
 
-        for (Map.Entry<String, String> entry : collection.description.publishTransactionIds.entrySet()) {
+        for (Map.Entry<String, String> entry : collection.getDescription().publishTransactionIds.entrySet()) {
             Host theTrainHost = new Host(entry.getKey());
             String transactionId = entry.getValue();
 
             futures.add(pool.submit(() -> {
                 IOException result = null;
                 try (Http http = new Http()) {
-                    Endpoint publish = new Endpoint(theTrainHost, "CommitManifest")
-                            .setParameter("transactionId", transactionId)
-                            .setParameter("encryptionPassword", encryptionPassword);
+                    Endpoint publish = new Endpoint(theTrainHost, SEND_MANIFEST_ENDPOINT)
+                            .setParameter(TRANSACTION_ID_PARAM, transactionId)
+                            .setParameter(ENCRYPTION_PASSWORD_PARAM, encryptionPassword);
 
                     Response<Result> response = http.postJson(publish, manifest, Result.class);
                     checkResponse(response);
 
                 } catch (IOException e) {
+                    logError(e, "PUBLISH: unexpected error while attempting to send publish manifest to train host")
+                            .collectionId(collection)
+                            .trainHost(theTrainHost)
+                            .transactionID(transactionId)
+                            .log();
                     result = e;
                 }
                 return result;
             }));
         }
 
-        // wait for all results to return, checking if an exception has occurred
-        for (Future<IOException> future : futures) {
-            try {
-                IOException exception = future.get();
-                if (exception != null) throw exception;
-            } catch (InterruptedException | ExecutionException e) {
-                throw new IOException("Error in sendManifest", e);
-            }
-        }
+        checkFutureResults(futures, "error sending publish manifest");
 
-        logInfo("sendManifest complete").timeTaken(System.currentTimeMillis() - start).log();
+        logInfo("PUBLISH: successfully sent publish manifest for collection to train hosts")
+                .collectionId(collection)
+                .hostToTransactionID(collection.getDescription().publishTransactionIds)
+                .timeTaken(System.currentTimeMillis() - start)
+                .log();
     }
 
-
-    /**
-     * Start a new transaction on the train and save the transaction ID to the collection.
-     *
-     * @param collection
-     * @param encryptionPassword
-     * @return
-     * @throws IOException
-     */
-    public static Map<String, String> BeginPublish(Collection collection, String encryptionPassword) throws IOException {
-
+    public static boolean commitPublish(Collection collection, String email, String encryptionPassword) throws IOException {
         long start = System.currentTimeMillis();
 
-        logInfo("PRE-PUBLISH: Begin transaction").collectionName(collection).log();
-
-        Map<String, String> hostToTransactionId = beginPublish(theTrainHosts, encryptionPassword);
-        collection.description.publishTransactionIds = hostToTransactionId;
-
-        collection.save();
-
-        logInfo("PRE-PUBLISH: BeginPublish complete").timeTaken(System.currentTimeMillis() - start).log();
-
-        return hostToTransactionId;
-    }
-
-    public static boolean CommitPublish(Collection collection, String email, String encryptionPassword) throws IOException {
-
-        boolean publishComplete = false;
-        long start = System.currentTimeMillis();
-
-        logInfo("CommitPublish collectiom start").collectionName(collection).log();
         // If all has gone well so far, commit the publishing transaction:
-        boolean success = true;
-        for (Result result : commitPublish(collection.description.publishTransactionIds, encryptionPassword)) {
-            success &= !result.error;
-            collection.description.AddPublishResult(result);
+        boolean isSuccess = true;
+        for (Result result : commitPublish(collection.getDescription().publishTransactionIds, encryptionPassword)) {
+            isSuccess &= !result.error;
+            collection.getDescription().AddPublishResult(result);
         }
 
-        if (success) {
+        if (isSuccess) {
             Date publishedDate = new Date();
-            collection.description.addEvent(new Event(publishedDate, EventType.PUBLISHED, email));
-            collection.description.publishComplete = true;
-            publishComplete = true;
+            collection.getDescription().addEvent(new Event(publishedDate, EventType.PUBLISHED, email));
+            collection.getDescription().publishComplete = true;
+
+            logInfo("PUBLISH: commit publish completed successfully")
+                    .collectionId(collection)
+                    .timeTaken((System.currentTimeMillis() - start))
+                    .log();
+
+            return true;
+        } else {
+            logWarn("PUBLISH: commit publish was unsuccessfully")
+                    .collectionId(collection)
+                    .timeTaken((System.currentTimeMillis() - start))
+                    .log();
+            return false;
         }
-
-        logInfo("CommitPublish end").collectionName(collection).timeTaken((System.currentTimeMillis() - start)).log();
-        return publishComplete;
-    }
-
-    public static void PublishCollectionFiles(
-            Collection collection,
-            CollectionReader collectionReader,
-            String encryptionPassword,
-            Function<String, Boolean>... filters
-    ) throws IOException {
-
-        List<Future<IOException>> results = new ArrayList<>();
-        long start = System.currentTimeMillis();
-
-        logInfo("PublishFiles start").collectionName(collection).log();
-        // Publish each item of content:
-        for (String uri : collection.reviewed.uris()) {
-            if (!shouldBeFiltered(filters, uri)) {
-                logInfo("Start PublishFile").collectionId(collection).addParameter("uri", uri).log();
-                publishFile(collection, encryptionPassword, pool, results, uri, collectionReader);
-            }
-        }
-
-        // Check the publishing results:
-        for (Future<IOException> result : results) {
-            try {
-                IOException exception = result.get();
-                if (exception != null) throw exception;
-            } catch (InterruptedException | ExecutionException e) {
-                throw new IOException("Error in file publish", e);
-            }
-        }
-        logInfo("PublishFiles end").collectionName(collection).timeTaken((System.currentTimeMillis() - start)).log();
     }
 
     /**
@@ -308,126 +424,6 @@ public class Publisher {
                 return true;
         }
         return false;
-    }
-
-    private static void publishFile(
-            Collection collection,
-            String encryptionPassword,
-            ExecutorService pool,
-            List<Future<IOException>> results,
-            String uri,
-            CollectionReader reader
-    ) {
-        Path source = collection.reviewed.get(uri);
-        if (source != null) {
-            boolean zipped = false;
-            String publishUri = uri;
-
-            // if we have a recognised compressed file - set the zip header and set the correct uri so that the files
-            // are unzipped to the correct place.
-            if (source.getFileName().toString().equals("timeseries-to-publish.zip")) {
-                zipped = true;
-                publishUri = StringUtils.removeEnd(uri, "-to-publish.zip");
-            }
-
-            for (Map.Entry<String, String> entry : collection.description.publishTransactionIds.entrySet()) {
-                Host theTrainHost = new Host(entry.getKey());
-                String transactionId = entry.getValue();
-                results.add(publishFile(theTrainHost, transactionId, encryptionPassword, uri, publishUri, zipped, source, reader, pool));
-            }
-        }
-    }
-
-    /**
-     * Starts a publishing transaction.
-     *
-     * @param hosts              The list of target Train {@link Host}s
-     * @param encryptionPassword The password used to encrypt files during publishing.
-     * @return The new transaction ID.
-     * @throws IOException If any errors are encountered in making the request or reported in the {@link com.github.onsdigital.zebedee.json.publishing.Result}.
-     */
-    private static Map<String, String> beginPublish(List<Host> hosts, String encryptionPassword) throws IOException {
-        Map<String, String> hostToTransactionIdMap = new ConcurrentHashMap<>();
-        try (Http http = new Http()) {
-
-            List<Future<IOException>> results = new ArrayList<>();
-
-            // submit a beginPublish call for each host to the thread pool.
-            for (Host host : hosts) {
-                results.add(pool.submit(() -> {
-                    IOException result = null;
-                    try {
-                        logInfo("BeginPublish start").addParameter("host", host.toString()).log();
-                        Endpoint begin = new Endpoint(host, "begin").setParameter("encryptionPassword", encryptionPassword);
-                        Response<Result> response = http.post(begin, Result.class);
-                        checkResponse(response);
-                        hostToTransactionIdMap.put(host.toString(), response.body.transaction.id);
-                        logInfo("BeginPublish end").addParameter("host", host.toString()).log();
-                    } catch (IOException e) {
-                        result = e;
-                    }
-
-                    return result;
-                }));
-            }
-
-            // wait for all results to return, checking if an exception has occurred
-            for (Future<IOException> result : results) {
-                try {
-                    IOException exception = result.get();
-                    if (exception != null) throw exception;
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new IOException("Error in BeginPublish", e);
-                }
-            }
-        }
-        return hostToTransactionIdMap;
-    }
-
-    /**
-     * Submits files for asynchronous publishing.
-     *
-     * @param host               The Train {@link Host}
-     * @param transactionId      The transaction to publish to.
-     * @param encryptionPassword The password used to encrypt files duing publishing.
-     * @param uri                The destination URI.
-     * @param source             The data to be published.
-     * @param pool               An {@link ExecutorService} to use for asynchronous execution.
-     * @return A {@link Future} that will evaluate to {@code null} unless an error occurs in publishing a file, in which case the exception will be returned.
-     * @throws IOException
-     */
-    private static Future<IOException> publishFile(
-            final Host host,
-            final String transactionId,
-            final String encryptionPassword,
-            final String uri,
-            final String publishUri,
-            final boolean zipped,
-            final Path source,
-            final CollectionReader reader,
-            ExecutorService pool
-    ) {
-        return pool.submit(() -> {
-            IOException result = null;
-            try (Http http = new Http()) {
-                Endpoint publish = new Endpoint(host, "publish")
-                        .setParameter("transactionId", transactionId)
-                        .setParameter("encryptionPassword", encryptionPassword)
-                        .setParameter("zip", Boolean.toString(zipped))
-                        .setParameter("uri", publishUri);
-                System.out.println("uri = " + uri);
-                try (
-                        Resource resource = reader.getResource(uri);
-                        InputStream dataStream = resource.getData()
-                ) {
-                    Response<Result> response = http.post(publish, dataStream, source.getFileName().toString(), Result.class);
-                    checkResponse(response);
-                }
-            } catch (IOException e) {
-                result = e;
-            }
-            return result;
-        });
     }
 
     /**
@@ -450,26 +446,36 @@ public class Publisher {
             futures.add(pool.submit(() -> {
                 IOException result = null;
                 try {
-                    logInfo("CommitPublish start").addParameter("host", host.toString()).log();
-                    results.add(endPublish(host, "commit", transactionId, encryptionPassword));
-                    logInfo("CommitPublish end").addParameter("host", host.toString()).log();
+                    logInfo("PUBLISH: sending commit transaction request to train host")
+                            .transactionID(transactionId)
+                            .trainHost(host)
+                            .log();
+
+                    try (Http http = new Http()) {
+                        Endpoint endpoint = new Endpoint(host, COMMIT_ENDPOINT)
+                                .setParameter(TRANSACTION_ID_PARAM, transactionId)
+                                .setParameter(ENCRYPTION_PASSWORD_PARAM, encryptionPassword);
+
+                        Response<Result> response = http.post(endpoint, Result.class);
+                        checkResponse(response);
+                        results.add(response.body);
+                    }
                 } catch (IOException e) {
+                    logError(e, "PUBLISH: error while sending commit transaction request to trian host")
+                            .trainHost(host)
+                            .transactionID(transactionId)
+                            .log();
                     result = e;
                 }
-
                 return result;
             }));
         }
 
-        // wait for all results to return, checking if an exception has occurred
-        for (Future<IOException> future : futures) {
-            try {
-                IOException exception = future.get();
-                if (exception != null) throw exception;
-            } catch (InterruptedException | ExecutionException e) {
-                throw new IOException("Error in commitPublish", e);
-            }
-        }
+        checkFutureResults(futures, "error in commit publish");
+
+        logInfo("PUBLISH: successfully committed publishing transaction")
+                .hostToTransactionID(transactionIds)
+                .log();
 
         return results;
     }
@@ -480,38 +486,49 @@ public class Publisher {
      * @param transactionIds     The {@link Host}s and transactions we are attempting to publish to.
      * @param encryptionPassword The password used to encrypt files during publishing.
      */
-    public static void rollbackPublish(Map<String, String> transactionIds, String encryptionPassword) {
-        for (Map.Entry<String, String> entry : transactionIds.entrySet()) {
+    public static void rollbackPublish(Collection collection, String encryptionPassword) {
+        for (Map.Entry<String, String> entry : collection.getDescription().publishTransactionIds.entrySet()) {
             Host host = new Host(entry.getKey());
             String transactionId = entry.getValue();
-            try {
-                endPublish(host, "rollback", transactionId, encryptionPassword);
+
+            try (Http http = new Http()) {
+                Endpoint endpoint = new Endpoint(host, ROLLBACK_ENDPOINT)
+                        .setParameter(TRANSACTION_ID_PARAM, transactionId)
+                        .setParameter(ENCRYPTION_PASSWORD_PARAM, encryptionPassword);
+
+                logInfo("PUBLISH: sending rollback transaction request for collection")
+                        .collectionId(collection)
+                        .collectionName(collection)
+                        .hostToTransactionID(collection.getDescription().publishTransactionIds)
+                        .log();
+
+                Response<Result> response = http.post(endpoint, Result.class);
+                checkResponse(response);
+
             } catch (IOException e) {
-                logError(e, "Error rolling back publish transaction:").log();
+                logError(e, "PUBLISH: error rolling back publish transaction")
+                        .collectionId(collection)
+                        .collectionName(collection)
+                        .transactionID(transactionId)
+                        .log();
             }
         }
     }
 
-    static Result endPublish(Host host, String endpointName, String transactionId, String encryptionPassword) throws IOException {
-        Result result;
-        try (Http http = new Http()) {
-            Endpoint endpoint = new Endpoint(host, endpointName)
-                    .setParameter("transactionId", transactionId)
-                    .setParameter("encryptionPassword", encryptionPassword);
-            Response<Result> response = http.post(endpoint, Result.class);
-            checkResponse(response);
-            result = response.body;
-        }
-        return result;
-    }
-
     static void checkResponse(Response<Result> response) throws IOException {
-
         if (response.statusLine.getStatusCode() != 200) {
             int code = response.statusLine.getStatusCode();
             String reason = response.statusLine.getReasonPhrase();
             String message = response.body != null ? response.body.message : "";
+
+            logWarn("PUBLISH: request was unsuccessful")
+                    .addParameter("statusCode", code)
+                    .addParameter("reason", reason)
+                    .addParameter("message", message)
+                    .log();
+
             throw new IOException("Error in request: " + code + " " + reason + " " + message);
+
         } else if (response.body.error == true) {
             throw new IOException("Result error: " + response.body.message);
         } else if (response.body.transaction.errors != null && response.body.transaction.errors.size() > 0) {
@@ -525,6 +542,22 @@ public class Publisher {
             }
             if (messages.size() > 0) {
                 throw new IOException(messages.toString());
+            }
+        }
+    }
+
+    /**
+     * Wait for all results to return, checking if an exception has occurred.
+     */
+    private static void checkFutureResults(List<Future<IOException>> results, String errorContext) throws IOException {
+        for (Future<IOException> result : results) {
+            try {
+                IOException exception = result.get();
+                if (exception != null) {
+                    throw exception;
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                throw new IOException(errorContext, e);
             }
         }
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -143,10 +143,10 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         String encryptionPassword = Random.password(100);
 
                         // begin the publish ahead of time. This creates the transaction on the train.
-                        Map<String, String> hostToTransactionIdMap = Publisher.BeginPublish(collection, encryptionPassword);
+                        Map<String, String> hostToTransactionIdMap = Publisher.createPublishingTransactions(collection, encryptionPassword);
 
                         // send versioned files manifest ahead of time. allowing files to be copied from the website into the transaction.
-                        Publisher.SendManifest(collection, encryptionPassword);
+                        Publisher.sendManifest(collection, encryptionPassword);
 
                         SecretKey key = zebedee.getKeyringCache().schedulerCache.get(collection.getDescription().getId());
                         ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, key);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
@@ -50,16 +50,16 @@ public class PublishCollectionTask implements Callable<Boolean> {
         try {
             collection.description.publishStartDate = new Date();
 
-            Publisher.PublishFilteredCollectionFiles(collection, collectionReader, encryptionPassword);
+            Publisher.publishFilteredCollectionFiles(collection, collectionReader, encryptionPassword);
 
-            published = Publisher.CommitPublish(collection, publisherSystemEmail, encryptionPassword);
+            published = Publisher.commitPublish(collection, publisherSystemEmail, encryptionPassword);
             collection.description.publishEndDate = new Date();
         } catch (IOException e) {
             logError(e, "Exception publishing collection").collectionName(collection).log();
             // If an error was caught, attempt to roll back the transaction:
             if (collection.description.publishTransactionIds != null) {
                 logInfo("Attempting rollback of publishing transaction").collectionName(collection).log();
-                Publisher.rollbackPublish(hostToTransactionIdMap, encryptionPassword);
+                Publisher.rollbackPublish(collection, encryptionPassword);
             }
         } finally {
             // Save any updates to the collection

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
@@ -136,8 +136,13 @@ public class SlackNotification {
     }
 
     private static String publicationMessage(PublishedCollection publishedCollection) throws ParseException {
-        Result result = publishedCollection.publishResults.get(0);
+        if (publishedCollection.publishResults != null && !publishedCollection.publishResults.isEmpty()) {
+            // TODO need to investigate why this sometimes throws a NPE
+            return "Collection " + publishedCollection.getName() + " was published at "
+                    + format.format(publishedCollection.publishStartDate);
+        }
 
+        Result result = publishedCollection.publishResults.get(0);
         String timeTaken = String.format("%.2f", (publishedCollection.publishEndDate.getTime() - publishedCollection.publishStartDate.getTime()) / 1000.0);
 
         String exampleUri = "";

--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -9,44 +9,27 @@
         </encoder>
     </appender>
 
-    <!-- Use this appender if you want the log output in plain/standard log format. -->
-    <appender name="PLAIN_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="DP_LOGGER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="com.github.onsdigital.logging.layouts.TextLayout" />
+            <layout class="com.github.onsdigital.logging.layouts.ConfigurableLayout" />
         </encoder>
     </appender>
 
-    <!-- Use this appender if you want the log output in json -->
-    <!--<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">-->
-        <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
-            <!--<layout class="com.github.onsdigital.logging.layouts.JsonLayout" />-->
-        <!--</encoder>-->
-    <!--</appender>-->
-
-    <!--<appender name="PRETTY_JSON" class="ch.qos.logback.core.ConsoleAppender">-->
-        <!--<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">-->
-            <!--<layout class="com.github.onsdigital.logging.layouts.PrettyJsonLayout" />-->
-        <!--</encoder>-->
-    <!--</appender>-->
 
     <logger name="com.github.onsdigital.zebedee" level="debug" additivity="false">
-        <!--<appender-ref ref="JSON"/>-->
-        <!--<appender-ref ref="PRETTY_JSON"/>-->
-        <appender-ref ref="PLAIN_TEXT"/>
+        <appender-ref ref="DP_LOGGER"/>
     </logger>
 
     <logger name="com.github.onsdigital.zebedee-reader" level="debug" additivity="false">
-        <!--<appender-ref ref="JSON"/>-->
-        <!--<appender-ref ref="PRETTY_JSON"/>-->
-        <appender-ref ref="PLAIN_TEXT"/>
+        <appender-ref ref="DP_LOGGER"/>
     </logger>
 
     <logger name="com.github.davidcarboni.restolino" level="warn" additivity="false">
-        <appender-ref ref="PLAIN_TEXT"/>
+        <appender-ref ref="DP_LOGGER"/>
     </logger>
 
     <root level="info">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="DP_LOGGER"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
### What
Added detailed logging around the publishing process. Publish should continue to work exactly the same but the log output should now give enough information to specifically identify:

- the transaction IDs and the instance of the train they belong to.
- the collection ID
- the uri of the content

Error responses should now also log out more details - the endpoint called, the URL of the train instance as well the collection ID and transaction ID

I have also tried to simplify the Publisher class by collapsing the many small methods for each step of the process into one.