### PR TITLE
Hotfix/create trans defect

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
@@ -246,9 +246,8 @@ public class Publisher {
                     return result;
                 }));
             }
+            checkFutureResults(results, "error creating publishing transaction");
         }
-
-        checkFutureResults(results, "error creating publishing transaction");
 
         collection.getDescription().publishTransactionIds = hostToTransactionIDMap;
         collection.save();


### PR DESCRIPTION
Fix for create publishing transaction issue.

Shared `Http` object was being closed early when running against multiple train hosts before all requests had finished using it. Each thread now has its own instance of `http` to prevent this from happening.

@ian-kent @janderson2 