### PR TITLE
removed collection name from log and updated calls to use collection …

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -185,7 +185,6 @@ public class Root {
     public static void cancelPublish(Collection collection) {
         try {
             logInfo("Attempting to cancel collection publish.")
-                    .collectionName(collection)
                     .collectionId(collection)
                     .addParameter("type", collection.getDescription().getType())
                     .log();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/ZebedeeLogBuilder.java
@@ -164,16 +164,6 @@ public class ZebedeeLogBuilder extends LogMessageBuilder {
         return this;
     }
 
-    public ZebedeeLogBuilder collectionName(Collection collection) {
-        addParameter(COLLECTION_NAME, collection.getDescription().getName());
-        return this;
-    }
-
-    public ZebedeeLogBuilder collectionName(String name) {
-        addParameter(COLLECTION_NAME, name);
-        return this;
-    }
-
     public ZebedeeLogBuilder table(String tableName) {
         addParameter(TABLE, tableName);
         return this;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -436,7 +436,7 @@ public class Collection {
         ) {
             Release release = (Release) ContentUtil.deserialiseContent(dataStream);
             logInfo("Release identified for collection")
-                    .collectionName(this.getDescription().getName())
+                    .collectionId(this)
                     .addParameter("title", release.getDescription().getTitle())
                     .log();
 
@@ -645,7 +645,7 @@ public class Collection {
         if (!permission) {
             logInfo("Content was not saved as user does not have EDIT permission")
                     .path(uri)
-                    .collectionName(this)
+                    .collectionId(this)
                     .user(email)
                     .log();
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/CollectionContentWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/CollectionContentWriter.java
@@ -45,7 +45,7 @@ public class CollectionContentWriter extends ContentWriter {
             );
             logInfo("Writing unencrypted content in collection")
                     .addParameter("uri", uri)
-                    .collectionName(collection.getDescription().getName())
+                    .collectionId(collection)
                     .log();
 
             return FileUtils.openOutputStream(path.toFile());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -423,12 +423,10 @@ public class Collections {
             PostPublisher.postPublish(zebedeeSupplier.get(), collection, skipVerification, collectionReader);
 
             logInfo("collection post publish process completed")
-                    .collectionName(collection)
                     .collectionId(collection)
                     .timeTaken((System.currentTimeMillis() - onPublishCompleteStart))
                     .log();
             logInfo("collection publish complete")
-                    .collectionName(collection)
                     .collectionId(collection)
                     .timeTaken((System.currentTimeMillis() - publishStart))
                     .log();
@@ -573,7 +571,7 @@ public class Collections {
         CollectionWriter collectionWriter = collectionReaderWriterFactory.getWriter(zebedeeSupplier.get(), collection, session);
 
         logInfo("Attempting to write content.")
-                .collectionName(collection)
+                .collectionId(collection)
                 .path(uri)
                 .user(session.getEmail())
                 .log();
@@ -624,7 +622,7 @@ public class Collections {
         }
 
         collection.save();
-        logInfo("content save successful.").collectionName(collection).path(uri).user(session.getEmail()).log();
+        logInfo("content save successful.").collectionId(collection).path(uri).user(session.getEmail()).log();
 
         path = collection.getInProgressPath(uri);
         if (!Files.exists(path)) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -177,13 +177,13 @@ public class ApproveTask implements Callable<Boolean> {
             return true;
 
         } catch (Exception e) {
-            logError(e, "Exception approving collection").collectionName(collection).user(session.getEmail()).log();
+            logError(e, "Exception approving collection").collectionId(collection).user(session.getEmail()).log();
 
             collection.description.approvalStatus = ApprovalStatus.ERROR;
             try {
                 collection.save();
             } catch (IOException e1) {
-                logError(e, "Exception saving collection after approval exception").collectionName(collection).log();
+                logError(e, "Exception saving collection after approval exception").collectionId(collection).log();
             }
 
             SlackNotification.collectionAlarm(collection,
@@ -204,7 +204,7 @@ public class ApproveTask implements Callable<Boolean> {
                     "Failed verification of time series zip files",
                     new PostMessageField("Advice", "Unlock the collection and re-approve to try again", false)
             );
-            logInfo("Failed verification of time series zip files").collectionName(collection).log();
+            logInfo("Failed verification of time series zip files").collectionId(collection).log();
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -122,13 +122,13 @@ public class ReleasePopulator {
                                        List<ContentDetail> collectionContent) throws IOException {
         if (collection.isRelease()) {
             logInfo("Release identified for collection, populating the page links")
-                    .collectionName(collection)
+                    .collectionId(collection)
                     .log();
             try {
                 collection.populateRelease(collectionReader, collectionWriter, collectionContent);
             } catch (ZebedeeException e) {
                 logError(e, "Failed to populate release page for collection")
-                        .collectionName(collection)
+                        .collectionId(collection)
                         .log();
             }
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/timeseries/TimeSeriesCompressionTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/timeseries/TimeSeriesCompressionTask.java
@@ -48,7 +48,7 @@ public class TimeSeriesCompressionTask {
      * @throws IOException
      */
     public boolean compressTimeseries(Collection collection, CollectionReader collectionReader, CollectionWriter collectionWriter) throws ZebedeeException, IOException {
-        logInfo("Compressing time series directories").collectionName(collection).log();
+        logInfo("Compressing time series directories").collectionId(collection).log();
         int attempt = 1;
         List<TimeseriesCompressionResult> failedZipFiles = null; // populated on a failed attempt
 
@@ -57,7 +57,7 @@ public class TimeSeriesCompressionTask {
 
             failedZipFiles = verifyZipFiles(collection, collectionReader, collectionWriter, attempt, zipFiles);
             if (failedZipFiles.size() == 0) {
-                logInfo("Verified time series zip files").collectionName(collection).addParameter("attempt", attempt).log();
+                logInfo("Verified time series zip files").collectionId(collection).addParameter("attempt", attempt).log();
                 return true;
             }
 
@@ -79,7 +79,8 @@ public class TimeSeriesCompressionTask {
 
     private List<TimeseriesCompressionResult> verifyZipFiles(Collection collection, CollectionReader collectionReader, CollectionWriter collectionWriter, int attempt, List<TimeseriesCompressionResult> zipFiles) throws IOException {
         List<TimeseriesCompressionResult> failedZipFiles;
-        logInfo("Verifying " + zipFiles.size() + " time series zip files").collectionName(collection).addParameter("attempt", attempt).log();
+        logInfo("Verifying " + zipFiles.size() + " time series zip files").collectionId(collection).addParameter("attempt",
+                attempt).log();
         failedZipFiles = zipFileVerifier.verifyZipFiles(
                 zipFiles,
                 collectionReader.getReviewed(),
@@ -92,7 +93,10 @@ public class TimeSeriesCompressionTask {
                     new PostMessageField("Attempt", Integer.toString(attempt, 10), true),
                     new PostMessageField("Zip path", failedZipFile.zipPath.toString(), false)
             );
-            logInfo("Failed verification of time series zip file").collectionName(collection).addParameter("attempt", attempt).addParameter("zipPath", failedZipFile.zipPath.toString()).log();
+            logInfo("Failed verification of time series zip file").collectionId(collection)
+                    .addParameter("attempt", attempt)
+                    .addParameter("zipPath", failedZipFile.zipPath.toString())
+                    .log();
         }
         return failedZipFiles;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -112,8 +112,7 @@ public class PostPublisher {
 
             return true;
         } catch (Exception exception) {
-            logError(exception, "An error occurred during the publish cleanup")
-                    .collectionName(collection).collectionId(collection).log();
+            logError(exception, "An error occurred during the publish cleanup").collectionId(collection).log();
             // FIXME using PostPublisher.getPublishedCollection feels a bit hacky
             SlackNotification.publishNotification(getPublishedCollection(collection),SlackNotification.CollectionStage.POST_PUBLISH, SlackNotification.StageStatus.FAILED);
         }
@@ -141,7 +140,7 @@ public class PostPublisher {
             applyManifestDeletesToMaster(collection, contentReader, contentWriter);
         } catch (Exception e) {
             logError(e, "An error occurred trying apply the deletes to publishing content ")
-                    .collectionName(collection).collectionId(collection).log();
+                    .collectionId(collection).log();
         }
     }
 
@@ -165,7 +164,7 @@ public class PostPublisher {
                     publishDate);
         } catch (Exception exception) {
             logError(exception, "An error occurred saving publish metrics")
-                    .collectionName(publishedCollection.getName()).collectionId(publishedCollection.getId()).log();
+                    .collectionId(publishedCollection.getId()).log();
         }
     }
 
@@ -217,12 +216,12 @@ public class PostPublisher {
                 } catch (IOException e) {
                     logError(e, "An error occurred trying to delete directory "
                             + target.toString())
-                            .collectionName(collection).collectionId(collection).log();
+                            .collectionId(collection).log();
                 }
             }
         } catch (Exception e) {
             logError(e, "An error occurred trying apply the publish manifest deletes to publishing content ")
-                    .collectionName(collection).collectionId(collection).log();
+                    .collectionId(collection).log();
         }
 
     }
@@ -244,7 +243,7 @@ public class PostPublisher {
                 } catch (IOException e) {
                     logError(e, "An error occurred trying to delete directory "
                             + target.toString())
-                            .collectionName(collection).collectionId(collection).log();
+                            .collectionId(collection).log();
                 }
             }
 
@@ -259,12 +258,12 @@ public class PostPublisher {
                             + fileCopy.source
                             + " to "
                             + fileCopy.target)
-                            .collectionName(collection).collectionId(collection).log();
+                            .collectionId(collection).log();
                 }
             }
         } catch (Exception e) {
             logError(e, "An error occurred trying apply the publish manifest to publishing content ")
-                    .collectionName(collection).collectionId(collection).log();
+                    .collectionId(collection).log();
         }
 
     }
@@ -289,7 +288,7 @@ public class PostPublisher {
      * @throws IOException
      */
     private static void unzipTimeseries(Collection collection, CollectionReader collectionReader, Zebedee zebedee) throws IOException, ZebedeeException {
-        logInfo("Unzipping files if required to move to master.").collectionName(collection).collectionId(collection).log();
+        logInfo("Unzipping files if required to move to master.").collectionId(collection).log();
         for (String uri : collection.reviewed.uris()) {
             Path source = collection.reviewed.get(uri);
             if (source != null) {
@@ -312,7 +311,7 @@ public class PostPublisher {
 
     private static void reindexPublishingSearch(Collection collection) throws IOException {
 
-        logInfo("Reindexing search").collectionName(collection).log();
+        logInfo("Reindexing search").collectionId(collection).log();
         try {
 
             long start = System.currentTimeMillis();
@@ -339,11 +338,11 @@ public class PostPublisher {
                 });
             }
 
-            logInfo("Redindex search completed").collectionName(collection)
+            logInfo("Redindex search completed").collectionId(collection)
                     .timeTaken((System.currentTimeMillis() - start)).log();
 
         } catch (Exception exception) {
-            logError(exception, "An error occurred during the search reindex").collectionName(collection).log();
+            logError(exception, "An error occurred during the search reindex").collectionId(collection).log();
             ExceptionUtils.printRootCauseStackTrace(exception);
         }
     }
@@ -372,7 +371,6 @@ public class PostPublisher {
             throws IOException, ZebedeeException {
         logInfo("Moving files from collection into master")
                 .collectionId(collection)
-                .collectionName(collection)
                 .log();
         // Move each item of content:
         for (String uri : collection.reviewed.uris()) {
@@ -392,7 +390,6 @@ public class PostPublisher {
     public static Path moveCollectionToArchive(Zebedee zebedee, Collection collection, CollectionReader collectionReader) throws IOException, ZebedeeException {
         logInfo("moving collection files to archive for collection")
                 .collectionId(collection)
-                .collectionName(collection)
                 .log();
 
         String filename = PathUtils.toFilename(collection.getDescription().getName());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishScheduler.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishScheduler.java
@@ -32,12 +32,12 @@ public class PublishScheduler extends Scheduler {
 
     @Override
     protected void schedule(Collection collection, Zebedee zebedee) {
-        logInfo("Scheduling collection using optimised publisher").collectionName(collection).log();
+        logInfo("Scheduling collection using optimised publisher").collectionId(collection).log();
         Date publishStartDate = collection.getDescription().getPublishDate();
         int getPreProcessSecondsBeforePublish = Configuration.getPreProcessSecondsBeforePublish();
         Date prePublishStartDate = new DateTime(publishStartDate).minusSeconds(getPreProcessSecondsBeforePublish).toDate();
 
-        logInfo("Scheduling collection prepublish").collectionName(collection)
+        logInfo("Scheduling collection prepublish").collectionId(collection)
                 .addParameter("prePublishStartDate", prePublishStartDate)
                 .addParameter("publishStartDate", publishStartDate).log();
         schedulePrePublish(collection, zebedee, prePublishStartDate, publishStartDate);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
@@ -74,18 +74,15 @@ public class PublishTask implements Runnable {
                     PostPublisher.postPublish(zebedee, collection, skipVerification, collectionReader);
 
                     logInfo("Collection postPublish process finished")
-                            .collectionName(collection)
                             .collectionId(collectionId)
                             .timeTaken((System.currentTimeMillis() - onPublishCompleteStart))
                             .log();
                     logInfo("Collection publish complete")
-                            .collectionName(collection)
                             .collectionId(collectionId)
                             .timeTaken((System.currentTimeMillis() - publishStart))
                             .log();
                 } else {
                     logWarn("scheduled collection publish did not complete successfully")
-                            .collectionName(collection)
                             .collectionId(collection)
                             .log();
 
@@ -95,7 +92,6 @@ public class PublishTask implements Runnable {
         } catch (Exception e) {
             logError(e, "Exception publishing scheduled collection")
                     .collectionId(collection)
-                    .collectionName(collection)
                     .log();
 
             SlackNotification.scheduledPublishFailure(collection);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/Scheduler.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/Scheduler.java
@@ -14,7 +14,7 @@ public abstract class Scheduler {
         if (Configuration.isSchedulingEnabled()) {
             try {
                 logInfo("Attempting collection schedule publish")
-                        .collectionName(collection)
+                        .collectionId(collection)
                         .addParameter("collectionType", collection.getDescription().getType())
                         .log();
                 if (collection.getDescription().getType() == CollectionType.scheduled) {
@@ -22,12 +22,12 @@ public abstract class Scheduler {
                 }
             } catch (Exception e) {
                 logError(e, "Exception caught trying to schedule existing collection")
-                        .collectionName(collection)
+                        .collectionId(collection)
                         .log();
             }
         } else {
             logInfo("Not scheduling collection, scheduling is not enabled")
-                    .collectionName(collection)
+                    .collectionId(collection)
                     .log();
         }
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PostPublishCollectionTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PostPublishCollectionTask.java
@@ -46,7 +46,7 @@ public class PostPublishCollectionTask implements Callable<Boolean> {
      */
     protected boolean doPostPublish(Collection collection, ZebedeeCollectionReader collectionReader) {
 
-        logInfo("POST-PUBLISH: Running collection post publish process").collectionName(collection).log();
+        logInfo("POST-PUBLISH: Running collection post publish process").collectionId(collection).log();
         long onPublishCompleteStart = System.currentTimeMillis();
         boolean skipVerification = false;
         boolean result = false;
@@ -54,11 +54,11 @@ public class PostPublishCollectionTask implements Callable<Boolean> {
         try {
             result = PostPublisher.postPublish(zebedee, collection, skipVerification, collectionReader);
         } catch (IOException e) {
-            logError(e, "Error while Running collection post publish process").collectionName(collection).log();
+            logError(e, "Error while Running collection post publish process").collectionId(collection).log();
         }
 
         logInfo("POST-PUBLISH: collectiom postPublish process complete.")
-                .collectionName(collection).timeTaken((System.currentTimeMillis() - onPublishCompleteStart)).log();
+                .collectionId(collection).timeTaken((System.currentTimeMillis() - onPublishCompleteStart)).log();
 
         return result;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -139,7 +139,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
             for (Collection collection : collections) {
                 futures.add(pool.submit(() -> {
                     try {
-                        logInfo("PRE-PUBLISH: creating collection publish task").collectionName(collection).log();
+                        logInfo("PRE-PUBLISH: creating collection publish task").collectionId(collection).log();
 
                         // FIXME using PostPublisher.getPublishedCollection feels a bit hacky
                         SlackNotification.publishNotification(PostPublisher.getPublishedCollection(collection),SlackNotification.CollectionStage.PRE_PUBLISH, SlackNotification.StageStatus.STARTED);
@@ -154,7 +154,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, key);
                         PublishCollectionTask publishCollectionTask = new PublishCollectionTask(collection, collectionReader, hostToTransactionIdMap);
 
-                        logInfo("PRE-PUBLISH: Adding publish task").collectionName(collection).log();
+                        logInfo("PRE-PUBLISH: Adding publish task").collectionId(collection).log();
                         collectionPublishTasks.add(publishCollectionTask);
 
                         // FIXME using PostPublisher.getPublishedCollection feels a bit hacky
@@ -198,7 +198,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
         List<PostPublishCollectionTask> postPublishCollectionTasks = new ArrayList<>(collectionPublishTasks.size());
 
         collectionPublishTasks.forEach(publishTask -> {
-            logInfo("PRE-PUBLISH: creating collection post-publish task").collectionName(publishTask.getCollection()).log();
+            logInfo("PRE-PUBLISH: creating collection post-publish task").collectionId(publishTask.getCollection()).log();
             PostPublishCollectionTask postPublishCollectionTask = new PostPublishCollectionTask(zebedee, publishTask);
             postPublishCollectionTasks.add(postPublishCollectionTask);
         });

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
@@ -89,7 +89,6 @@ public class PublishCollectionTask implements Callable<Boolean> {
             if (!published) {
                 logWarn("Exception publishing scheduled collection")
                         .collectionId(collection)
-                        .collectionName(collection)
                         .log();
 
                 SlackNotification.scheduledPublishFailure(collection);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/verification/VerificationAgent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/verification/VerificationAgent.java
@@ -53,7 +53,7 @@ public class VerificationAgent {
     }
 
     public void submitForVerification(PublishedCollection publishedCollection, Path jsonPath, CollectionReader reader) {
-        logInfo("Submitting collection for external verification").collectionName(publishedCollection.getName()).log();
+        logInfo("Submitting collection for external verification").collectionId(publishedCollection.getId()).log();
         List<Result> publishResults = publishedCollection.publishResults;
         for (Result publishResult : publishResults) {
             Set<UriInfo> uriInfos = publishResult.transaction.uriInfos;
@@ -175,7 +175,7 @@ public class VerificationAgent {
             zebedee.getPublishedCollections().save(publishedCollection, jsonPath);
         } catch (IOException e) {
             logError(e, "Saving published collection failed")
-                    .collectionName(publishedCollection.getName()).log();
+                    .collectionId(publishedCollection.getId()).log();
         }
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -393,7 +393,6 @@ public class CollectionsTest {
             verify(collectionReaderWriterFactoryMock, times(1)).getWriter(zebedeeMock, collectionMock, sessionMock);
             verify(sessionMock, times(1)).getEmail();
             verify(collectionMock, times(2)).getDescription();
-            verify(collectionDescriptionMock, times(1)).getName();
             verifyZeroInteractions(permissionsServiceMock);
             verify(collectionMock, never()).find(anyString());
             verify(collectionMock, never()).create(anyString(), anyString());


### PR DESCRIPTION
Initial step of improving logging standards.

### What
Removed `collectionName` log field and update all calls to use `collectionID` instead for consistency - this will make searching the application logs easier as there should always been a collection ID in each message.

### How to review

The app should continue to work the same.

### Who can review

@jondewijones @mikeAdamss @janderson2 
