### PR TITLE
Hotfix/merge xlscells fix

### DIFF
--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <logger name="com.github.onsdigital.zebedee-reader" level="trace" additivity="false">
+    <logger name="com.github.onsdigital.zebedee-reader" level="debug" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 


### PR DESCRIPTION
### What

Merge hotfix that went into `master` to fix issues where XLS files could not be generated due to cell styles exceeding hard limit of 4000.

### How to review

Run the website locally and attempt to download http://localhost:8080/generator?uri=/employmentandlabourmarket/peopleinwork/earningsandworkinghours/compendium/distributionofukearningsanalyses/2017/regionaldistributionofearningsintheuk2017/f20c193b&format=xls

### Who can review

Anyone.
