### PR TITLE
added regex validation for service token ids

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -31,12 +31,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.zebedee.configuration.Configuration.isVerificationEnabled;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.beingEditedByAnotherCollectionError;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.beingEditedByThisCollectionError;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.markedDeleteInAnotherCollectionError;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 
 public class Zebedee {
 
@@ -60,6 +60,7 @@ public class Zebedee {
     private final Path teamsPath;
     private final Path applicationKeysPath;
     private final Path redirectPath;
+    private final Path servicePath;
 
     private final VerificationAgent verificationAgent;
     private final ApplicationKeys applicationKeys;
@@ -108,6 +109,7 @@ public class Zebedee {
         this.teamsPath = configuration.getTeamsPath();
         this.applicationKeysPath = configuration.getApplicationKeysPath();
         this.redirectPath = configuration.getRedirectPath();
+        this.servicePath = configuration.getServicePath();
     }
 
     /**
@@ -348,5 +350,9 @@ public class Zebedee {
 
     public ServiceStore getServiceStore() {
         return serviceStoreImpl;
+    }
+
+    public Path getServicePath() {
+        return servicePath;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStore.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStore.java
@@ -5,9 +5,27 @@ import com.github.onsdigital.zebedee.model.ServiceAccount;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Represents a repository for storing and retriving service accounts.
+ */
 public interface ServiceStore {
 
-     ServiceAccount get(String id) throws IOException;
+    /**
+     * Get a service account by its token value.
+     *
+     * @param token the token of the service account to retrive.
+     * @return the {@link ServiceAccount} if it exists otherwise return null;
+     * @throws IOException thrown for any errors encountered getting the service account.
+     */
+    ServiceAccount get(String token) throws IOException;
 
-     ServiceAccount store(String token, InputStream service) throws IOException;
+    /**
+     * Store a service account.
+     *
+     * @param token   of the service account to save.
+     * @param service a byte array input stream of the service account to store.
+     * @return a service account object for the byte array input stream saved.
+     * @throws IOException any problem saving the service account.
+     */
+    ServiceAccount store(String token, InputStream service) throws IOException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStoreImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStoreImpl.java
@@ -10,20 +10,33 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 
+/**
+ * File based service account store implementation.
+ */
 public class ServiceStoreImpl implements ServiceStore {
 
     private final Path serviceRoot;
 
     private final JSONSerialiser<ServiceAccount> jsonSerialise;
 
-    private final static String JSON_EXTENSION = ".json";
-
+    /**
+     * Construct a new ServiceStoreImpl instance.
+     *
+     * @param serviceRoot the file path of the service account root directory.
+     */
     public ServiceStoreImpl(Path serviceRoot) {
         this.serviceRoot = serviceRoot;
         this.jsonSerialise = new JSONSerialiser<>(ServiceAccount.class);
     }
 
+    /**
+     * Construct a new ServiceStoreImpl instance.
+     *
+     * @param serviceRoot   the file path of the service account root directory.
+     * @param jsonSerialise the {@link JSONSerialiser} implementation to use.
+     */
     public ServiceStoreImpl(Path serviceRoot, JSONSerialiser<ServiceAccount> jsonSerialise) {
         this.serviceRoot = serviceRoot;
         this.jsonSerialise = jsonSerialise;
@@ -42,15 +55,20 @@ public class ServiceStoreImpl implements ServiceStore {
     }
 
     private ServiceAccount getServiceAccount(Path filePath) throws IOException {
-        if (filePath == null || !Files.exists(filePath)) {
-            return null;
-        }
+        ServiceAccount account = null;
 
-        try (InputStream input = Files.newInputStream(filePath)) {
-            return jsonSerialise.deserialiseQuietly(input, filePath);
-        } catch (Exception ex) {
-            throw new IOException("error deserialising service account json", ex);
+        if (filePath == null) {
+            warn().log("error getting service account file path null");
+        } else if (!Files.exists(filePath)) {
+            warn().log("error getting service account file does not exist");
+        } else {
+            try (InputStream input = Files.newInputStream(filePath)) {
+                account = jsonSerialise.deserialiseQuietly(input, filePath);
+            } catch (Exception ex) {
+                throw new IOException("error deserialising service account json", ex);
+            }
         }
+        return account;
     }
 
     @Override

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStoreImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceStoreImpl.java
@@ -1,6 +1,6 @@
 package com.github.onsdigital.zebedee.service;
 
-import com.github.onsdigital.zebedee.model.PathUtils;
+import com.github.davidcarboni.cryptolite.Random;
 import com.github.onsdigital.zebedee.model.ServiceAccount;
 import com.github.onsdigital.zebedee.util.serialiser.JSONSerialiser;
 import org.apache.commons.lang3.StringUtils;
@@ -10,8 +10,13 @@ import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 
 public class ServiceStoreImpl implements ServiceStore {
+
+    private static final Pattern VALID_FILENAME_REGEX = Pattern.compile("^\\w+$");
 
     private final Path rootLocation;
 
@@ -52,9 +57,17 @@ public class ServiceStoreImpl implements ServiceStore {
     private Path getPath(String id) {
         Path result = null;
         if (StringUtils.isNotBlank(id)) {
+            validateToken(id);
             String sessionFileName = id + JSON_EXTENSION;
             result = rootLocation.resolve(sessionFileName);
         }
         return result;
+    }
+
+    private void validateToken(String token) {
+        if (!VALID_FILENAME_REGEX.matcher(token).matches()) {
+            warn().data("token", token).log("invalid service token value");
+            throw new RuntimeException("invalid service token value: tokens must match alphanumeric with underscores");
+        }
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
@@ -1,0 +1,73 @@
+package com.github.onsdigital.zebedee.service;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
+import static java.text.MessageFormat.format;
+
+/**
+ * Utility class for {@link com.github.onsdigital.zebedee.model.ServiceAccount} token values.
+ */
+public class ServiceTokenUtils {
+
+    private static final Pattern VALID_FILENAME_REGEX = Pattern.compile("^[a-zA-Z0-9]+$");
+
+    static final String JSON_EXTENSION = ".json";
+    static final int MIN_TOKEN_LENGTH = 16;
+    static final String EMPTY_TOKEN_ERROR = "invalid service token value: empty";
+    static final String INVALID_TOKEN_ERROR = "invalid service token value: tokens must match alphanumeric";
+    static final String TOKEN_LENGTH_INVALID_ERROR = "invalid service token value: tokens must have length >= {0} characters";
+    static final String SERVICE_PATH_EMPTY_ERROR = "service dir path required but was empty or null";
+
+    /**
+     * ServiceTokenValidator is a utility class containing only static methods.
+     */
+    private ServiceTokenUtils() {
+    }
+
+    /**
+     * Validate the given token string conatins only alphanumeric characters and has a minimum length of 16 characters.
+     * Throws a {@link RuntimeException} if the token is invalid.
+     *
+     * @param token the token string to validate.
+     * @throws {@link RuntimeException} if the token is not valid.
+     */
+    public static void validateToken(String token) {
+        if (StringUtils.isEmpty(token)) {
+            throw new RuntimeException(EMPTY_TOKEN_ERROR);
+        }
+
+        if (!VALID_FILENAME_REGEX.matcher(token).matches()) {
+            warn().data("token", token).log(EMPTY_TOKEN_ERROR);
+            throw new RuntimeException(INVALID_TOKEN_ERROR);
+        }
+
+        if (token.length() < MIN_TOKEN_LENGTH) {
+            throw new RuntimeException(format(TOKEN_LENGTH_INVALID_ERROR, MIN_TOKEN_LENGTH));
+        }
+    }
+
+    /**
+     * Get the {@link Path} to the service account file for the given token.
+     *
+     * @param servicesPath the {@link Path} of the service root directory.
+     * @param token        the service account token.
+     * @return a {@link Path} to the service account file.
+     * @throws {@link RuntimeException} if there is a problem for getting the path.
+     */
+    public static Path getServiceTokenPath(Path servicesPath, String token) {
+        if (servicesPath == null) {
+            throw new RuntimeException(SERVICE_PATH_EMPTY_ERROR);
+        }
+        validateToken(token);
+        return servicesPath.resolve(getTokenFilename(token));
+    }
+
+    static final String getTokenFilename(String token) {
+        return token + JSON_EXTENSION;
+    }
+
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
@@ -20,9 +20,6 @@ public class ServiceTokenUtils {
 
     static final String BEARER_PREFIX_UC = "Bearer";
     static final String JSON_EXTENSION = ".json";
-    static final String EMPTY_TOKEN_ERROR = "invalid service token value: empty";
-    static final String INVALID_TOKEN_ERROR = "invalid service token value: tokens must match alphanumeric";
-    static final String AUTH_HEADER_INVALID_ERROR = "invalid service authorization header value is null or empty";
 
     /**
      * ServiceTokenValidator is a utility class containing only static methods.
@@ -32,12 +29,10 @@ public class ServiceTokenUtils {
 
     /**
      * Validate the given token string conatins only alphanumeric characters and has a minimum length of 16 characters.
-     * Throws a {@link RuntimeException} if the token is invalid.
      *
-     * @param token the token string to validate.
-     * @throws {@link RuntimeException} if the token is not valid.
+     * @param token the token value to validate.
+     * @return true if valid false otherwise.
      */
-
     public static boolean isValidServiceToken(String token) {
         boolean isValid = false;
 
@@ -52,8 +47,8 @@ public class ServiceTokenUtils {
     }
 
     /**
-     * Check if a token is a valid service account token. Valid tokens and >= 16 characters and contain only
-     * alphanumeric characters.
+     * Determined if a value is a valid service account token. Valid tokens contain only alphanumeric characters and
+     * must have a length of >= 16 characters.
      *
      * @param token the value to check.
      * @return true if valid token value false otherwise.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/IdentityTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/IdentityTest.java
@@ -26,10 +26,6 @@ import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -39,7 +35,7 @@ public class IdentityTest {
 
     private static final String FLORENCE_TOKEN = "666";
     private static final String FLORENCE_TOKEN_HEADER = "X-Florence-Token";
-    private static final String AUTH_TOKEN = "Bearer 123";
+    private static final String AUTH_TOKEN = "Bearer d8b90a24c3d247aeaf84731e4e69dd6f";
     private static final String SERVICE_NAME = "dp-dataset-api";
 
     @Mock
@@ -133,7 +129,7 @@ public class IdentityTest {
 
         api.identifyUser(mockRequest, mockResponse);
 
-        verify(serviceStore, times(1)).get("123");
+        verify(serviceStore, times(1)).get("d8b90a24c3d247aeaf84731e4e69dd6f");
         verify(authorisationService, times(0)).identifyUser(FLORENCE_TOKEN);
         verifyResponseInteractions(identity, SC_OK);
     }
@@ -149,7 +145,7 @@ public class IdentityTest {
 
         api.identifyUser(mockRequest, mockResponse);
 
-        verify(serviceStore, times(1)).get("123");
+        verify(serviceStore, times(1)).get("d8b90a24c3d247aeaf84731e4e69dd6f");
         verify(authorisationService, times(0)).identifyUser(FLORENCE_TOKEN);
         verifyResponseInteractions(identity, SC_OK);
     }
@@ -217,56 +213,6 @@ public class IdentityTest {
         verifyZeroInteractions(serviceStore, authorisationService);
         verifyResponseInteractions(new Error("service not authenticated"), SC_UNAUTHORIZED);
     }
-
-    @Test
-    public void testRemoveBearerPrefixNull() {
-        String actual = api.removeBearerPrefix(null);
-        assertThat(actual, is(nullValue()));
-    }
-
-    @Test
-    public void testRemoveBearerPrefix_NoPrefix() {
-        String actual = api.removeBearerPrefix("123");
-        assertThat(actual, equalTo("123"));
-    }
-
-    @Test
-    public void testRemoveBearerPrefix_validHeader() {
-        String actual = api.removeBearerPrefix("Bearer 123");
-        assertThat(actual, equalTo("123"));
-    }
-
-    @Test
-    public void testRemoveBearerPrefix_validHeaderExcessiveSpaces() {
-        String actual = api.removeBearerPrefix("Bearer     123          ");
-        assertThat(actual, equalTo("123"));
-    }
-
-    @Test
-    public void testIsValidAuthorizationHeader_null() {
-        assertThat(api.isValidAuthorizationHeader(null), is(false));
-    }
-
-    @Test
-    public void testIsValidAuthorizationHeader_empty() {
-        assertThat(api.isValidAuthorizationHeader(""), is(false));
-    }
-
-    @Test
-    public void testIsValidAuthorizationHeader_noBearerPrefix() {
-        assertThat(api.isValidAuthorizationHeader("123"), is(false));
-    }
-
-    @Test
-    public void testIsValidAuthorizationHeader_lowerCaseBearerPrefix() {
-        assertThat(api.isValidAuthorizationHeader("bearer 123"), is(false));
-    }
-
-    @Test
-    public void testIsValidAuthorizationHeader_success() {
-        assertThat(api.isValidAuthorizationHeader("Bearer 123"), is(true));
-    }
-
 
     private void verifyResponseInteractions(JSONable body, int statusCode) throws IOException {
         verify(mockResponse, times(1)).getWriter();

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ServiceStoreImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ServiceStoreImplTest.java
@@ -1,0 +1,151 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.model.ServiceAccount;
+import com.github.onsdigital.zebedee.util.serialiser.JSONSerialiser;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class ServiceStoreImplTest {
+
+    static final String TEST_TOKEN = "a2d53b6425de4549964b5ece2678ef60";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private JSONSerialiser<ServiceAccount> jsonSerialiser;
+
+    private ServiceStore serviceStore;
+    private Path servicePath;
+
+    @Before
+    public void setUp() throws IOException {
+        MockitoAnnotations.initMocks(this);
+
+        servicePath = temporaryFolder.newFolder("service").toPath();
+
+        serviceStore = new ServiceStoreImpl(servicePath, jsonSerialiser);
+    }
+
+    @Test
+    public void testGet_invalidToken() throws Exception {
+        ServiceAccount account = serviceStore.get("");
+        assertThat(account, is(nullValue()));
+    }
+
+    @Test
+    public void testGet_accountNotFound() throws Exception {
+        ServiceAccount actual = serviceStore.get(TEST_TOKEN);
+
+        assertThat(actual, is(nullValue()));
+        verifyZeroInteractions(jsonSerialiser);
+    }
+
+    @Test(expected = IOException.class)
+    public void testGet_getServiceAccountPathIllegalArgumentEx() throws Exception {
+        serviceStore = new ServiceStoreImpl(null, jsonSerialiser);
+
+        try {
+            serviceStore.get(TEST_TOKEN);
+        } catch (IOException ex) {
+            assertThat(ex.getMessage(), equalTo("error getting service account path for token"));
+            verifyZeroInteractions(jsonSerialiser);
+            throw ex;
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testGet_jsonDeserialiseError() throws Exception {
+        Path serviceAccountPath = Files.createFile(servicePath.resolve(TEST_TOKEN + ".json"));
+
+        when(jsonSerialiser.deserialiseQuietly(any(InputStream.class), any(Path.class)))
+                .thenThrow(new RuntimeException("nargle!"));
+
+        try {
+            serviceStore.get(TEST_TOKEN);
+        } catch (IOException ex) {
+            assertThat(ex.getMessage(), equalTo("error deserialising service account json"));
+            verify(jsonSerialiser, times(1)).deserialiseQuietly(any(InputStream.class), eq(serviceAccountPath));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testGet_success() throws Exception {
+        Path serviceAccountPath = Files.createFile(servicePath.resolve(TEST_TOKEN + ".json"));
+        ServiceAccount serviceAccount = new ServiceAccount("Weyland-Yutani Corporation");
+
+        when(jsonSerialiser.deserialiseQuietly(any(InputStream.class), any(Path.class)))
+                .thenReturn(serviceAccount);
+
+        ServiceAccount actual = serviceStore.get(TEST_TOKEN);
+        assertThat(actual.getID(), equalTo(serviceAccount.getID()));
+        verify(jsonSerialiser, times(1)).deserialiseQuietly(any(InputStream.class), eq(serviceAccountPath));
+    }
+
+    @Test(expected = IOException.class)
+    public void testStore_serviceRootNull() throws Exception {
+        serviceStore = new ServiceStoreImpl(null, jsonSerialiser);
+
+        try {
+            serviceStore.store(null, null);
+        } catch (IOException ex) {
+            assertThat(ex.getMessage(), equalTo("error getting service account path for token"));
+            verifyZeroInteractions(jsonSerialiser);
+            throw ex;
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testStore_fileAlreadyExists() throws Exception {
+        Path p = Files.write(servicePath.resolve(TEST_TOKEN + ".json"), "nargle".getBytes());
+
+        InputStream inputStream = mock(InputStream.class);
+        try {
+            serviceStore.store(TEST_TOKEN, inputStream);
+        } catch (FileAlreadyExistsException ex) {
+            assertThat(ex.getMessage(), equalTo("The service token already exists : " + p));
+            verifyZeroInteractions(jsonSerialiser);
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testStore_success() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+        Path filePath = servicePath.resolve(TEST_TOKEN + ".json");
+
+        ServiceAccount account = new ServiceAccount("Weyland Yutani Corp");
+
+
+        when(jsonSerialiser.deserialiseQuietly(inputStream, filePath))
+                .thenReturn(account);
+
+        ServiceAccount actual = serviceStore.store(TEST_TOKEN, inputStream);
+
+        assertThat(actual, equalTo(account));
+        verify(jsonSerialiser, times(1)).deserialiseQuietly(inputStream, filePath);
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ServiceTokenUtilsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ServiceTokenUtilsTest.java
@@ -1,0 +1,153 @@
+package com.github.onsdigital.zebedee.service;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.EMPTY_TOKEN_ERROR;
+import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.INVALID_TOKEN_ERROR;
+import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.MIN_TOKEN_LENGTH;
+import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.SERVICE_PATH_EMPTY_ERROR;
+import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.TOKEN_LENGTH_INVALID_ERROR;
+import static java.text.MessageFormat.format;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ServiceTokenUtilsTest {
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectNullToken() {
+        try {
+            ServiceTokenUtils.validateToken(null);
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(EMPTY_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectEmptyToken() {
+        try {
+            ServiceTokenUtils.validateToken("");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(EMPTY_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenWithSpace() {
+        try {
+            ServiceTokenUtils.validateToken("123 abc");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenWithInvalidCharacter() {
+        try {
+            ServiceTokenUtils.validateToken("123_abc");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenWithPeriod() {
+        try {
+            ServiceTokenUtils.validateToken(".123_abc");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenWithSlash() {
+        try {
+            ServiceTokenUtils.validateToken("/123_abc");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenWithPeriodAndSlash() {
+        try {
+            ServiceTokenUtils.validateToken("../123_abc");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateTokenShouldRejectTokenShorterThanMinLength() {
+        try {
+            ServiceTokenUtils.validateToken("1wed5438u");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(format(TOKEN_LENGTH_INVALID_ERROR, MIN_TOKEN_LENGTH)));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void validateTokenShouldAllowTokenWithOnlyNumerics() {
+        ServiceTokenUtils.validateToken("1234567890123456");
+    }
+
+    @Test
+    public void validateTokenShouldAllowValidToken() {
+        ServiceTokenUtils.validateToken("d8b90a24c3d247aeaf84731e4e69dd6f");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getServiceTokenPath_ShouldThrowExIfPathNull() {
+        try {
+            ServiceTokenUtils.getServiceTokenPath(null, null);
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(SERVICE_PATH_EMPTY_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getServiceTokenPath_ShouldThrowExIfTokenNull() {
+        try {
+            ServiceTokenUtils.getServiceTokenPath(Paths.get("/test"), null);
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(EMPTY_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getServiceTokenPath_ShouldThrowExIfTokenInvalid() {
+        try {
+            ServiceTokenUtils.getServiceTokenPath(Paths.get("/test"), "__^&*()_");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), equalTo(INVALID_TOKEN_ERROR));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void getServiceTokenPath_Success() {
+        Path servicePath = Paths.get("/service");
+        String token = "d8b90a24c3d247aeaf84731e4e69dd6f";
+
+        Path actual = ServiceTokenUtils.getServiceTokenPath(servicePath, token);
+        assertThat(actual, equalTo(servicePath.resolve(token + ".json")));
+    }
+
+    @Test
+    public void testGetTokenFilename() {
+        String token = "d8b90a24c3d247aeaf84731e4e69dd6f";
+        assertThat(ServiceTokenUtils.getTokenFilename(token), equalTo(token + ".json"));
+    }
+}


### PR DESCRIPTION
### Service token ID validation.

 - Remove enforced lower casing of token value when retrieving token from store. Fixes issue where token not found in case sensitive file systems. 
 - Improved general logging around service tokens to clearly communicate the reason when a token is not found.
- Added validation to service tokens
  - Tokens can only contain _alphanumeric_ characters.
  - Must have a length >= *16* characters.
 - Added new `ServiceTokenUtils` for service token validation and unit tests.
 - Updated `ServiceStoreImpl` to use `ServiceTokenUtils` for consistency and added unit tests as there were none.
- Updated `Identity` API to also use `ServiceTokenUtils` for validation of service token request header values.
- Added missing javadoc to various things because it was missing or incorrect. (Clean the campsite n all that)