### PR TITLE
hot fix for xls cells limit when generating download file

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/Generator.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/Generator.java
@@ -17,6 +17,7 @@ import javax.ws.rs.GET;
 import java.io.IOException;
 import java.util.List;
 
+import static com.github.onsdigital.zebedee.logging.ZebedeeReaderLogBuilder.logWarn;
 import static com.github.onsdigital.zebedee.reader.util.ReaderRequestUtils.extractFilter;
 import static com.github.onsdigital.zebedee.reader.util.ReaderRequestUtils.getRequestedLanguage;
 import static com.github.onsdigital.zebedee.reader.util.ReaderResponseResponseUtils.sendResponse;
@@ -62,10 +63,14 @@ public class Generator {
         // Check format string
         String format = request.getParameter(FORMAT_PARAM);
         if (StringUtils.isEmpty(format)) {
+            logWarn("generator endpoint format parameter is required but was empty").log();
             throw new BadRequestException(UNDEFINED_FORMAT_MSG);
         }
 
         if (!SUPPORTED_FORMATS.contains(format.toLowerCase())) {
+            logWarn("generator endpoint requested format is not supported")
+                    .addParameter("format", format)
+                    .log();
             throw new BadRequestException(UNSUPPORTED_FORMAT_MSG);
         }
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/configuration/SearchConfiguration.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/configuration/SearchConfiguration.java
@@ -11,7 +11,7 @@ public class SearchConfiguration {
     private static String elasticSearchServer = defaultIfBlank(getVariableValue("ELASTIC_SEARCH_SERVER"), "localhost");
     private static String elasticSearchAlias = defaultIfBlank(getVariableValue("ELASTIC_SEARCH_ALIAS"), "ons");
     private static Integer elasticSearchPort = Integer.parseInt(defaultIfBlank(getVariableValue
-            ("ELASTIC_SEARCH_PORT"), "9300"));
+            ("ELASTIC_SEARCH_PORT"), "9500"));
     private static String elasticSearchCluster = defaultIfBlank(getVariableValue("ELASTIC_SEARCH_CLUSTER"), "");
     private static boolean startEmbeddedSearch = "Y".equals(defaultIfBlank(getVariableValue("START_EMBEDDED_SERVER"), "N"));
 

--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <logger name="com.github.onsdigital.zebedee-reader" level="debug" additivity="false">
+    <logger name="com.github.onsdigital.zebedee-reader" level="trace" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 


### PR DESCRIPTION
### What

Hotfix for live issue with XLS download. XLS lib has a hard limit of 4000 cell styles per workbook - we were generating a new cell style per cell - in large work books this causes a server error.

Updated logic to only generate unique styles and reuse exists ones.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
