### PR TITLE
Expose dataset information in publishedCollection data

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
@@ -2,11 +2,18 @@ package com.github.onsdigital.zebedee.json.publishing;
 
 import com.github.onsdigital.zebedee.json.CollectionBase;
 import com.github.onsdigital.zebedee.json.CollectionType;
+import com.github.onsdigital.zebedee.json.CollectionDataset;
+import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
+
 
 public class PublishedCollection extends CollectionBase {
+
+    public Set<CollectionDataset> datasets;
+    public Set<CollectionDatasetVersion> datasetVersions;
 
     public PublishedCollection(String id, String name, CollectionType type, Date publishDate) {
         this.id = id;


### PR DESCRIPTION
### What

Added datasets and datasetVersions when being serialised

### How to review

Published a cmd dataset, and go to the publishedCollections or report screen, should see dataset information that was published e.g.: <img width="960" alt="Screenshot 2019-09-02 at 16 47 53" src="https://user-images.githubusercontent.com/47502916/64125317-75b90800-cda1-11e9-8c7c-d799f5a27025.png">

### Who can review

Anyone except me


