### PR TITLE
pinned logger version to prevent breakages...

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
@@ -2,15 +2,12 @@ package com.github.onsdigital.zebedee;
 
 import com.github.davidcarboni.restolino.framework.Startup;
 import com.github.onsdigital.logging.v2.DPLogger;
-import com.github.onsdigital.logging.v2.config.Config;
-import com.github.onsdigital.logging.v2.config.Builder;
-import com.github.onsdigital.logging.v2.serializer.JacksonLogSerialiser;
+import com.github.onsdigital.logging.v2.config.nop.NopConfig;
 import com.github.onsdigital.zebedee.api.Root;
 import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
 import com.github.onsdigital.zebedee.model.ZebedeeCollectionReaderFactory;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDaoFactory;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
-import org.slf4j.LoggerFactory;
 
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logDebug;
 import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
@@ -19,15 +16,10 @@ import static com.github.onsdigital.zebedee.logging.ZebedeeLogBuilder.logInfo;
  * Created by bren on 31/07/15.
  */
 public class Init implements Startup {
+
     @Override
     public void init() {
-        Config config = new Builder()
-                .logger(LoggerFactory.getLogger("com.zebedee.app"))
-                .serialiser(new JacksonLogSerialiser())
-                .dataNamespace("zebedee.data")
-                .create();
-        DPLogger.init(config);
-
+        DPLogger.init(new NopConfig());
         logInfo("inside CMS INIT").log();
 
         logInfo("loading CMS feature flags").log();

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/LoggingTestHelper.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/LoggingTestHelper.java
@@ -1,10 +1,7 @@
 package com.github.onsdigital.zebedee;
 
 import com.github.onsdigital.logging.v2.DPLogger;
-import com.github.onsdigital.logging.v2.config.Config;
-import com.github.onsdigital.logging.v2.config.Builder;
-import com.github.onsdigital.logging.v2.serializer.JacksonLogSerialiser;
-import org.slf4j.LoggerFactory;
+import com.github.onsdigital.logging.v2.config.nop.NopConfig;
 
 public class LoggingTestHelper {
 
@@ -12,13 +9,6 @@ public class LoggingTestHelper {
     }
 
     public static void initDPLogger(Class c) {
-
-        Config loggerConfigMock = new Builder()
-                .logger(LoggerFactory.getLogger("com.zebedee.app"))
-                .serialiser(new JacksonLogSerialiser())
-                .dataNamespace("zebedee.data")
-                .create();
-
-        DPLogger.init(loggerConfigMock);
+        DPLogger.init(new NopConfig());
     }
 }

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -90,8 +90,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>
-            <!--<version>master-SNAPSHOT</version>-->
-            <version>master-SNAPSHOT</version>
+            <version>master-60d8cbfea9-1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### What
Pinned `dp-logger` version to prevent future updates breaking zebedee. Updated config to use NOP logger impl until it is ready to be turned on.
