### PR TITLE
Tell user which collection a URI is being edited in

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -26,7 +26,9 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.github.onsdigital.zebedee.configuration.Configuration.isVerificationEnabled;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.beingEditedByAnotherCollectionError;
@@ -134,6 +136,13 @@ public class Zebedee {
                 .stream()
                 .filter(c -> c.isInCollection(uri) && !workingCollection.getDescription().getId()
                         .equals(c.getDescription().getId()))
+                .findFirst();
+    }
+
+    public Optional<Collection> checkForCollectionBlockingChange(String uri) throws IOException {
+        return collections.list()
+                .stream()
+                .filter(c -> c.isInCollection(uri))
                 .findFirst();
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
@@ -1,0 +1,48 @@
+package com.github.onsdigital.zebedee.api;
+
+import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import java.io.IOException;
+import java.util.Optional;
+
+@Api
+public class CheckCollectionsForURI {
+    private static ZebedeeCmsService zebedeeCmsService = ZebedeeCmsService.getInstance();
+
+    /**
+     * Checks whether a URI is already in a collection
+     *
+     * @param request This should contain a X-Florence-Token header for the current session
+     * @param response 200 if the URI is being edited, othewise a 204
+     * @return The collection name if the URI is being edited, otherwise an empty string
+     * @throws IOException If an error occurs in processing data, typically to the filesystem, but also on the HTTP connection.
+     * @throws UnauthorizedException If the user does not have editor/admin permission.
+     */
+    @GET
+    public String get(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, UnauthorizedException {
+
+        Session session = Root.zebedee.getSessionsService().get(request);
+        if (session == null || !zebedeeCmsService.getPermissions().canEdit(session.getEmail())) {
+            throw new UnauthorizedException("You are not authorised to check collections for a URI");
+        }
+
+        String uri = request.getParameter("uri");
+
+        Optional<com.github.onsdigital.zebedee.model.Collection> collection = Root.zebedee.checkForCollectionBlockingChange(uri);
+        if(!collection.isPresent()) {
+            response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            return "";
+        }
+
+        return collection.get().getDescription().getName();
+    }
+
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/DeleteContentRequestDeniedException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/DeleteContentRequestDeniedException.java
@@ -31,6 +31,8 @@ public class DeleteContentRequestDeniedException extends ZebedeeException {
     private static final String PAGE_TYPE_CANNOT_BE_DELETED
             = "Delete not allowed for {0}.";
 
+    protected String collectionName;
+
     /**
      * Delete not allowed for this page type.
      */
@@ -71,8 +73,10 @@ public class DeleteContentRequestDeniedException extends ZebedeeException {
      */
     public static DeleteContentRequestDeniedException markedDeleteInAnotherCollectionError(
             Collection collection, String uri) {
-        return new DeleteContentRequestDeniedException(MARKED_BY_ANOTHER_COLLECTION,
+        DeleteContentRequestDeniedException e = new DeleteContentRequestDeniedException(MARKED_BY_ANOTHER_COLLECTION,
                 HttpStatus.SC_BAD_REQUEST, uri, collection.getDescription().getName());
+        e.collectionName = collection.getDescription().getName();
+        return e;
     }
 
     private static String buildDetailedMessage(String reason, Object... args) {
@@ -84,5 +88,9 @@ public class DeleteContentRequestDeniedException extends ZebedeeException {
 
     private DeleteContentRequestDeniedException(String message, int status, Object... args) {
         super(buildDetailedMessage(message, args), status);
+    }
+
+    public String getCollectionName() {
+        return collectionName;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -231,6 +231,11 @@ public class Collection {
             release = getPublishedRelease(collectionDescription.getReleaseUri(), zebedee);
 
             if (zebedee.isBeingEdited(release.getUri().toString() + "/data.json") > 0) {
+                Optional<Collection> otherCollection = zebedee.checkForCollectionBlockingChange(release.getUri().toString() + "/data.json");
+                if(otherCollection.isPresent()) {
+                    throw new ConflictException(
+                            "Cannot use this release. It is being edited as part of another collection.", otherCollection.get().getDescription().getName());
+                }
                 throw new ConflictException(
                         "Cannot use this release. It is being edited as part of another collection.");
             }
@@ -239,6 +244,11 @@ public class Collection {
             try {
                 zebedee.checkAllCollectionsForDeleteMarker(release.getUri().toString());
             } catch (DeleteContentRequestDeniedException ex) {
+                Optional<Collection> otherCollection = zebedee.checkForCollectionBlockingChange(release.getUri().toString() + "/data.json");
+                if(otherCollection.isPresent()) {
+                    throw new ConflictException(
+                            "Cannot use this release. It is being deleted as part of another collection.", otherCollection.get().getDescription().getName());
+                }
                 throw new ConflictException(
                         "Cannot use this release. It is being deleted as part of another collection.");
             }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -835,6 +835,8 @@ public class CollectionsTest {
                 .thenReturn(null);
         when(collectionMock.edit(TEST_EMAIL, uri.toString(), collectionWriterMock, false))
                 .thenReturn(false);
+        when(zebedeeMock.checkForCollectionBlockingChange(uri.toString()))
+                .thenReturn(Optional.empty());
         try {
             collections.writeContent(collectionMock, uri.toString(), sessionMock, requestMock, mock(InputStream.class), false,
                     CollectionEventType.COLLECTION_PAGE_SAVED, false);
@@ -865,6 +867,8 @@ public class CollectionsTest {
                 .thenReturn(uri);
         when(collectionMock.edit(TEST_EMAIL, uri.toString(), collectionWriterMock, false))
                 .thenReturn(false);
+        when(zebedeeMock.checkForCollectionBlockingChange(uri.toString()))
+                .thenReturn(Optional.empty());
         try {
             collections.writeContent(collectionMock, uri.toString(), sessionMock, requestMock, mock(InputStream.class), false,
                     CollectionEventType.COLLECTION_PAGE_SAVED, false);
@@ -1016,6 +1020,8 @@ public class CollectionsTest {
                 .thenReturn(false);
         when(zebedeeMock.checkForCollectionBlockingChange(collectionMock, uri))
                 .thenReturn(Optional.of(blocker));
+        when(zebedeeMock.checkForCollectionBlockingChange(uri))
+                .thenReturn(Optional.of(blocker));
         when(blocker.getDescription())
                 .thenReturn(collectionDescriptionMock);
         when(collectionDescriptionMock.getName())
@@ -1027,8 +1033,8 @@ public class CollectionsTest {
             verify(publishedContentMock, times(1)).exists(uri);
             verify(zebedeeMock, times(1)).checkForCollectionBlockingChange(collectionMock, uri);
             verify(collectionMock, times(1)).getDescription();
-            verify(blocker, times(1)).getDescription();
-            verify(collectionDescriptionMock, times(2)).getName();
+            verify(blocker, times(2)).getDescription();
+            verify(collectionDescriptionMock, times(3)).getName();
             verifyNoMoreInteractions(zebedeeMock);
             verifyZeroInteractions(collectionReaderWriterFactoryMock, collectionWriterMock, collectionMock);
             throw e;

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/exceptions/ConflictException.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/exceptions/ConflictException.java
@@ -2,11 +2,25 @@ package com.github.onsdigital.zebedee.exceptions;
 
 import org.eclipse.jetty.http.HttpStatus;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by david on 23/04/15.
  */
-public class ConflictException extends ZebedeeException {
+public class ConflictException extends ZebedeeExceptionWithData {
+    public String collectionName;
+
     public ConflictException(String message) {
         super(message, HttpStatus.CONFLICT_409);
+    }
+
+    public ConflictException(String message, String collectionName) {
+        super(message, HttpStatus.CONFLICT_409);
+        this.collectionName = collectionName;
+        
+        HashMap<String, String> data = new HashMap<>();
+        data.put("collectionName", collectionName);
+        this.data = data;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/exceptions/ZebedeeExceptionWithData.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/exceptions/ZebedeeExceptionWithData.java
@@ -1,0 +1,26 @@
+package com.github.onsdigital.zebedee.exceptions;
+
+import java.util.Map;
+
+/**
+ * Superclass that identifies exceptions thrown by Zebedee that require a particular status code to be set
+ * (other than default {@value org.eclipse.jetty.http.HttpStatus#INTERNAL_SERVER_ERROR_500} in an HTTP response to an API request.
+ */
+public abstract class ZebedeeExceptionWithData extends ZebedeeException {
+
+    // Additional data which can be returned with the exception message
+    protected Map<String, String> data;
+
+    public ZebedeeExceptionWithData(String message, int responseCode) {
+        super(message, responseCode);
+    }
+
+    public ZebedeeExceptionWithData(String message, int responseCode, Map<String, String> data) {
+        super(message, responseCode);
+        this.data = data;
+    }
+
+    public Map<String, String> getData() {
+        return data;
+    }
+}

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/ServerResponse.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/ServerResponse.java
@@ -1,13 +1,21 @@
 package com.github.onsdigital.zebedee.reader.api.bean;
 
+import java.util.Map;
+
 /**
  * Created by bren on 31/07/15.
  */
 public class ServerResponse {
 
     private String message;
+    private Map<String, String> data;
 
     public ServerResponse(String message) {
         this.message = message;
+    }
+
+    public ServerResponse(String message, Map<String, String> data) {
+        this.message = message;
+        this.data = data;
     }
 }


### PR DESCRIPTION
### What

Tell user which collection a URI is being edited in: 

* Add version of `checkForCollectionBlockingChange` which doesn't require a collection context
* Add `/checkcollectionsforuri` endpoint which returns a `204` if the URI is safe to edit, or a `200` and the collection name if the URI is being edited in another collection
* Store the collection name in a `DeleteContentRequestDeniedException`
* Update `ServerResponse` to allow additional data to be returned
* Add`ZebedeeExceptionWithData` which subclasses `ZebedeeException` and allows additional data (as a `Map<String,String>`)
* Allow `ConflictException` to store the collection name, and update it to use `ZebedeeExceptionWithData`
* Update collections handling to return the collection name when there's a URI conflict

### How to review

* Use the `feature/already-in-collection` branch of florence
* Edit URI in one collection and save, edit the same URI in another collection and you should get an error telling you it's in the first collection
* Create new URI in one collection, create the same URI again in another collection, you should get an error telling you it's in the first collection

### Who can review

Anyone except @ian-kent