### PR TITLE
Hotfix: Fix nomad node class for reader

### DIFF
--- a/zebedee-reader/zebedee-reader.nomad
+++ b/zebedee-reader/zebedee-reader.nomad
@@ -20,8 +20,7 @@ job "zebedee-reader" {
 
     constraint {
       attribute = "${node.class}"
-      operator  = "regexp"
-      value     = "web.*"
+      value     = "web-mount"
     }
 
     restart {


### PR DESCRIPTION
### What

Fix nomad node class for reader to ensure that zebedee reader will always be deployed to a node that has the content mount.

### How to review

Ensure that the nomad plan is valid.

### Who can review

Anyone but me.
