### PR TITLE
initial changes to prevent orphaned collections encryption keys being…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersService.java
@@ -5,12 +5,15 @@ import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.Credentials;
+import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Interface defining User management functions.
@@ -46,6 +49,18 @@ public interface UsersService {
      * @throws BadRequestException
      */
     void removeStaleCollectionKeys(String userEmail) throws IOException, NotFoundException, BadRequestException;
+
+    /**
+     *
+     * @param collectionMap
+     * @param orphanedCollections
+     * @param userEmail
+     * @throws IOException
+     * @throws NotFoundException
+     * @throws BadRequestException
+     */
+    void removeStaleCollectionKeys(Map<String, Collection> collectionMap, List<String> orphanedCollections,
+                                   String userEmail) throws IOException, NotFoundException, BadRequestException;
 
     /**
      * Add a collection key to a {@link User#keyring}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
@@ -261,20 +261,18 @@ public class UsersServiceImpl implements UsersService {
 
             if (user.keyring() != null) {
                 Map<String, Collection> collectionMap = collections.mapByID();
+                List<String> orphanedCollections = collections.listOrphaned();
 
                 List<String> keysToRemove = user.keyring()
                         .list()
                         .stream()
-                        .filter(key -> {
-                            if (applicationKeys.containsKey(key)) {
-                                return false;
-                            }
-                            return !collectionMap.containsKey(key);
-                        }).collect(Collectors.toList());
+                        .filter(key -> isStale(key, collectionMap, orphanedCollections, userEmail))
+                        .collect(Collectors.toList());
+
 
                 keysToRemove.stream().forEach(staleKey -> {
                     info().data("user", userEmail)
-                            .data("collectionId", staleKey)
+                            .data("collection_id", staleKey)
                             .log(REMOVING_STALE_KEY_LOG_MSG);
                     user.keyring().remove(staleKey);
                 });
@@ -288,6 +286,49 @@ public class UsersServiceImpl implements UsersService {
         }
     }
 
+    @Override
+    public void removeStaleCollectionKeys(Map<String, Collection> collectionMap, List<String> orphanedCollections,
+                                          String userEmail) throws IOException, NotFoundException, BadRequestException {
+        lock.lock();
+        try {
+            User user = getUserByEmail(userEmail);
+
+            if (user.keyring() != null) {
+                List<String> keysToRemove = user.keyring()
+                        .list()
+                        .stream()
+                        .filter(key -> isStale(key, collectionMap, orphanedCollections, userEmail))
+                        .collect(Collectors.toList());
+
+
+                keysToRemove.stream().forEach(staleKey -> {
+                    info().data("user", userEmail)
+                            .data("collection_id", staleKey)
+                            .log(REMOVING_STALE_KEY_LOG_MSG);
+                    user.keyring().remove(staleKey);
+                });
+
+                if (!keysToRemove.isEmpty()) {
+                    update(user, user, user.getLastAdmin());
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean isStale(String key, Map<String, Collection> collectionMap, List<String> orphanedCollections,
+                            String userEmail) {
+        if (applicationKeys.containsKey(key)) {
+            return false;
+        }
+
+        String collectionName = key.split("-")[0];
+        if (orphanedCollections.contains(collectionName)) {
+            return false;
+        }
+        return !collectionMap.containsKey(key);
+    }
 
     @Override
     public User removeKeyFromKeyring(String email, String keyIdentifier) throws IOException {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/ReaderInit.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/ReaderInit.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.Logger;
 import com.github.onsdigital.logging.v2.LoggerImpl;
 import com.github.onsdigital.logging.v2.LoggingException;
+import com.github.onsdigital.logging.v2.UncheckedLoggingException;
 import com.github.onsdigital.logging.v2.config.Builder;
 import com.github.onsdigital.logging.v2.serializer.JacksonLogSerialiser;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
@@ -31,19 +32,24 @@ public class ReaderInit implements Startup {
 
     @Override
     public void init() {
-        LogSerialiser serialiser = getLogSerialiser();
-        LogStore store = new MDCLogStore(serialiser);
-        Logger logger = new LoggerImpl("zebedee");
-
         try {
-            DPLogger.init(new Builder()
-                    .serialiser(serialiser)
-                    .logStore(store)
-                    .logger(logger)
-                    .create());
-        } catch (LoggingException ex) {
-            System.err.println(ex);
-            System.exit(1);
+            DPLogger.logConfig();
+        } catch (UncheckedLoggingException e) {
+            // no logger is configured so create one.
+            LogSerialiser serialiser = getLogSerialiser();
+            LogStore store = new MDCLogStore(serialiser);
+            Logger logger = new LoggerImpl("zebedee");
+
+            try {
+                DPLogger.init(new Builder()
+                        .serialiser(serialiser)
+                        .logStore(store)
+                        .logger(logger)
+                        .create());
+            } catch (LoggingException ex) {
+                System.err.println(ex);
+                System.exit(1);
+            }
         }
 
         info().log("loading zebedee reader feature flags");

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
@@ -116,7 +116,6 @@ class PageTypeResolver implements JsonDeserializer<Page> {
                 String className = contentClass.getSimpleName();
                 boolean _abstract = Modifier.isAbstract(contentClass.getModifiers());
                 if (_abstract) {
-                    info().data("type", className).log("Skipping registering abstract content");
                     continue;
                 }
 


### PR DESCRIPTION
# DO NOT MERGE

Prevent orphaned collection encryption keys from being removed from user key rings.

An *Orphaned collection* is where the collection `.json` file is missing but the collection directory still exists.

Currently on Zebedee start up or user login collections in this state have their encryption keys removed user keyrings. Once the key is gone an encrypted collection it can never be recovered.

This experimental change  identifies such collections and ensures their encryption keys are retained. This gives us to potentially rescue a broken collection.