### PR TITLE
removed jackson databind dependency as should be supplied by dp-logge…

### DIFF
--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -57,13 +57,6 @@
             <artifactId>zebedee-reader</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- File upload -->
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Incorrect `jackson-databind` version causing issues. Removed from pom as it will be added to `dp-logger` (with the correct version).