### PR TITLE
Release/1.17.0

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
@@ -340,7 +340,7 @@ public class Page {
 
     private boolean execCreationHook(com.github.onsdigital.zebedee.content.page.base.Page page, String uri,
                                      Collection collection, Session session) {
-        info().data("path", uri).data("collectionId", collection).data("user", session.getEmail())
+        info().data("path", uri).data("collectionId", collection.getDescription().getId()).data("user", session.getEmail())
                 .log("page delete endpoint: executing PageCreationHook");
         try {
             pageCreationHook.get().onPageUpdated(page, uri);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/cmd/Permissions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/cmd/Permissions.java
@@ -1,0 +1,153 @@
+package com.github.onsdigital.zebedee.api.cmd;
+
+import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.zebedee.authorisation.AuthorisationService;
+import com.github.onsdigital.zebedee.authorisation.AuthorisationServiceImpl;
+import com.github.onsdigital.zebedee.authorisation.DatasetPermissions;
+import com.github.onsdigital.zebedee.authorisation.DatasetPermissionsException;
+import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
+import com.github.onsdigital.zebedee.json.response.Error;
+import com.github.onsdigital.zebedee.util.HttpResponseWriter;
+import com.github.onsdigital.zebedee.util.JsonUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import java.io.IOException;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
+
+@Api
+public class Permissions {
+
+    static final String DATASET_ID_PARAM = "dataset_id";
+    static final String COLLECTION_ID_PARAM = "collection_id";
+    static final String SERVICE_AUTH_HEADER = "Authorization";
+    static final String FLORENCE_AUTH_HEATHER = "X-Florence-Token";
+    static final String DATASET_ID_MISSING = "dataset_id param required but not found";
+    static final String COLLECTION_ID_MISSING = "collection_id param required but not found";
+    static final String BREARER_PREFIX = "Bearer ";
+
+    private static AuthorisationService authorisationService;
+
+    private boolean enabled = false;
+    private HttpResponseWriter httpResponseWriter;
+
+    /**
+     * Contruct the permissions endpoint with the default values.
+     */
+    public Permissions() {
+        this(cmsFeatureFlags().isEnableDatasetImport(),
+                getAuthorisationService(),
+                (req, body, status) -> JsonUtils.writeResponse(req, body, status));
+    }
+
+    /**
+     * Construct a new Permissions endpoint.
+     *
+     * @param enabled              true enables the endpoint, false all request valid or invaild will return 404.
+     * @param authorisationService the authorisation service to use.
+     * @param responseWriter       the http reponse writer impl to use.
+     */
+    public Permissions(boolean enabled,
+                       AuthorisationService authorisationService,
+                       HttpResponseWriter responseWriter) {
+        this.enabled = enabled;
+        this.authorisationService = authorisationService;
+        this.httpResponseWriter = responseWriter;
+    }
+
+    @GET
+    public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!enabled) {
+            info().data("feature_flag", CMSFeatureFlags.ENABLE_DATASET_IMPORT)
+                    .log("permissions api endpoint reqiures CMD feature to be enabled request will not be processed");
+            writeResponse(response, null, SC_NOT_FOUND);
+            return;
+        }
+
+        try {
+            DatasetPermissions permissions = getPermissions(request, response);
+            writeResponse(response, permissions, SC_OK);
+        } catch (DatasetPermissionsException ex) {
+            error().exception(ex).log("error getting dataset permissions");
+            writeResponse(response, new Error(ex.getMessage()), ex.statusCode);
+        } catch (IOException ex) {
+            error().exception(ex).log("error getting dataset permissions");
+            writeResponse(response, null, SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    DatasetPermissions getPermissions(HttpServletRequest request, HttpServletResponse response)
+            throws DatasetPermissionsException {
+
+        String sessionID = request.getHeader(FLORENCE_AUTH_HEATHER);
+        String serviceToken = request.getHeader(SERVICE_AUTH_HEADER);
+
+        if (isEmpty(sessionID) && isEmpty(serviceToken)) {
+            info().log("invalid permissions request expected user or service auth token but none found");
+            throw new DatasetPermissionsException("invalid request", SC_BAD_REQUEST);
+        }
+
+        if (isNotEmpty(sessionID)) {
+            return getUserPermissions(request, response, sessionID);
+        }
+
+        return getServicePermissions(request, response, serviceToken);
+    }
+
+    DatasetPermissions getUserPermissions(HttpServletRequest request, HttpServletResponse response,
+                                          String sessionID)
+            throws DatasetPermissionsException {
+        info().log("handling permissions request for user");
+
+        String datasetID = request.getParameter(DATASET_ID_PARAM);
+        if (isEmpty(datasetID)) {
+            info().data("param", DATASET_ID_PARAM)
+                    .log("invalid user permissions request mandatory parameter not provided");
+            throw new DatasetPermissionsException(DATASET_ID_MISSING, SC_BAD_REQUEST);
+        }
+
+        String collectionID = request.getParameter(COLLECTION_ID_PARAM);
+        if (isEmpty(collectionID)) {
+            info().data("param", COLLECTION_ID_PARAM)
+                    .log("invalid user permissions request mandatory parameter not provided");
+            throw new DatasetPermissionsException(COLLECTION_ID_MISSING, SC_BAD_REQUEST);
+        }
+
+        return authorisationService.getUserPermissions(sessionID, datasetID, collectionID);
+    }
+
+    DatasetPermissions getServicePermissions(HttpServletRequest request, HttpServletResponse response,
+                                             String serviceToken) throws DatasetPermissionsException {
+        info().log("handling permissions request for service");
+        if (serviceToken.startsWith(BREARER_PREFIX)) {
+            serviceToken = serviceToken.replaceFirst(BREARER_PREFIX, "");
+        }
+        return authorisationService.getServicePermissions(serviceToken);
+    }
+
+    void writeResponse(HttpServletResponse response, Object entity, int status) throws IOException {
+        try {
+            httpResponseWriter.writeJSONResponse(response, entity, status);
+        } catch (Exception ex) {
+            error().exception(ex).log("error writing user body to response");
+            httpResponseWriter.writeJSONResponse(response, null, SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private static AuthorisationService getAuthorisationService() {
+        if (authorisationService == null) {
+            authorisationService = new AuthorisationServiceImpl();
+        }
+        return authorisationService;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/AuthorisationService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/AuthorisationService.java
@@ -14,4 +14,17 @@ public interface AuthorisationService {
      * @throws UserIdentityException if there is any problem determining the user identity.
      */
     UserIdentity identifyUser(String sessionID) throws UserIdentityException;
+
+    /**
+     * Get the user's permissions for the specified dataset.
+     *
+     * @param sessionID    the requesting user's session ID.
+     * @param datasetID    the dataset to get the permissions for.
+     * @param collectionID the collection ID the dataset is part of.
+     * @return {@link DatasetPermissions}
+     * @throws DatasetPermissionsException a problem getting the permissions.
+     */
+    DatasetPermissions getUserPermissions(String sessionID, String datasetID, String collectionID) throws DatasetPermissionsException;
+
+    DatasetPermissions getServicePermissions(String serviceToken) throws DatasetPermissionsException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissionType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissionType.java
@@ -1,0 +1,18 @@
+package com.github.onsdigital.zebedee.authorisation;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum DatasetPermissionType {
+
+    @SerializedName("CREATE")
+    CREATE,
+
+    @SerializedName("READ")
+    READ,
+
+    @SerializedName("UPDATE")
+    UPDATE,
+
+    @SerializedName("DELETE")
+    DELETE,
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissions.java
@@ -1,0 +1,40 @@
+package com.github.onsdigital.zebedee.authorisation;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class DatasetPermissions {
+
+    private Set<DatasetPermissionType> permissions;
+
+    public DatasetPermissions() {
+        this.permissions = new HashSet<>();
+    }
+
+    public DatasetPermissions(DatasetPermissionType... grantedPermissions) {
+        this.permissions = new LinkedHashSet<>();
+        permit(grantedPermissions);
+    }
+
+    public Set<DatasetPermissionType> getPermissions() {
+        return permissions;
+    }
+
+    public DatasetPermissions setPermissions(Set<DatasetPermissionType> permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+
+    public DatasetPermissions grantPermission(DatasetPermissionType permission) {
+        this.permissions.add(permission);
+        return this;
+    }
+
+    public DatasetPermissions permit(DatasetPermissionType... permissions) {
+        for (DatasetPermissionType p : permissions) {
+            this.permissions.add(p);
+        }
+        return this;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissionsException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/DatasetPermissionsException.java
@@ -1,0 +1,10 @@
+package com.github.onsdigital.zebedee.authorisation;
+
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+
+public class DatasetPermissionsException extends ZebedeeException {
+
+    public DatasetPermissionsException(String message, int responseCode) {
+        super(message, responseCode);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
@@ -10,7 +10,7 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
  */
 public class CMSFeatureFlags {
 
-    private static final String ENABLE_DATASET_IMPORT = "ENABLE_DATASET_IMPORT";
+    public static final String ENABLE_DATASET_IMPORT = "ENABLE_DATASET_IMPORT";
 
     /**
      * Singleton instance

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
@@ -3,7 +3,15 @@ package com.github.onsdigital.zebedee.filters;
 import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.davidcarboni.restolino.helpers.Path;
 import com.github.davidcarboni.restolino.json.Serialiser;
-import com.github.onsdigital.zebedee.api.*;
+import com.github.onsdigital.zebedee.api.ClickEventLog;
+import com.github.onsdigital.zebedee.api.CsdbKey;
+import com.github.onsdigital.zebedee.api.CsdbNotify;
+import com.github.onsdigital.zebedee.api.Identity;
+import com.github.onsdigital.zebedee.api.Login;
+import com.github.onsdigital.zebedee.api.Password;
+import com.github.onsdigital.zebedee.api.Ping;
+import com.github.onsdigital.zebedee.api.Root;
+import com.github.onsdigital.zebedee.api.cmd.Permissions;
 import com.github.onsdigital.zebedee.search.api.endpoint.ReIndex;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.google.common.collect.ImmutableList;
@@ -16,77 +24,78 @@ import java.io.IOException;
 
 public class AuthenticationFilter implements Filter {
 
-	/**
-	 * Endpoints that do not require authorisation.
-	 */
-	private static final ImmutableList<Class> NO_AUTH_REQUIRED = new ImmutableList.Builder<Class>()
-			.add(Login.class)
-			.add(Password.class)
-			.add(CsdbKey.class)
-			.add(CsdbNotify.class)
-			.add(ReIndex.class)
-			.add(Ping.class)
-			.add(ClickEventLog.class)
-			.add(Identity.class)
-			.build();
+    /**
+     * Endpoints that do not require authorisation.
+     */
+    private static final ImmutableList<Class> NO_AUTH_REQUIRED = new ImmutableList.Builder<Class>()
+            .add(Login.class)
+            .add(Password.class)
+            .add(CsdbKey.class)
+            .add(CsdbNotify.class)
+            .add(ReIndex.class)
+            .add(Ping.class)
+            .add(ClickEventLog.class)
+            .add(Identity.class)
+            .add(Permissions.class)
+            .build();
 
-	/**
-	 * This filter protects all resources except {@link com.github.onsdigital.zebedee.api.Login}.
-	 *
-	 * @param request
-	 * @param response
-	 * @return <ul>
-	 * <li>If the first path segment is login, true.</li>
-	 * <li>Otherwise, if a {@link Session} can be found for the login token, true.</li>
-	 * <li>Otherwise false.</li>
-	 * </ul>
-	 */
-	@Override
-	public boolean filter(HttpServletRequest request, HttpServletResponse response) {
+    /**
+     * This filter protects all resources except {@link com.github.onsdigital.zebedee.api.Login}.
+     *
+     * @param request
+     * @param response
+     * @return <ul>
+     * <li>If the first path segment is login, true.</li>
+     * <li>Otherwise, if a {@link Session} can be found for the login token, true.</li>
+     * <li>Otherwise false.</li>
+     * </ul>
+     */
+    @Override
+    public boolean filter(HttpServletRequest request, HttpServletResponse response) {
 
-		// Pass through OPTIONS request without authentication for cross-origin preflight requests:
-		if (StringUtils.equalsIgnoreCase("OPTIONS", request.getMethod())) {
-			return true;
-		}
+        // Pass through OPTIONS request without authentication for cross-origin preflight requests:
+        if (StringUtils.equalsIgnoreCase("OPTIONS", request.getMethod())) {
+            return true;
+        }
 
-		// Pass through without authentication for login requests:
-		// Password requests check
-		Path path = Path.newInstance(request);
-		if (noAuthorisationRequired(path)) {
-			return true;
-		}
+        // Pass through without authentication for login requests:
+        // Password requests check
+        Path path = Path.newInstance(request);
+        if (noAuthorisationRequired(path)) {
+            return true;
+        }
 
-		// Check all other requests:
-		boolean result = false;
-		try {
-			Session session = Root.zebedee.getSessionsService().get(request);
-			if (session == null) {
-				forbidden(response);
-			} else {
-				result = true;
-			}
-		} catch (IOException e) {
-			error(response);
-		}
-		return result;
-	}
+        // Check all other requests:
+        boolean result = false;
+        try {
+            Session session = Root.zebedee.getSessionsService().get(request);
+            if (session == null) {
+                forbidden(response);
+            } else {
+                result = true;
+            }
+        } catch (IOException e) {
+            error(response);
+        }
+        return result;
+    }
 
-	private void forbidden(HttpServletResponse response) throws IOException {
-		response.setContentType("application/json");
-		response.setStatus(HttpStatus.UNAUTHORIZED_401);
-		Serialiser.serialise(response, "Please log in");
-	}
+    private void forbidden(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json");
+        response.setStatus(HttpStatus.UNAUTHORIZED_401);
+        Serialiser.serialise(response, "Please log in");
+    }
 
-	private void error(HttpServletResponse response) {
-		response.setContentType("application/json");
-		response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
-	}
+    private void error(HttpServletResponse response) {
+        response.setContentType("application/json");
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    }
 
-	public boolean noAuthorisationRequired(Path path) {
-		return NO_AUTH_REQUIRED
-				.stream()
-				.filter(clazzName -> clazzName.getSimpleName().toLowerCase().equals(path.lastSegment().toLowerCase()))
-				.findFirst()
-				.isPresent();
-	}
+    public boolean noAuthorisationRequired(Path path) {
+        return NO_AUTH_REQUIRED
+                .stream()
+                .filter(clazzName -> clazzName.getSimpleName().toLowerCase().equals(path.lastSegment().toLowerCase()))
+                .findFirst()
+                .isPresent();
+    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/response/Error.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/response/Error.java
@@ -2,6 +2,8 @@ package com.github.onsdigital.zebedee.json.response;
 
 import com.github.onsdigital.zebedee.content.util.ContentUtil;
 import com.github.onsdigital.zebedee.json.JSONable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Created by dave on 07/03/2018.
@@ -21,5 +23,25 @@ public class Error implements JSONable {
     @Override
     public String toJSON() {
         return ContentUtil.serialise(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Error error = (Error) o;
+
+        return new EqualsBuilder()
+                .append(getMessage(), error.getMessage())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getMessage())
+                .toHashCode();
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
@@ -1,0 +1,100 @@
+package com.github.onsdigital.zebedee.logging;
+
+import com.github.onsdigital.logging.v2.DPLogger;
+import com.github.onsdigital.logging.v2.event.BaseEvent;
+import com.github.onsdigital.logging.v2.event.Severity;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.session.model.Session;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.github.onsdigital.logging.v2.DPLogger.logConfig;
+
+public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
+
+    public static CMSLogEvent warn() {
+        return new CMSLogEvent(logConfig().getNamespace(), Severity.WARN);
+    }
+
+    public static CMSLogEvent info() {
+        return new CMSLogEvent(logConfig().getNamespace(), Severity.INFO);
+    }
+
+    public static CMSLogEvent error() {
+        return new CMSLogEvent(logConfig().getNamespace(), Severity.ERROR);
+    }
+
+    private CMSLogEvent(String namespace, Severity severity) {
+        super(namespace, severity, DPLogger.logConfig().getLogStore());
+    }
+
+    public CMSLogEvent user(Session session) {
+        if (session != null) {
+            user(session.getEmail());
+        }
+        return this;
+    }
+
+    public CMSLogEvent sessionID(Session session) {
+        if (session != null) {
+            sessionID(session.getId());
+        }
+        return this;
+    }
+
+    public CMSLogEvent sessionID(String sessionID) {
+        if (StringUtils.isNotEmpty(sessionID)) {
+            data("session_id", sessionID);
+        }
+        return this;
+    }
+
+    public CMSLogEvent user(String email) {
+        if (StringUtils.isNotEmpty(email)) {
+            data("user", email);
+        }
+        return this;
+    }
+
+    public CMSLogEvent collectionID(CollectionDescription desc) {
+        if (desc != null) {
+            collectionID(desc.getId());
+        }
+        return this;
+    }
+
+    public CMSLogEvent collectionID(Collection collection) {
+        if (collection != null && collection.getDescription() != null) {
+            collectionID(collection.getDescription().getId());
+        }
+        return this;
+    }
+
+    public CMSLogEvent collectionID(String collectionID) {
+        if (StringUtils.isNotEmpty(collectionID)) {
+            data("collection_id", collectionID);
+        }
+        return this;
+    }
+
+    public CMSLogEvent datasetID(String datasetID) {
+        if (StringUtils.isNotEmpty(datasetID)) {
+            data("dataset_id", datasetID);
+        }
+        return this;
+    }
+
+    public CMSLogEvent serviceAccountID(String serviceAccountID) {
+        if (StringUtils.isNotEmpty(serviceAccountID)) {
+            data("service_account_id", serviceAccountID);
+        }
+        return this;
+    }
+
+    public CMSLogEvent serviceAccountToken(String serviceAccountToken) {
+        if (StringUtils.isNotEmpty(serviceAccountToken)) {
+            data("service_account_token", serviceAccountToken);
+        }
+        return this;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -290,9 +290,9 @@ public class ApproveTask implements Callable<Boolean> {
         ReleasePopulator.populateQuietly(collection, collectionReader, collectionWriter, collectionContent);
     }
 
-    public void generatePdfFiles(Iterable<ContentDetail> collectionContent) {
+    public void generatePdfFiles(List<ContentDetail> collectionContent) throws ZebedeeException {
         CollectionPdfGenerator pdfGenerator = new CollectionPdfGenerator(new BabbagePdfService(session, collection));
-        pdfGenerator.generatePdfsInCollection(collectionWriter, collectionContent);
+        pdfGenerator.generatePDFsForCollection(collection, collectionWriter, collectionContent);
     }
 
     private static ContentDetailResolver getDefaultContentDetailResolver() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -1,33 +1,60 @@
 package com.github.onsdigital.zebedee.model.approval.tasks;
 
 import com.github.onsdigital.zebedee.content.page.base.PageType;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ContentDetail;
+import com.github.onsdigital.zebedee.logging.CMSLogEvent;
+import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.CollectionWriter;
+import com.github.onsdigital.zebedee.model.ContentWriter;
 import com.github.onsdigital.zebedee.service.PdfService;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.article;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.bulletin;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.compendium_chapter;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.compendium_landing_page;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.static_methodology;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
+import static java.text.MessageFormat.format;
 
 /**
  * Generates a PDF for each page in a collection that needs one.
  */
 public class CollectionPdfGenerator {
 
-    private static final List<PageType> pagesWithPdf;
+    private static final List<PageType> PDF_GENERATING_PAGES;
+    private static final ExecutorService EXECUTOR_SERVICE;
 
     static {
-        pagesWithPdf = new ArrayList<>();
-        pagesWithPdf.add(PageType.article);
-        pagesWithPdf.add(PageType.bulletin);
-        pagesWithPdf.add(PageType.compendium_landing_page);
-        pagesWithPdf.add(PageType.compendium_chapter);
-        pagesWithPdf.add(PageType.static_methodology);
+        // The PDF generation process is done with the entire page content in memory. This can potentially be very large
+        // so it is recommended to use a small pool to reduce the chances of running out of heap space.
+        EXECUTOR_SERVICE = Executors.newFixedThreadPool(5); // TODO should this be configurable?
+
+        PDF_GENERATING_PAGES = new ArrayList<PageType>() {{
+            add(article);
+            add(bulletin);
+            add(compendium_landing_page);
+            add(compendium_chapter);
+            add(static_methodology);
+        }};
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> closeExecutorService()));
     }
 
     private PdfService pdfService;
+
+    private Predicate<ContentDetail> isPDFPage = (c -> PDF_GENERATING_PAGES.contains(PageType.valueOf(c.type)));
 
     /**
      * Create a new instance to use the provided PdfService.
@@ -38,19 +65,115 @@ public class CollectionPdfGenerator {
         this.pdfService = pdfService;
     }
 
-    public void generatePdfsInCollection(CollectionWriter collectionWriter, Iterable<ContentDetail> collectionContent) {
+    /**
+     * @param collection
+     * @param collectionWriter
+     * @param collectionContent
+     * @throws ZebedeeException
+     */
+    public void generatePDFsForCollection(Collection collection, CollectionWriter collectionWriter,
+                                          List<ContentDetail> collectionContent) throws ZebedeeException {
+        List<ContentDetail> filtered = filterPDFContent(collectionContent);
 
-        for (ContentDetail contentDetail : collectionContent) {
-            boolean pdfShouldBeAdded = pagesWithPdf.contains(PageType.valueOf(contentDetail.type));
+        int index = 1;
+        for (ContentDetail detail : filtered) {
+            generatePDFForContent(collection, collectionWriter.getReviewed(), detail.uri);
 
-            if (pdfShouldBeAdded) {
-                String pdfUri = null;
-                try {
-                    pdfService.generatePdf(collectionWriter.getReviewed(), contentDetail.uri);
-                } catch (IOException e) {
-                    error().data("uri", pdfUri).logException(e, "Error while generating collection PDF");
-                }
-            }
+            warn().collectionID(collection)
+                    .data("uri", detail.uri)
+                    .log(format("successfully generated collection content PDF {0}/{1}", index, filtered.size()));
+            index++;
+        }
+
+        warn().collectionID(collection)
+                .log(format("successfully generated {0}/{0} PDFs for collection content", filtered.size()));
+    }
+
+    /**
+     * Generate PDF's for pages that require them using a thread pool to allow concurrent throughput.
+     *
+     * @param collection        the collection the task is being invoked for.
+     * @param collectionWriter  a CollectionWriter to use to write the generated PDF files back to the the collection
+     *                          directories.
+     * @param collectionContent the entire content of the collection.
+     * @throws ZebedeeException PDF generation was unsuccessful.
+     */
+    public void generatePDFsForCollectionAsyc(Collection collection, CollectionWriter collectionWriter,
+                                              List<ContentDetail> collectionContent) throws ZebedeeException {
+        ContentWriter writer = collectionWriter.getReviewed();
+        List<Callable<Boolean>> tasks = createGeneratePdfTasks(filterPDFContent(collectionContent), writer, collection);
+
+        invokeAllAndCheckResults(tasks, collection);
+    }
+
+    private List<ContentDetail> filterPDFContent(List<ContentDetail> content) {
+        return content.stream()
+                .filter(isPDFPage)
+                .collect(Collectors.toList());
+    }
+
+    private List<Callable<Boolean>> createGeneratePdfTasks(List<ContentDetail> filtered, ContentWriter writer,
+                                                           Collection collection) {
+        // Create a callable for each of the filtered content items.
+        List<Callable<Boolean>> tasks = filtered
+                .stream()
+                .map(c -> newGeneratePDFCallable(writer, collection, c.uri))
+                .collect(Collectors.toList());
+
+        // log some useful info.
+        info().collectionID(collection)
+                .data("uris", filtered
+                        .stream()
+                        .map(c -> c.uri)
+                        .collect(Collectors.toList()))
+                .log("successfully created generated PDF tasks for collection content");
+
+        return tasks;
+    }
+
+    private void invokeAllAndCheckResults(List<Callable<Boolean>> jobs, Collection collection)
+            throws ZebedeeException {
+        try {
+            List<Future<Boolean>> results = EXECUTOR_SERVICE.invokeAll(jobs);
+            checkFutures(collection, results);
+        } catch (ZebedeeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new InternalServerError("error generating collection PDF content", ex);
         }
     }
+
+    private boolean generatePDFForContent(Collection collection, ContentWriter writer, String uri)
+            throws InternalServerError {
+        CMSLogEvent e = info().data("uri", uri).collectionID(collection);
+        try {
+            pdfService.generatePdf(writer, uri);
+            e.log("content PDF generated successfully");
+            return true;
+        } catch (Exception ex) {
+            e.exception(ex).log("error generating PDF content");
+            throw new InternalServerError("error generating PDF content", ex);
+        }
+    }
+
+    private Callable<Boolean> newGeneratePDFCallable(ContentWriter writer, Collection collection, String uri) {
+        return () -> generatePDFForContent(collection, writer, uri);
+    }
+
+    private void checkFutures(Collection collection, List<Future<Boolean>> results) throws ZebedeeException {
+        info().collectionID(collection).log("checking generate PDF future results");
+        try {
+            for (Future<Boolean> r : results) {
+                r.get();
+            }
+        } catch (Exception ex) {
+            throw new InternalServerError("checking generate PDF future returned an error", ex);
+        }
+    }
+
+    private static void closeExecutorService() {
+        info().log("shutting down CollectionPdfGenerator.EXECUTOR_SERVICE");
+        EXECUTOR_SERVICE.shutdown();
+    }
+
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
@@ -74,10 +74,10 @@ public interface PermissionsService {
     /**
      * Grant a {@link User} admin permissions.
      *
-     * @param email   the email of the user to grant the permission to.
+     * @param email   the email of the user to permit the permission to.
      * @param session the {@link Session} of the user granting the permission.
      * @throws IOException           unexpected error granting the permission.
-     * @throws UnauthorizedException user does not have the required permissions to grant admin permissions.
+     * @throws UnauthorizedException user does not have the required permissions to permit admin permissions.
      */
     void addAdministrator(String email, Session session) throws IOException, UnauthorizedException;
 
@@ -142,7 +142,7 @@ public interface PermissionsService {
     /**
      * Grant editor permission to a user.
      *
-     * @param email   the email of the user to grant the permission to.
+     * @param email   the email of the user to permit the permission to.
      * @param session the {@link Session} of the {@link User} granting the permissison.
      * @throws IOException           unexpected error while granting the permission.
      * @throws UnauthorizedException the user granting the permission is not authorised to do so.
@@ -197,7 +197,7 @@ public interface PermissionsService {
      * Grant view permissions to a {@link Team}.
      *
      * @param collectionDescription the {@link CollectionDescription} of the {@link Collection} in question.
-     * @param team                  the {@link Team} to grant view permission to.
+     * @param team                  the {@link Team} to permit view permission to.
      * @param session               the {@link Session} of the user granting the permission.
      * @throws IOException      unexpected error while checking permissions.
      * @throws ZebedeeException unexpected error while checking permissions.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
@@ -401,7 +401,7 @@ public class PermissionsServiceImpl implements PermissionsService {
      *
      * @param collectionDescription The collection to give the team access to.
      * @param team                  The team to be granted access.
-     * @param session               Only editors can grant a team access to a collection.
+     * @param session               Only editors can permit a team access to a collection.
      * @throws IOException If a filesystem error occurs.
      */
     @Override

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/BabbagePdfService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/BabbagePdfService.java
@@ -1,10 +1,9 @@
 package com.github.onsdigital.zebedee.service;
 
 import com.github.onsdigital.zebedee.configuration.Configuration;
-import com.github.onsdigital.zebedee.exceptions.BadRequestException;
-import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.ContentWriter;
+import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.util.URIUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -15,6 +14,7 @@ import java.io.IOException;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static java.text.MessageFormat.format;
 
 /**
  * Render PDF output for a given URI using babbage.
@@ -57,14 +57,19 @@ public class BabbagePdfService implements PdfService {
 
             try (CloseableHttpResponse response = client.execute(httpGet)) {
 
-                if (response.getStatusLine().getStatusCode() != 200) {
-                    throw new IOException("Failed to generate PDF for URI " + uri +
-                            ". Response: " + response.getStatusLine().getStatusCode() +
-                            " " + response.toString());
+                int status = response.getStatusLine().getStatusCode();
+                if (status != 200) {
+                    String body = response.toString();
+                    error().data("status_code", status)
+                            .data("body", body)
+                            .log("generate PDF failure");
+
+                    throw new IOException(format("Failed to generate PDF for URI {0}. Response: {1} {2}", uri, status, body));
                 }
                 contentWriter.write(response.getEntity().getContent(), pdfURI);
-            } catch (BadRequestException e) {
+            } catch (Exception e) {
                 error().data("path", pdfURI).logException(e, "Error while generating collection PDF");
+                throw new IOException(e);
             }
         }
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/HttpResponseWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/HttpResponseWriter.java
@@ -1,0 +1,12 @@
+package com.github.onsdigital.zebedee.util;
+
+import com.github.onsdigital.zebedee.json.JSONable;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface HttpResponseWriter {
+
+    void writeJSONResponse(HttpServletResponse response, Object body, int status) throws IOException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/JsonUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/JsonUtils.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.util;
 
 import com.github.davidcarboni.httpino.Serialiser;
 import com.github.onsdigital.zebedee.json.JSONable;
+import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import javax.servlet.http.HttpServletResponse;
@@ -9,11 +10,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 public class JsonUtils {
+
+    private static Gson GSON = new Gson();
 
     public static boolean isValidJson(InputStream inputStream) {
         try {
@@ -30,6 +32,20 @@ public class JsonUtils {
             response.setContentType(APPLICATION_JSON);
             response.setCharacterEncoding(StandardCharsets.UTF_8.name());
             response.getWriter().write(body.toJSON());
+        } catch (IOException e) {
+            error().logException(e, "error while attempting to write userIdentity to HTTP response");
+            throw e;
+        }
+    }
+
+    public static void writeResponse(HttpServletResponse response, Object body, int status) throws IOException {
+        try {
+            response.setStatus(status);
+            response.setContentType(APPLICATION_JSON);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            if (body != null) {
+                response.getWriter().write(GSON.toJson(body));
+            }
         } catch (IOException e) {
             error().logException(e, "error while attempting to write userIdentity to HTTP response");
             throw e;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/cmd/PermissionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/cmd/PermissionsTest.java
@@ -1,0 +1,298 @@
+package com.github.onsdigital.zebedee.api.cmd;
+
+import com.github.onsdigital.zebedee.authorisation.AuthorisationService;
+import com.github.onsdigital.zebedee.authorisation.DatasetPermissions;
+import com.github.onsdigital.zebedee.authorisation.DatasetPermissionsException;
+import com.github.onsdigital.zebedee.json.response.Error;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.util.HttpResponseWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.COLLECTION_ID_MISSING;
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.COLLECTION_ID_PARAM;
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.DATASET_ID_MISSING;
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.DATASET_ID_PARAM;
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.FLORENCE_AUTH_HEATHER;
+import static com.github.onsdigital.zebedee.api.cmd.Permissions.SERVICE_AUTH_HEADER;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.CREATE;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.DELETE;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.READ;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.UPDATE;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class PermissionsTest {
+
+    @Mock
+    protected HttpServletRequest mockRequest;
+
+    @Mock
+    protected HttpServletResponse mockResponse;
+
+    @Mock
+    private AuthorisationService authorisationService;
+
+    @Mock
+    private HttpResponseWriter httpResponseWriter;
+
+    private DatasetPermissions datasetPermissions;
+
+    @Mock
+    private Session session;
+
+    private Permissions api;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    /**
+     * CMD feature is disabled.
+     * Expected response: Not found.
+     */
+    @Test
+    public void testCMDFeatureDisabled() throws Exception {
+        api = new Permissions(false, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(httpResponseWriter, times(1)).writeJSONResponse(mockResponse, null, SC_NOT_FOUND);
+        verifyNoMoreInteractions(mockRequest, mockResponse, authorisationService);
+    }
+
+    /**
+     * Request does not contain a Florence auth header or a service auth token.
+     * Expected response: Bad Request
+     */
+    @Test
+    public void testGetPermissionNoAuthHeaderOrServiceToken() throws IOException {
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(httpResponseWriter, times(1)).writeJSONResponse(mockResponse, new Error("invalid request"), SC_BAD_REQUEST);
+    }
+
+    /**
+     * Request contains Florence auth header but no dataset_id param.
+     * Expected response: Bad request.
+     */
+    @Test
+    public void testUserRequestNoDatasetID() throws Exception {
+        when(mockRequest.getHeader(FLORENCE_AUTH_HEATHER))
+                .thenReturn("666");
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(mockRequest, times(1)).getHeader(FLORENCE_AUTH_HEATHER);
+        verify(mockRequest, times(1)).getParameter(DATASET_ID_PARAM);
+        verify(httpResponseWriter, times(1)).writeJSONResponse(mockResponse, new Error(DATASET_ID_MISSING), SC_BAD_REQUEST);
+        verifyNoMoreInteractions(mockResponse, authorisationService, httpResponseWriter);
+    }
+
+    /**
+     * Request contains Florence auth header, dataset_id param but no collection_id param.
+     * Expected response: Bad request.
+     */
+    @Test
+    public void testUserRequestNoCollectionID() throws Exception {
+        when(mockRequest.getHeader(FLORENCE_AUTH_HEATHER))
+                .thenReturn("666");
+
+        when(mockRequest.getParameter(DATASET_ID_PARAM))
+                .thenReturn("666");
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(mockRequest, times(1)).getHeader(FLORENCE_AUTH_HEATHER);
+        verify(mockRequest, times(1)).getParameter(DATASET_ID_PARAM);
+        verify(httpResponseWriter, times(1)).writeJSONResponse(mockResponse, new Error(COLLECTION_ID_MISSING), SC_BAD_REQUEST);
+        verifyNoMoreInteractions(mockResponse, authorisationService, httpResponseWriter);
+    }
+
+    /**
+     * Valid request for user dataset permissions. HttpResponseWriter throws an exception.
+     * Expected response: internal server error.
+     */
+    @Test
+    public void testGetUserPermissionsHttpResponseWriterException() throws Exception {
+        datasetPermissions = new DatasetPermissions(READ);
+
+        when(mockRequest.getHeader(FLORENCE_AUTH_HEATHER))
+                .thenReturn("666");
+
+        when(mockRequest.getParameter(DATASET_ID_PARAM))
+                .thenReturn("777");
+
+        when(mockRequest.getParameter(COLLECTION_ID_PARAM))
+                .thenReturn("888");
+
+        when(authorisationService.getUserPermissions("666", "777", "888"))
+                .thenReturn(datasetPermissions);
+
+        ArgumentCaptor<DatasetPermissions> permissionsCaptor = ArgumentCaptor.forClass(DatasetPermissions.class);
+
+        doThrow(new IOException("bang")).when(httpResponseWriter)
+                .writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(200));
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(authorisationService, times(1)).getUserPermissions("666", "777", "888");
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(200));
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), isNull(), eq(500));
+    }
+
+    /**
+     * Valid request for user dataset permissions.
+     * Expected response: status OK, Body: the user's permissions entity.
+     */
+    @Test
+    public void testGetUserPermissionsSuccess() throws Exception {
+        datasetPermissions = new DatasetPermissions(READ);
+
+        when(mockRequest.getHeader(FLORENCE_AUTH_HEATHER))
+                .thenReturn("666");
+
+        when(mockRequest.getParameter(DATASET_ID_PARAM))
+                .thenReturn("777");
+
+        when(mockRequest.getParameter(COLLECTION_ID_PARAM))
+                .thenReturn("888");
+
+        when(authorisationService.getUserPermissions("666", "777", "888"))
+                .thenReturn(datasetPermissions);
+
+        ArgumentCaptor<DatasetPermissions> permissionsCaptor = ArgumentCaptor.forClass(DatasetPermissions.class);
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(authorisationService, times(1)).getUserPermissions("666", "777", "888");
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(200));
+
+        DatasetPermissions actual = permissionsCaptor.getValue();
+        assertThat(actual.getPermissions().size(), equalTo(1));
+        assertTrue("expected READ permission but not found", actual.getPermissions().contains(READ));
+    }
+
+    /**
+     * Valid request for service dataset permissions.
+     * Expected response: status OK, Body: the service's permissions entity.
+     */
+    @Test
+    public void testGetServicePermissionsSuccess() throws Exception {
+        when(mockRequest.getHeader(SERVICE_AUTH_HEADER))
+                .thenReturn("Bearer 666");
+
+        datasetPermissions = new DatasetPermissions(CREATE, READ, UPDATE, DELETE);
+
+        when(authorisationService.getServicePermissions("666"))
+                .thenReturn(datasetPermissions);
+
+        ArgumentCaptor<DatasetPermissions> permissionsCaptor = ArgumentCaptor.forClass(DatasetPermissions.class);
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(authorisationService, times(1)).getServicePermissions("666");
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(200));
+
+        DatasetPermissions actual = permissionsCaptor.getValue();
+        assertThat(actual.getPermissions().size(), equalTo(4));
+        assertTrue("expected CREATE permission but not found", actual.getPermissions().contains(CREATE));
+        assertTrue("expected READ permission but not found", actual.getPermissions().contains(READ));
+        assertTrue("expected UPDATE permission but not found", actual.getPermissions().contains(UPDATE));
+        assertTrue("expected DELETE permission but not found", actual.getPermissions().contains(DELETE));
+    }
+
+    /**
+     * Valid request for service dataset permissions which encounters an unexpected error.
+     * Expected response: status Internal Server Error, Body: "internal server error"
+     */
+    @Test
+    public void testGetServicePermissions_DatasetPermissionsException() throws Exception {
+        when(mockRequest.getHeader(SERVICE_AUTH_HEADER))
+                .thenReturn("666");
+
+        when(authorisationService.getServicePermissions("666"))
+                .thenThrow(new DatasetPermissionsException("internal server error", SC_INTERNAL_SERVER_ERROR));
+
+        ArgumentCaptor<DatasetPermissions> permissionsCaptor = ArgumentCaptor.forClass(DatasetPermissions.class);
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(authorisationService, times(1)).getServicePermissions("666");
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(500));
+
+        assertThat(permissionsCaptor.getValue(), equalTo(new Error("internal server error")));
+    }
+
+    /**
+     * Valid request for user dataset permissions that contains both user and service auth headers. In this case the
+     * the user permissions take precedence over the service.
+     * Expected response: status OK, Body: the user's permissions entity.
+     */
+    @Test
+    public void testGetUserPermissions_userAndServiceHeaders() throws Exception {
+        datasetPermissions = new DatasetPermissions(READ);
+
+        when(mockRequest.getHeader(FLORENCE_AUTH_HEATHER))
+                .thenReturn("666");
+
+        when(mockRequest.getHeader(SERVICE_AUTH_HEADER))
+                .thenReturn("Bearer 999");
+
+        when(mockRequest.getParameter(DATASET_ID_PARAM))
+                .thenReturn("777");
+
+        when(mockRequest.getParameter(COLLECTION_ID_PARAM))
+                .thenReturn("888");
+
+        when(authorisationService.getUserPermissions("666", "777", "888"))
+                .thenReturn(datasetPermissions);
+
+        ArgumentCaptor<DatasetPermissions> permissionsCaptor = ArgumentCaptor.forClass(DatasetPermissions.class);
+
+        api = new Permissions(true, authorisationService, httpResponseWriter);
+
+        api.handle(mockRequest, mockResponse);
+
+        verify(authorisationService, times(1)).getUserPermissions("666", "777", "888");
+        verify(httpResponseWriter, times(1)).writeJSONResponse(eq(mockResponse), permissionsCaptor.capture(), eq(200));
+
+        DatasetPermissions actual = permissionsCaptor.getValue();
+        assertThat(actual.getPermissions().size(), equalTo(1));
+        assertTrue("expected READ permission but not found", actual.getPermissions().contains(READ));
+    }
+
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/authorisation/AuthorisationServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/authorisation/AuthorisationServiceImplTest.java
@@ -1,5 +1,12 @@
 package com.github.onsdigital.zebedee.authorisation;
 
+import com.github.onsdigital.zebedee.json.CollectionDataset;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Collections;
+import com.github.onsdigital.zebedee.model.ServiceAccount;
+import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.SessionsService;
@@ -12,149 +19,720 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.CREATE;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.DELETE;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.READ;
+import static com.github.onsdigital.zebedee.authorisation.DatasetPermissionType.UPDATE;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class AuthorisationServiceImplTest {
 
-	private static final String SESSION_ID = "666";
+    private static final String SESSION_ID = "666";
 
-	@Mock
-	private SessionsService sessionsService;
+    @Mock
+    private SessionsService sessionsService;
 
-	@Mock
-	private UsersService usersService;
+    @Mock
+    private UsersService usersService;
 
-	private ServiceSupplier<SessionsService> sessionServiceSupplier = () -> sessionsService;
-	private ServiceSupplier<UsersService> userServiceSupplier = () -> usersService;
-	private AuthorisationService service;
-	private UserIdentityException notAuthenticatedEx;
-	private UserIdentityException internalServerErrorEx;
-	private UserIdentityException notFoundEx;
-	private Session session;
+    @Mock
+    private Collections collections;
+
+    @Mock
+    private PermissionsService permissionsService;
+
+    @Mock
+    private ServiceStore serviceStore;
+
+    @Mock
+    private Collection collection;
+
+    @Mock
+    private ServiceAccount serviceAccount;
+
+    private ServiceSupplier<SessionsService> sessionServiceSupplier = () -> sessionsService;
+    private ServiceSupplier<UsersService> userServiceSupplier = () -> usersService;
+    private ServiceSupplier<Collections> collectionsSupplier = () -> collections;
+    private ServiceSupplier<PermissionsService> permissionsServiceSupplier = () -> permissionsService;
+    private ServiceSupplier<ServiceStore> serviceStoreSupplier = () -> serviceStore;
+
+    private AuthorisationService service;
+    private UserIdentityException notAuthenticatedEx;
+    private UserIdentityException internalServerErrorEx;
+    private UserIdentityException notFoundEx;
+    private Session session;
+    private CollectionDescription desc;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        notAuthenticatedEx = new UserIdentityException("user not authenticated", SC_UNAUTHORIZED);
+        internalServerErrorEx = new UserIdentityException("internal server error", SC_INTERNAL_SERVER_ERROR);
+        notFoundEx = new UserIdentityException("user does not exist", SC_NOT_FOUND);
+
+        service = new AuthorisationServiceImpl();
+
+        session = new Session();
+        session.setEmail("rickSanchez@CitadelOfRicks.com");
+        session.setId(SESSION_ID);
+
+        desc = new CollectionDescription();
+        desc.setId("666");
+
+        ReflectionTestUtils.setField(service, "sessionServiceSupplier", sessionServiceSupplier);
+        ReflectionTestUtils.setField(service, "userServiceSupplier", userServiceSupplier);
+        ReflectionTestUtils.setField(service, "collectionsSupplier", collectionsSupplier);
+        ReflectionTestUtils.setField(service, "permissionsServiceSupplier", permissionsServiceSupplier);
+        ReflectionTestUtils.setField(service, "serviceStoreSupplier", serviceStoreSupplier);
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnNotAuthorisedIfSessionIDNull() throws Exception {
+        try {
+            service.identifyUser(null);
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(notAuthenticatedEx));
+            verifyZeroInteractions(sessionsService, usersService);
+            throw ex;
+        }
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnNotAuthorisedIfSessionIDEmpty() throws Exception {
+        try {
+            service.identifyUser("");
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(notAuthenticatedEx));
+            verifyZeroInteractions(sessionsService, usersService);
+            throw ex;
+        }
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnInternalServerErrorIfErrorGettingSession() throws Exception {
+        when(sessionsService.get(SESSION_ID))
+                .thenThrow(new IOException("error getting session"));
+        try {
+            service.identifyUser(SESSION_ID);
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(internalServerErrorEx));
+            verify(sessionsService, times(1)).get(SESSION_ID);
+            verifyZeroInteractions(usersService);
+            throw ex;
+        }
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnNotAuthenicatedIfSessionNotFound() throws Exception {
+        when(sessionsService.get(SESSION_ID))
+                .thenReturn(null);
+        try {
+            service.identifyUser(SESSION_ID);
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(notAuthenticatedEx));
+            verify(sessionsService, times(1)).get(SESSION_ID);
+            verifyZeroInteractions(usersService);
+            throw ex;
+        }
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnNotFoundIfUserDoesNotExist() throws Exception {
+        when(sessionsService.get(SESSION_ID))
+                .thenReturn(session);
+        when(usersService.exists(session.getEmail()))
+                .thenReturn(false);
+        try {
+            service.identifyUser(SESSION_ID);
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(notFoundEx));
+            verify(sessionsService, times(1)).get(SESSION_ID);
+            verify(usersService, times(1)).exists(session.getEmail());
+            throw ex;
+        }
+    }
+
+    @Test(expected = UserIdentityException.class)
+    public void shouldReturnInternalServerErrorIfErrorCheckingUserExistance() throws Exception {
+        when(sessionsService.get(SESSION_ID))
+                .thenReturn(session);
+        when(usersService.exists(session.getEmail()))
+                .thenThrow(new IOException("something terrible happened!"));
+        try {
+            service.identifyUser(SESSION_ID);
+        } catch (UserIdentityException ex) {
+            assertThat(ex, equalTo(internalServerErrorEx));
+            verify(sessionsService, times(1)).get(SESSION_ID);
+            verify(usersService, times(1)).exists(session.getEmail());
+            throw ex;
+        }
+    }
+
+    @Test
+    public void shouldReturnUserIdentityIfSessionAndUserExist() throws Exception {
+        when(sessionsService.get(SESSION_ID))
+                .thenReturn(session);
+        when(usersService.exists(session.getEmail()))
+                .thenReturn(true);
+
+        UserIdentity expected = new UserIdentity(session);
+
+        UserIdentity actual = service.identifyUser(SESSION_ID);
+
+        assertThat(actual, equalTo(expected));
+        verify(sessionsService, times(1)).get(SESSION_ID);
+        verify(usersService, times(1)).exists(session.getEmail());
+    }
 
 
-	@Before
-	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetSession_sessionIDNull() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
 
-		notAuthenticatedEx = new UserIdentityException("user not authenticated", SC_UNAUTHORIZED);
-		internalServerErrorEx = new UserIdentityException("internal server error", SC_INTERNAL_SERVER_ERROR);
-		notFoundEx = new UserIdentityException("user does not exist", SC_NOT_FOUND);
+        try {
+            serviceImpl.getSession(null);
+        } catch (DatasetPermissionsException ex) {
+            verify(sessionsService, never()).get(anyString());
 
-		service = new AuthorisationServiceImpl();
+            assertThat(ex.statusCode, equalTo(SC_BAD_REQUEST));
+            assertThat(ex.getMessage(), equalTo("user dataset permissions request denied session ID required but empty"));
+            throw ex;
+        }
+    }
 
-		session = new Session();
-		session.setEmail("rickSanchez@CitadelOfRicks.com");
-		session.setId(SESSION_ID);
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetSession_sessionIDEmpty() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
 
-		ReflectionTestUtils.setField(service, "sessionServiceSupplier", sessionServiceSupplier);
-		ReflectionTestUtils.setField(service, "userServiceSupplier", userServiceSupplier);
-	}
+        try {
+            serviceImpl.getSession("");
+        } catch (DatasetPermissionsException ex) {
+            verify(sessionsService, never()).get(anyString());
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnNotAuthorisedIfSessionIDNull() throws Exception {
-		try {
-			service.identifyUser(null);
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(notAuthenticatedEx));
-			verifyZeroInteractions(sessionsService, usersService);
-			throw ex;
-		}
-	}
+            assertThat(ex.statusCode, equalTo(SC_BAD_REQUEST));
+            assertThat(ex.getMessage(), equalTo("user dataset permissions request denied session ID required but empty"));
+            throw ex;
+        }
+    }
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnNotAuthorisedIfSessionIDEmpty() throws Exception {
-		try {
-			service.identifyUser("");
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(notAuthenticatedEx));
-			verifyZeroInteractions(sessionsService, usersService);
-			throw ex;
-		}
-	}
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetSession_IOException() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnInternalServerErrorIfErrorGettingSession() throws Exception {
-		when(sessionsService.get(SESSION_ID))
-				.thenThrow(new IOException("error getting session"));
-		try {
-			service.identifyUser(SESSION_ID);
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(internalServerErrorEx));
-			verify(sessionsService, times(1)).get(SESSION_ID);
-			verifyZeroInteractions(usersService);
-			throw ex;
-		}
-	}
+        when(sessionsService.get("666"))
+                .thenThrow(new IOException("BOOOOOOOOM"));
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnNotAuthenicatedIfSessionNotFound() throws Exception {
-		when(sessionsService.get(SESSION_ID))
-				.thenReturn(null);
-		try {
-			service.identifyUser(SESSION_ID);
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(notAuthenticatedEx));
-			verify(sessionsService, times(1)).get(SESSION_ID);
-			verifyZeroInteractions(usersService);
-			throw ex;
-		}
-	}
+        try {
+            serviceImpl.getSession("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(sessionsService, times(1)).get("666");
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnNotFoundIfUserDoesNotExist() throws Exception {
-		when(sessionsService.get(SESSION_ID))
-				.thenReturn(session);
-		when(usersService.exists(session.getEmail()))
-				.thenReturn(false);
-		try {
-			service.identifyUser(SESSION_ID);
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(notFoundEx));
-			verify(sessionsService, times(1)).get(SESSION_ID);
-			verify(usersService, times(1)).exists(session.getEmail());
-			throw ex;
-		}
-	}
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            throw ex;
+        }
+    }
 
-	@Test(expected = UserIdentityException.class)
-	public void shouldReturnInternalServerErrorIfErrorCheckingUserExistance() throws Exception {
-		when(sessionsService.get(SESSION_ID))
-				.thenReturn(session);
-		when(usersService.exists(session.getEmail()))
-				.thenThrow(new IOException("something terrible happened!"));
-		try {
-			service.identifyUser(SESSION_ID);
-		} catch (UserIdentityException ex) {
-			assertThat(ex, equalTo(internalServerErrorEx));
-			verify(sessionsService, times(1)).get(SESSION_ID);
-			verify(usersService, times(1)).exists(session.getEmail());
-			throw ex;
-		}
-	}
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetSession_sessionNotFound() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
 
-	@Test
-	public void shouldReturnUserIdentityIfSessionAndUserExist() throws Exception {
-		when(sessionsService.get(SESSION_ID))
-				.thenReturn(session);
-		when(usersService.exists(session.getEmail()))
-				.thenReturn(true);
+        when(sessionsService.get("666"))
+                .thenReturn(null);
 
-		UserIdentity expected = new UserIdentity(session);
+        try {
+            serviceImpl.getSession("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(sessionsService, times(1)).get("666");
 
-		UserIdentity actual = service.identifyUser(SESSION_ID);
+            assertThat(ex.statusCode, equalTo(SC_UNAUTHORIZED));
+            assertThat(ex.getMessage(), equalTo("session not found"));
+            throw ex;
+        }
+    }
 
-		assertThat(actual, equalTo(expected));
-		verify(sessionsService, times(1)).get(SESSION_ID);
-		verify(usersService, times(1)).exists(session.getEmail());
-	}
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetSession_sessionExpired() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(sessionsService.get("666"))
+                .thenReturn(session);
+        when(sessionsService.expired(session))
+                .thenReturn(true);
+
+        try {
+            serviceImpl.getSession("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(sessionsService, times(1)).get("666");
+            verify(sessionsService, times(1)).expired(session);
+
+            assertThat(ex.statusCode, equalTo(SC_UNAUTHORIZED));
+            assertThat(ex.getMessage(), equalTo("session expired"));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testGetSession_success() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(sessionsService.get("666"))
+                .thenReturn(session);
+        when(sessionsService.expired(session))
+                .thenReturn(false);
+
+        Session s = serviceImpl.getSession("666");
+
+        verify(sessionsService, times(1)).get("666");
+        verify(sessionsService, times(1)).expired(session);
+        assertThat(s, equalTo(session));
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetCollection_IDNull() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        try {
+            serviceImpl.getCollection(null);
+        } catch (DatasetPermissionsException ex) {
+            verify(collections, never()).getCollection(anyString());
+
+            assertThat(ex.statusCode, equalTo(SC_BAD_REQUEST));
+            assertThat(ex.getMessage(), equalTo("collection ID required but was empty"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetCollection_IOException() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(collections.getCollection("666"))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.getCollection("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(collections, times(1)).getCollection("666");
+
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetCollection_collectionNotFound() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(collections.getCollection("666"))
+                .thenReturn(null);
+
+        try {
+            serviceImpl.getCollection("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(collections, times(1)).getCollection("666");
+
+            assertThat(ex.statusCode, equalTo(SC_NOT_FOUND));
+            assertThat(ex.getMessage(), equalTo("collection not found"));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testGetCollection_success() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(collections.getCollection("666"))
+                .thenReturn(collection);
+
+        Collection c = serviceImpl.getCollection("666");
+
+        verify(collections, times(1)).getCollection("666");
+        assertThat(c, equalTo(collection));
+    }
+
+    @Test
+    public void testValidateCollectionContainsRequestedDataset_datasetPresent() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        CollectionDataset ds = new CollectionDataset();
+        ds.setId("666");
+
+        CollectionDescription containingDataset = new CollectionDescription();
+        containingDataset.addDataset(ds);
+
+        when(collection.getDescription())
+                .thenReturn(containingDataset);
+
+        serviceImpl.validateCollectionContainsRequestedDataset(collection, "666");
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testValidateCollectionContainsRequestedDataset_datasetNotPresent() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        CollectionDataset ds = new CollectionDataset();
+        ds.setId("666");
+
+        CollectionDescription containingDataset = new CollectionDescription();
+        containingDataset.addDataset(ds);
+
+        when(collection.getDescription())
+                .thenReturn(containingDataset);
+
+        try {
+            serviceImpl.validateCollectionContainsRequestedDataset(collection, "667");
+        } catch (DatasetPermissionsException ex) {
+            assertThat(ex.getMessage(), equalTo("requested collection does not contain the requested dataset"));
+            assertThat(ex.statusCode, equalTo(SC_BAD_REQUEST));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testIsAdminOrPublisher_adminEditorUser() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(true);
+
+        assertThat(serviceImpl.isAdminOrPublisher(session), equalTo(true));
+
+        verify(permissionsService, times(1)).canEdit(session);
+    }
+
+    @Test
+    public void testIsAdminOrPublisher_viewerUser() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(false);
+
+        assertThat(serviceImpl.isAdminOrPublisher(session), equalTo(false));
+
+        verify(permissionsService, times(1)).canEdit(session);
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testIsAdminOrPublisher_IOException() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.isAdminOrPublisher(session);
+        } catch (DatasetPermissionsException ex) {
+            verify(permissionsService, times(1)).canEdit(session);
+
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testIsCollectionViewer_success() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canView(session, desc))
+                .thenReturn(true);
+
+        boolean canView = serviceImpl.isCollectionViewer(session, desc);
+
+        assertThat(canView, equalTo(true));
+        verify(permissionsService, times(1)).canView(session, desc);
+    }
+
+    @Test
+    public void testIsCollectionViewer_fail() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canView(session, desc))
+                .thenReturn(false);
+
+        boolean canView = serviceImpl.isCollectionViewer(session, desc);
+
+        assertThat(canView, equalTo(false));
+        verify(permissionsService, times(1)).canView(session, desc);
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testIsCollectionViewer_IOException() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canView(session, desc))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.isCollectionViewer(session, desc);
+        } catch (DatasetPermissionsException ex) {
+            verify(permissionsService, times(1)).canView(session, desc);
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testAssignPermissions_AdminUserPermissionServiceEx() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.assignPermissions(session, desc, "666");
+        } catch (DatasetPermissionsException ex) {
+            verify(permissionsService, times(1)).canEdit(session);
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testAssignPermissions_AdminUserSuccess() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(true);
+
+        DatasetPermissions permissions = serviceImpl.assignPermissions(session, desc, "666");
+
+        assertTrue(permissions.getPermissions().contains(CREATE));
+        assertTrue(permissions.getPermissions().contains(READ));
+        assertTrue(permissions.getPermissions().contains(UPDATE));
+        assertTrue(permissions.getPermissions().contains(DELETE));
+        verify(permissionsService, times(1)).canEdit(session);
+    }
+
+    @Test
+    public void testAssignPermissions_ViewerUserSuccess() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(false);
+        when(permissionsService.canView(session, desc))
+                .thenReturn(true);
+
+        DatasetPermissions permissions = serviceImpl.assignPermissions(session, desc, "666");
+
+        assertTrue(permissions.getPermissions().contains(READ));
+        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canView(session, desc);
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testAssignPermissions_ViewerUserPermissionServiceEx() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(false);
+        when(permissionsService.canView(session, desc))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.assignPermissions(session, desc, "666");
+        } catch (DatasetPermissionsException ex) {
+            verify(permissionsService, times(1)).canEdit(session);
+            verify(permissionsService, times(1)).canView(session, desc);
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testAssignPermissions_ViewerUserNotInTeamAssignedToCollection() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(false);
+        when(permissionsService.canView(session, desc))
+                .thenReturn(false);
+
+        DatasetPermissions permissions = serviceImpl.assignPermissions(session, desc, "666");
+
+        assertTrue(permissions.getPermissions().isEmpty());
+        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canView(session, desc);
+    }
+
+    @Test
+    public void testGetUserPermissions_adminUser() throws Exception {
+        when(sessionsService.get("666"))
+                .thenReturn(session);
+        when(sessionsService.expired(session))
+                .thenReturn(false);
+        when(collections.getCollection("666"))
+                .thenReturn(collection);
+
+        CollectionDataset collectionDataset = new CollectionDataset();
+        collectionDataset.setId("666");
+        desc.addDataset(collectionDataset);
+
+        when(collection.getDescription())
+                .thenReturn(desc);
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(true);
+
+        DatasetPermissions permissions = service.getUserPermissions("666", "666", "666");
+
+        assertTrue(permissions.getPermissions().contains(CREATE));
+        assertTrue(permissions.getPermissions().contains(READ));
+        assertTrue(permissions.getPermissions().contains(UPDATE));
+        assertTrue(permissions.getPermissions().contains(DELETE));
+
+        verify(sessionsService, times(1)).get("666");
+        verify(sessionsService, times(1)).expired(session);
+        verify(collections, times(1)).getCollection("666");
+        verify(permissionsService, times(1)).canEdit(session);
+        verifyNoMoreInteractions(sessionsService, collections, permissionsService);
+    }
+
+    @Test
+    public void testGetUserPermissions_viewer() throws Exception {
+        when(sessionsService.get("666"))
+                .thenReturn(session);
+        when(sessionsService.expired(session))
+                .thenReturn(false);
+        when(collections.getCollection("666"))
+                .thenReturn(collection);
+
+        CollectionDataset collectionDataset = new CollectionDataset();
+        collectionDataset.setId("666");
+        CollectionDescription description = new CollectionDescription();
+        description.addDataset(collectionDataset);
+
+        when(collection.getDescription())
+                .thenReturn(description);
+
+        when(permissionsService.canEdit(session))
+                .thenReturn(false);
+        when(permissionsService.canView(session, description))
+                .thenReturn(true);
+
+        DatasetPermissions permissions = service.getUserPermissions("666", "666", "666");
+
+        assertTrue(permissions.getPermissions().contains(READ));
+
+        verify(sessionsService, times(1)).get("666");
+        verify(sessionsService, times(1)).expired(session);
+        verify(collections, times(1)).getCollection("666");
+        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canView(session, description);
+        verifyNoMoreInteractions(sessionsService, collections, permissionsService);
+    }
+
+    @Test
+    public void testGetServiceAccountSuccess() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(serviceStore.get("666"))
+                .thenReturn(serviceAccount);
+
+        ServiceAccount account = serviceImpl.getServiceAccount("666");
+
+        assertThat(account, equalTo(serviceAccount));
+        verify(serviceStore, times(1)).get("666");
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetServiceAccount_IOException() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(serviceStore.get("666"))
+                .thenThrow(new IOException());
+
+        try {
+            serviceImpl.getServiceAccount("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(serviceStore, times(1)).get("666");
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetServiceAccount_NotFound() throws Exception {
+        AuthorisationServiceImpl serviceImpl = (AuthorisationServiceImpl) service;
+
+        when(serviceStore.get("666"))
+                .thenReturn(null);
+
+        try {
+            serviceImpl.getServiceAccount("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(serviceStore, times(1)).get("666");
+            assertThat(ex.statusCode, equalTo(SC_UNAUTHORIZED));
+            assertThat(ex.getMessage(), equalTo("permisson denied service account not found"));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testGetServicePermissionsSuccess() throws Exception {
+        when(serviceStore.get("666"))
+                .thenReturn(serviceAccount);
+        when(serviceAccount.getId())
+                .thenReturn("Über-service");
+
+        DatasetPermissions permissions = service.getServicePermissions("666");
+
+        assertTrue(permissions.getPermissions().contains(CREATE));
+        assertTrue(permissions.getPermissions().contains(READ));
+        assertTrue(permissions.getPermissions().contains(UPDATE));
+        assertTrue(permissions.getPermissions().contains(DELETE));
+
+        verify(serviceStore, times(1)).get("666");
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetServicePermissions_IOException() throws Exception {
+        when(serviceStore.get("666"))
+                .thenThrow(new IOException());
+
+        try {
+            service.getServicePermissions("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(serviceStore, times(1)).get("666");
+            assertThat(ex.statusCode, equalTo(SC_INTERNAL_SERVER_ERROR));
+            assertThat(ex.getMessage(), equalTo("internal server error"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = DatasetPermissionsException.class)
+    public void testGetServicePermissions_NotFound() throws Exception {
+        when(serviceStore.get("666"))
+                .thenReturn(null);
+
+        try {
+            service.getServicePermissions("666");
+        } catch (DatasetPermissionsException ex) {
+            verify(serviceStore, times(1)).get("666");
+            assertThat(ex.statusCode, equalTo(SC_UNAUTHORIZED));
+            assertThat(ex.getMessage(), equalTo("permisson denied service account not found"));
+            throw ex;
+        }
+    }
 
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.model.approval.task;
 import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ContentDetail;
+import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.CollectionWriter;
 import com.github.onsdigital.zebedee.model.ContentWriter;
 import com.github.onsdigital.zebedee.model.approval.tasks.CollectionPdfGenerator;
@@ -31,6 +32,9 @@ public class CollectionPdfGeneratorTest {
     @Mock
     private ContentWriter mockContentWriter;
 
+    @Mock
+    private Collection collection;
+
     private CollectionPdfGenerator generator;
 
     @Before
@@ -41,8 +45,8 @@ public class CollectionPdfGeneratorTest {
 
 
     @Test
-    public void shouldGenerateNothingForAnEmptyCollection() throws IOException {
-        generator.generatePdfsInCollection(mockCollectionWriter, new ArrayList<>());
+    public void shouldGenerateNothingForAnEmptyCollection() throws Exception {
+        generator.generatePDFsForCollection(collection, mockCollectionWriter, new ArrayList<>());
         verifyZeroInteractions(mockPDFService);
     }
 
@@ -55,7 +59,7 @@ public class CollectionPdfGeneratorTest {
         String uri = "/the/uri";
         collectionContent.add(new ContentDetail("Some article", uri, PageType.article.toString()));
 
-        generator.generatePdfsInCollection(mockCollectionWriter, collectionContent);
+        generator.generatePDFsForCollection(collection, mockCollectionWriter, collectionContent);
 
         verify(mockCollectionWriter, times(1)).getReviewed();
     }

--- a/zebedee-cms/src/test/resources/logback.xml
+++ b/zebedee-cms/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <property scope="context" name="default.logger.formatted" value="false"/>
+    <property scope="context" name="default.logger.formatted" value="true"/>
 
     <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DatasetLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DatasetLandingPage.java
@@ -16,6 +16,7 @@ public class DatasetLandingPage extends Statistics {
     private List<DownloadSection> downloads;
     private MarkdownSection section;
     private List<MarkdownSection> notes;
+    private List<Link> relatedFilterableDatasets;
     private List<Link> relatedDatasets;
     private List<Link> relatedDocuments;
     private List<Link> datasets;
@@ -51,6 +52,14 @@ public class DatasetLandingPage extends Statistics {
 
     public void setSection(MarkdownSection section) {
         this.section = section;
+    }
+
+    public List<Link> getRelatedFilterableDatasets() {
+        return relatedFilterableDatasets;
+    }
+
+    public void setRelatedFilterableDatasets(List<Link> relatedFilterableDatasets) {
+        this.relatedFilterableDatasets = relatedFilterableDatasets;
     }
 
     public List<Link> getRelatedDatasets() {

--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -31,19 +31,16 @@
         </encoder>
     </appender>
 
-    <logger name="zebedee" level="debug" additivity="false">
+
+    <logger name="dp-dataset-api-java-client" level="info" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <logger name="dp-dataset-api-java-client" level="debug" additivity="false">
+    <logger name="zebedee" level="info" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <logger name="zebedee" level="debug" additivity="false">
-        <appender-ref ref="DP_LOGGER"/>
-    </logger>
-
-    <logger name="zebedee-reader" level="debug" additivity="false">
+    <logger name="zebedee-reader" level="info" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 


### PR DESCRIPTION
### What

## Release 1.17.0

* initial api implementation for user permissions
* added empty stub for get service permissions, refactored api handler to handle both user and service permissions, fixed broken tests
* added skeleton functionality for service permissions and added test
* added permissions endpoint to auth filter whitelist and fixed annoying session clean up issue because it was bugging me
* added impl for get user permissions and started adding tests
* added get session success test case
* added unit test cases for get collection
* added test cases for validateCollectionContainsRequestedDataset
* added unit test cases for isAdminOrEditor and isCollectionViewer
* added test cases got get admin and viewer permissions
* updated AuthorisationService to include new methods for getting user & service permissions, added new permissions models and permissions exception
* added new empty methods to AuthorisationServiceImpl
* refactoring and added helpful logging
* added CMS logger with helper methods for common data
* reverted changes that broken session service
* added implementation for getting service permissions
* improvements to logging and added check for bearer prefix on service permission requests
* Add relatedFilterableDatsets list field to model
* reverted thread pool change from PDF generation on approval

### Who can review

Should be reviewed by both @jondewijones @daiLlew