### PR TITLE
fixed logic error to prevent NPE in publish slack notification

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
@@ -136,7 +136,7 @@ public class SlackNotification {
     }
 
     private static String publicationMessage(PublishedCollection publishedCollection) throws ParseException {
-        if (publishedCollection.publishResults != null && !publishedCollection.publishResults.isEmpty()) {
+        if (publishedCollection.publishResults == null || publishedCollection.publishResults.isEmpty()) {
             // TODO need to investigate why this sometimes throws a NPE
             return "Collection " + publishedCollection.getName() + " was published at "
                     + format.format(publishedCollection.publishStartDate);


### PR DESCRIPTION
Corrected defensive logic to prevent null pointer exception when attempting to send slack publish notification.
