### PR TITLE
index time series via scan method

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -186,6 +186,8 @@ public class Indexer {
                 //TODO: optimize resolving latest flag, only update elastic search for existing releases rather than reindexing
                 //Load old releases as well to get latest flag re-calculated
                 index(getSearchAlias(), new FileScanner().scan(URIUtils.removeLastSegment(uri)));
+            } else if (page.getType() == PageType.timeseries) {
+                index(getSearchAlias(), new FileScanner().scan(uri));
             } else {
                 indexSingleContent(getSearchAlias(), page);
             }


### PR DESCRIPTION
### What

An attempt at fixing the index issue with time series data. I can't be sure (as we can replicate the issue, so it's wading through convoluted code) but the logic for the below seems to hold.

**Explanation:**
There are three methods for indexing content:
1.) ReindexAll - which walks the whole content directory to get the content information for indexing.
2.) Single indexing requests for `periodical` content, basically does a limited "walk" from the directory specified in the url but otherwise is the same as 1.)
3.) Single indexing requests for all other content, uses zebedeeReader.**Published**ContentReader() to get the content information for indexing (i.e the release date)

I believe the "Published" in PublishedContentReader is responsible for getting the incorrect/old release dates with correct data for timeseries.

It appears inconsistently as 2.) being triggered by anything in the same tree will "accidentally" fix timeseries indexed with the wrong date before we become aware of the problem. But that should/may also be inconsistent, as the timeseries request could come after the `periodic` content and basically un-fix itself. 

I've modified Zebedee to use method 2.) directly for timeseries as it uses the same mechanism as reIndex (which we know works for time-series).

I've testes indexing `time-series` locally with 2.) and they appear to index correctly, so would like to try it in dev.

### How to review

I have no idea.

### Who can review

Anyone.
