### PR TITLE
Added Sessions interface

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -18,7 +18,7 @@ import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.service.ServiceStoreImpl;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.service.UsersService;
@@ -74,7 +74,7 @@ public class Zebedee {
 
     private final UsersService usersService;
     private final TeamsService teamsService;
-    private final SessionsService sessionsService;
+    private final Sessions sessions;
     private final DataIndex dataIndex;
     private final DatasetService datasetService;
     private final ServiceStoreImpl serviceStoreImpl;
@@ -87,7 +87,7 @@ public class Zebedee {
     public Zebedee(ZebedeeConfiguration configuration) {
         this.path = configuration.getZebedeePath();
         this.publishedContentPath = configuration.getPublishedContentPath();
-        this.sessionsService = configuration.getSessionsService();
+        this.sessions = configuration.getSessions();
         this.keyringCache = configuration.getKeyringCache();
         this.permissionsService = configuration.getPermissionsService();
         this.published = configuration.getPublished();
@@ -277,7 +277,7 @@ public class Zebedee {
         // Create a session
         Session session = null;
         try {
-            session = sessionsService.create(user);
+            session = sessions.create(user);
         } catch (Exception e) {
             error().data("user", user.getEmail()).logException(e, "error attempting to create session for user");
             throw new IOException(e);
@@ -328,8 +328,8 @@ public class Zebedee {
         return this.applicationKeys;
     }
 
-    public SessionsService getSessionsService() {
-        return this.sessionsService;
+    public Sessions getSessions() {
+        return this.sessions;
     }
 
     public VerificationAgent getVerificationAgent() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -17,6 +17,7 @@ import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ServiceStoreImpl;
 import com.github.onsdigital.zebedee.service.ZebedeeDatasetService;
 import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.SessionsServiceImpl;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.teams.service.TeamsServiceImpl;
 import com.github.onsdigital.zebedee.teams.store.TeamsStoreFileSystemImpl;
@@ -125,7 +126,7 @@ public class ZebedeeConfiguration {
         this.dataIndex = new DataIndex(new FileSystemContentReader(publishedContentPath));
         this.publishedCollections = new PublishedCollections(publishedCollectionsPath);
         this.applicationKeys = new ApplicationKeys(applicationKeysPath);
-        this.sessionsService = new SessionsService(sessionsPath);
+        this.sessionsService = new SessionsServiceImpl(sessionsPath);
         this.keyringCache = new KeyringCache(sessionsService);
 
         this.teamsService = new TeamsServiceImpl(

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -16,7 +16,7 @@ import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
 import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ServiceStoreImpl;
 import com.github.onsdigital.zebedee.service.ZebedeeDatasetService;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.session.service.SessionsServiceImpl;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.teams.service.TeamsServiceImpl;
@@ -74,7 +74,7 @@ public class ZebedeeConfiguration {
     private PermissionsService permissionsService;
     private UsersService usersService;
     private TeamsService teamsService;
-    private SessionsService sessionsService;
+    private Sessions sessions;
     private DataIndex dataIndex;
     private PermissionsStore permissionsStore;
     private DatasetService datasetService;
@@ -126,8 +126,8 @@ public class ZebedeeConfiguration {
         this.dataIndex = new DataIndex(new FileSystemContentReader(publishedContentPath));
         this.publishedCollections = new PublishedCollections(publishedCollectionsPath);
         this.applicationKeys = new ApplicationKeys(applicationKeysPath);
-        this.sessionsService = new SessionsServiceImpl(sessionsPath);
-        this.keyringCache = new KeyringCache(sessionsService);
+        this.sessions = new SessionsServiceImpl(sessionsPath);
+        this.keyringCache = new KeyringCache(sessions);
 
         this.teamsService = new TeamsServiceImpl(
                 new TeamsStoreFileSystemImpl(teamsPath), this::getPermissionsService);
@@ -267,8 +267,8 @@ public class ZebedeeConfiguration {
         return this.applicationKeys;
     }
 
-    public SessionsService getSessionsService() {
-        return this.sessionsService;
+    public Sessions getSessions() {
+        return this.sessions;
     }
 
     public PermissionsService getPermissionsService() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Approve.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Approve.java
@@ -41,7 +41,7 @@ public class Approve {
     public boolean approveCollection(HttpServletRequest request, HttpServletResponse response) throws IOException, ZebedeeException {
         info().log("approve endpoint: request received");
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null) {
             warn().log("approve request: request unsuccessful valid user session not found");
             throw new UnauthorizedException("You are not authorized to approve collections");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
@@ -28,7 +28,7 @@ public class CheckCollectionsForURI {
     public String get(HttpServletRequest request, HttpServletResponse response)
             throws IOException, UnauthorizedException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null || !zebedeeCmsService.getPermissions().canEdit(session.getEmail())) {
             throw new UnauthorizedException("You are not authorised to check collections for a URI");
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CheckCollectionsForURI.java
@@ -2,7 +2,6 @@ package com.github.onsdigital.zebedee.api;
 
 import com.github.davidcarboni.restolino.framework.Api;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
-import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -45,7 +45,7 @@ public class Collection {
             throws IOException, ZebedeeException {
         info().log("get collection endpoint: request received");
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null) {
             info().log("get collection endpoint: request unsuccessful valid session for user was not found.");
             throw new UnauthorizedException("You are not authorised to view collections.");
@@ -108,7 +108,7 @@ public class Collection {
                                         CollectionDescription collectionDescription) throws IOException, ZebedeeException {
         info().log("create collection endpoint: request received");
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null) {
             warn().log("create collection endpoint: request unsuccessful no valid session found");
             throw new UnauthorizedException("You are not authorised to create collections.");
@@ -181,7 +181,7 @@ public class Collection {
 
         String collectionId = Collections.getCollectionId(request);
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null) {
             warn().data("user", session.getEmail()).data("collectionId", collectionId).log("update collection endpoint: request unsuccessful no valid session found");
             throw new UnauthorizedException("You are not authorised to update collections.");
@@ -230,7 +230,7 @@ public class Collection {
             ZebedeeException {
         info().log("delete collection endpoint: request received");
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null) {
             error().log("delete collection endpoint: request unsuccessful no valid session found");
             throw new UnauthorizedException("You are not authorised to delete collections.");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionBrowseTree.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionBrowseTree.java
@@ -33,7 +33,7 @@ public class CollectionBrowseTree {
         com.github.onsdigital.zebedee.model.Collection collection = Collections
                 .getCollection(request);
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         CollectionReader collectionReader = new ZebedeeCollectionReader(Root.zebedee, collection, session);
         return ContentTree.getOverlayed(collection, collectionReader);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -81,7 +81,7 @@ public class Collections {
         info().log("get collections endpoint: request received");
         Session session = null;
         try {
-            session = Root.zebedee.getSessionsService().get(request);
+            session = Root.zebedee.getSessions().get(request);
             if (session == null) {
                 warn().log("get collections endpoint: valid user session not found");
                 throw new UnauthorizedException("You are not authorized to perform get collections requests");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Complete.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Complete.java
@@ -36,7 +36,7 @@ public class Complete {
 
         // Locate the collection:
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String uri = request.getParameter("uri");
 
         Boolean recursive = BooleanUtils.toBoolean(StringUtils.defaultIfBlank(request.getParameter("recursive"), "false"));

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Content.java
@@ -76,7 +76,7 @@ public class Content {
         // otherwise the call to get a request parameter will actually consume the body:
         InputStream requestBody = request.getInputStream();
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         Collection collection = Collections.getCollection(request);
 
@@ -125,7 +125,7 @@ public class Content {
     public boolean delete(HttpServletRequest request, HttpServletResponse response) throws IOException,
             ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ContentMove.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ContentMove.java
@@ -22,7 +22,7 @@ public class ContentMove {
     @POST
     public boolean MoveContent(HttpServletRequest request, HttpServletResponse response) throws IOException, ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         Collection collection = Collections.getCollection(request);
 
         String uri = request.getParameter("uri");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ContentRename.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ContentRename.java
@@ -28,7 +28,7 @@ public class ContentRename {
     public boolean RenameContent(HttpServletRequest request, HttpServletResponse response) throws IOException,
             ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
 
         String uri = request.getParameter("uri");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Equation.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Equation.java
@@ -44,7 +44,7 @@ public class Equation {
             com.github.onsdigital.zebedee.content.page.statistics.document.figure.equation.Equation equation
     ) throws IOException, ZebedeeException, FileUploadException, TranscoderException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");
 
@@ -95,7 +95,7 @@ public class Equation {
             HttpServletResponse response
     ) throws IOException, ZebedeeException, FileUploadException, TranscoderException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Login.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Login.java
@@ -6,7 +6,7 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.SessionsServiceImpl;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.apache.commons.lang.BooleanUtils;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Login.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Login.java
@@ -6,7 +6,6 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
-import com.github.onsdigital.zebedee.session.service.SessionsServiceImpl;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.apache.commons.lang.BooleanUtils;
@@ -61,7 +60,7 @@ public class Login {
             response.setStatus(HttpStatus.UNAUTHORIZED_401);
             Audit.Event.LOGIN_AUTHENTICATION_FAILURE.parameters().host(request).user(credentials.getEmail()).log();
             info().data("user", user.getEmail())
-                .log("login endpoint: request unsuccessful credentials were not authenticated successfully");
+                    .log("login endpoint: request unsuccessful credentials were not authenticated successfully");
             return "Authentication failed.";
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ModifyTable.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ModifyTable.java
@@ -65,7 +65,7 @@ public class ModifyTable {
     public void modifyTable(HttpServletRequest request, HttpServletResponse response)
             throws IOException, ZebedeeException, ParserConfigurationException, TransformerException, FileUploadException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
         CollectionReader collectionReader = new ZebedeeCollectionReader(Root.zebedee, collection, session);
         String currentUri = request.getParameter(CURRENT_URI);
@@ -97,7 +97,7 @@ public class ModifyTable {
     @GET
     public void getTableMetadata(HttpServletRequest request, HttpServletResponse response) throws IOException,
             ZebedeeException {
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
 
         CollectionReader collectionReader = new ZebedeeCollectionReader(Root.zebedee, collection, session);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Password.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Password.java
@@ -46,7 +46,7 @@ public class Password {
     public String setPassword(HttpServletRequest request, HttpServletResponse response, Credentials credentials) throws IOException, UnauthorizedException, BadRequestException, NotFoundException {
 
         // Get the user session
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         // If the user is not logged in, but they are attempting to change their password, authenticate using the old password
         if (session == null && credentials != null) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
@@ -41,7 +41,7 @@ public class Permission {
     public String grantPermission(HttpServletRequest request, HttpServletResponse response, PermissionDefinition permissionDefinition)
             throws IOException, ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         // Administrator
         if (BooleanUtils.isTrue(permissionDefinition.isAdmin())) {
@@ -95,7 +95,7 @@ public class Permission {
     @GET
     public PermissionDefinition getPermissions(HttpServletRequest request, HttpServletResponse response) throws IOException, NotFoundException, UnauthorizedException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String email = request.getParameter("email");
 
         PermissionDefinition permissionDefinition = Root.zebedee.getPermissionsService().userPermissions(email, session);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Ping.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Ping.java
@@ -5,7 +5,7 @@ import com.github.onsdigital.zebedee.json.PingRequest;
 import com.github.onsdigital.zebedee.json.PingResponse;
 import com.github.onsdigital.zebedee.reader.util.RequestUtils;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.util.mertics.service.MetricsService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -44,13 +44,13 @@ public class Ping {
     private void setSessionDetails(HttpServletRequest request, PingResponse pingResponse) {
         String token = "";
         try {
-            SessionsService sessionsService = Root.zebedee.getSessionsService();
+            Sessions sessions = Root.zebedee.getSessions();
             token = RequestUtils.getSessionId(request);
-            if (sessionsService.exists(token)) {
-                Session session = sessionsService.get(token);
-                if (session != null && !sessionsService.expired(session)) {
+            if (sessions.exists(token)) {
+                Session session = sessions.get(token);
+                if (session != null && !sessions.expired(session)) {
                     pingResponse.hasSession = true;
-                    pingResponse.sessionExpiryDate = sessionsService.getExpiryDate(session);
+                    pingResponse.sessionExpiryDate = sessions.getExpiryDate(session);
                 }
             }
         } catch (IOException e) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Ping.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Ping.java
@@ -47,7 +47,7 @@ public class Ping {
             SessionsService sessionsService = Root.zebedee.getSessionsService();
             token = RequestUtils.getSessionId(request);
             if (sessionsService.exists(token)) {
-                Session session = sessionsService.read(token);
+                Session session = sessionsService.get(token);
                 if (session != null && !sessionsService.expired(session)) {
                     pingResponse.hasSession = true;
                     pingResponse.sessionExpiryDate = sessionsService.getExpiryDate(session);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Review.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Review.java
@@ -41,7 +41,7 @@ public class Review {
             throw new NotFoundException("Collection not found");
         }
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String uri = request.getParameter("uri");
 
         Boolean recursive = BooleanUtils.toBoolean(StringUtils.defaultIfBlank(request.getParameter("recursive"), "false"));

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Service.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Service.java
@@ -10,7 +10,7 @@ import com.github.onsdigital.zebedee.model.ServiceAccountWithToken;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -32,7 +32,7 @@ public class Service {
 
     private Supplier<String> randomIdGenerator = () -> Random.id();
     private ServiceStore serviceStore;
-    private SessionsService sessionsService;
+    private Sessions sessions;
     private PermissionsService permissionsService;
     private boolean datasetImportEnabled;
 
@@ -64,7 +64,7 @@ public class Service {
 
         info().log("feature EnableDatasetImport is enabled");
 
-        final Session session = getSessionsService().get(request);
+        final Session session = getSessions().get(request);
         if (session != null && getPermissionsService().isAdministrator(session)) {
             final ServiceStore serviceStoreImpl = getServiceStore();
             final String token = randomIdGenerator.get();
@@ -83,11 +83,11 @@ public class Service {
         return serviceStore;
     }
 
-    private SessionsService getSessionsService() {
-        if (sessionsService == null) {
-            sessionsService = Root.zebedee.getSessionsService();
+    private Sessions getSessions() {
+        if (sessions == null) {
+            sessions = Root.zebedee.getSessions();
         }
-        return sessionsService;
+        return sessions;
     }
 
     private PermissionsService getPermissionsService() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Table.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Table.java
@@ -38,7 +38,7 @@ public class Table {
     public void createTable(HttpServletRequest request, HttpServletResponse response)
             throws IOException, ParserConfigurationException, TransformerException, ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");
         CollectionReader collectionReader = new ZebedeeCollectionReader(Root.zebedee, collection, session);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
@@ -68,7 +68,7 @@ public class Teams {
 
     public boolean createTeam(HttpServletRequest request, HttpServletResponse response) throws IOException, ConflictException, UnauthorizedException, NotFoundException, ForbiddenException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String teamName = getTeamName(request);
 
         Root.zebedee.getTeamsService().createTeam(teamName, session);
@@ -84,7 +84,7 @@ public class Teams {
 
     public boolean addTeamMember(HttpServletRequest request, HttpServletResponse response) throws UnauthorizedException, IOException, NotFoundException, BadRequestException, ForbiddenException {
         Zebedee zebedee = Root.zebedee;
-        Session session = zebedee.getSessionsService().get(request);
+        Session session = zebedee.getSessions().get(request);
 
         String teamName = getTeamName(request);
 
@@ -132,7 +132,7 @@ public class Teams {
         String teamName = getTeamName(request);
 
         Zebedee zebedee = Root.zebedee;
-        Session session = zebedee.getSessionsService().get(request);
+        Session session = zebedee.getSessions().get(request);
         Team team = zebedee.getTeamsService().findTeam(teamName);
         zebedee.getTeamsService().deleteTeam(team, session);
 
@@ -152,7 +152,7 @@ public class Teams {
         String teamName = getTeamName(request);
 
         Zebedee zebedee = Root.zebedee;
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String email = request.getParameter("email");
         Team team = zebedee.getTeamsService().findTeam(teamName);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
@@ -6,7 +6,7 @@ import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
@@ -48,7 +48,7 @@ public class TeamsReport {
     static final String SHEET_TITLE = "Teams Summary {0}";
 
     private ServiceSupplier<TeamsService> teamsServiceSupplier = () -> Root.zebedee.getTeamsService();
-    private ServiceSupplier<SessionsService> serviceServiceSupplier = () -> Root.zebedee.getSessionsService();
+    private ServiceSupplier<Sessions> serviceServiceSupplier = () -> Root.zebedee.getSessions();
 
     /**
      * Generate an on the fly Team memmbers report XLS and write to the response as a file download.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TimeseriesImport.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TimeseriesImport.java
@@ -28,7 +28,7 @@ public class TimeseriesImport {
         // otherwise the call to get a request parameter will actually consume the body:
         try (InputStream requestBody = request.getInputStream()) {
 
-            Session session = Root.zebedee.getSessionsService().get(request);
+            Session session = Root.zebedee.getSessions().get(request);
             com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
 
             CollectionWriter collectionWriter = new ZebedeeCollectionWriter(Root.zebedee, collection, session);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Transfer.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Transfer.java
@@ -40,7 +40,7 @@ public class Transfer {
 
 
         // user has permission
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (!Root.zebedee.getPermissionsService().canEdit(session.getEmail())){
             response.setStatus(HttpStatus.UNAUTHORIZED_401);
             return false;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Unlock.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Unlock.java
@@ -31,7 +31,7 @@ public class Unlock {
             ZebedeeException {
 
         com.github.onsdigital.zebedee.model.Collection collection = Collections.getCollection(request);
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         boolean result = Root.zebedee.getCollections().unlock(collection, session);
         if (result) {
             Audit.Event.COLLECTION_UNLOCKED

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Users.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Users.java
@@ -56,7 +56,7 @@ public class Users {
         Object result = null;
 
         String email = request.getParameter(EMAIL_PARAM);
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         if (session != null) {
             // If email is empty
@@ -87,7 +87,7 @@ public class Users {
     @POST
     public UserSanitised create(HttpServletRequest request, HttpServletResponse response, User user) throws
             IOException, ConflictException, BadRequestException, UnauthorizedException {
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         User created = usersServiceSupplier.getService().create(session, user);
 
         Audit.Event.USER_CREATED
@@ -111,7 +111,7 @@ public class Users {
     @PUT
     public UserSanitised update(HttpServletRequest request, HttpServletResponse response, User updatedUser) throws
             IOException, NotFoundException, BadRequestException, UnauthorizedException {
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
 
         String email = request.getParameter(EMAIL_PARAM);
         User user = usersServiceSupplier.getService().getUserByEmail(email);
@@ -136,7 +136,7 @@ public class Users {
     public boolean delete(HttpServletRequest request, HttpServletResponse response) throws
             UnauthorizedException, IOException, NotFoundException, BadRequestException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         String email = request.getParameter(EMAIL_PARAM);
         User user = usersServiceSupplier.getService().getUserByEmail(email);
         boolean result = usersServiceSupplier.getService().delete(session, user);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
@@ -35,7 +35,7 @@ public class Version {
     @POST
     public String create(HttpServletRequest request, HttpServletResponse response) throws IOException, ZebedeeException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null || !Root.zebedee.getPermissionsService().canEdit(session.getEmail())) {
             throw new UnauthorizedException("You are not authorised to edit content.");
         }
@@ -69,7 +69,7 @@ public class Version {
     @DELETE
     public boolean delete(HttpServletRequest request, HttpServletResponse response) throws IOException, BadRequestException, NotFoundException, UnauthorizedException {
 
-        Session session = Root.zebedee.getSessionsService().get(request);
+        Session session = Root.zebedee.getSessions().get(request);
         if (session == null || !Root.zebedee.getPermissionsService().canEdit(session.getEmail())) {
             throw new UnauthorizedException("You are not authorised to edit content.");
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/AuthorisationServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/authorisation/AuthorisationServiceImpl.java
@@ -6,7 +6,7 @@ import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.apache.commons.lang3.StringUtils;
 
@@ -20,7 +20,7 @@ import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 
 public class AuthorisationServiceImpl implements AuthorisationService {
 
-    private ServiceSupplier<SessionsService> sessionServiceSupplier = () -> Root.zebedee.getSessionsService();
+    private ServiceSupplier<Sessions> sessionsSupplier = () -> Root.zebedee.getSessions();
     private ServiceSupplier<UsersService> userServiceSupplier = () -> Root.zebedee.getUsersService();
     private ServiceSupplier<Collections> collectionsSupplier = () -> Root.zebedee.getCollections();
     private ServiceSupplier<PermissionsService> permissionsServiceSupplier = () -> Root.zebedee.getPermissionsService();
@@ -39,7 +39,7 @@ public class AuthorisationServiceImpl implements AuthorisationService {
 
         Session session;
         try {
-            session = sessionServiceSupplier.getService().get(sessionID);
+            session = sessionsSupplier.getService().get(sessionID);
         } catch (IOException e) {
             error().logException(e, "identify user error, unexpected error while attempting to get user session");
             throw new UserIdentityException(INTERNAL_ERROR, SC_INTERNAL_SERVER_ERROR);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
@@ -74,7 +74,7 @@ public class AuthenticationFilter implements Filter {
         // Check all other requests:
         boolean result = false;
         try {
-            Session session = Root.zebedee.getSessionsService().get(request);
+            Session session = Root.zebedee.getSessions().get(request);
             if (session == null) {
                 forbidden(response);
             } else {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
@@ -192,7 +192,7 @@ public class KeyManager {
         zebedee.getUsersService().addKeyToKeyring(user.getEmail(), keyIdentifier, key);
 
         // If the user is logged in assign the key to their cached keyring
-        Session session = zebedee.getSessionsService().find(user.getEmail());
+        Session session = zebedee.getSessions().find(user.getEmail());
         if (session != null) {
             Keyring keyring = zebedee.getKeyringCache().get(session);
             try {
@@ -222,7 +222,7 @@ public class KeyManager {
         zebedee.getUsersService().removeKeyFromKeyring(user.getEmail(), keyIdentifier);
 
         // If the user is logged in remove the key from their cached keyring
-        Session session = zebedee.getSessionsService().find(user.getEmail());
+        Session session = zebedee.getSessions().find(user.getEmail());
         if (session != null) {
             Keyring keyring = zebedee.getKeyringCache().get(session);
             try {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
@@ -2,7 +2,7 @@ package com.github.onsdigital.zebedee.model;
 
 import com.github.onsdigital.zebedee.json.Keyring;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.model.User;
 
 import javax.crypto.SecretKey;
@@ -18,10 +18,10 @@ public class KeyringCache {
     // Publisher keyring keeps all available secret keys available
     public Map<String, SecretKey> schedulerCache = new ConcurrentHashMap<>();
     private Map<Session, Keyring> keyringMap = new ConcurrentHashMap<>();
-    private SessionsService sessionsService;
+    private Sessions sessions;
 
-    public KeyringCache(SessionsService sessionsService) {
-        this.sessionsService = sessionsService;
+    public KeyringCache(Sessions sessions) {
+        this.sessions = sessions;
     }
 
     /**
@@ -56,7 +56,7 @@ public class KeyringCache {
         Keyring result = null;
 
         if (user != null) {
-            Session session = sessionsService.find(user.getEmail());
+            Session session = sessions.find(user.getEmail());
             if (session != null) {
                 result = keyringMap.get(session);
             }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderFactory.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderFactory.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.model;
 
 import com.github.onsdigital.zebedee.Zebedee;
-import com.github.onsdigital.zebedee.api.Root;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderFactory.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderFactory.java
@@ -34,7 +34,7 @@ public class ZebedeeCollectionReaderFactory implements CollectionReaderFactory {
      */
     @Override
     public CollectionReader createCollectionReader(String collectionId, String sessionId) throws NotFoundException, IOException, BadRequestException, UnauthorizedException {
-        Session session = zebedee.getSessionsService().get(sessionId);
+        Session session = zebedee.getSessions().get(sessionId);
         Collection collection = zebedee.getCollections().getCollection(collectionId);
         return getCollectionReader(collection, session);
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
@@ -8,7 +8,7 @@ import com.github.onsdigital.zebedee.model.ServiceAccount;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -45,14 +45,14 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
 
     public static CMDPermissionsService instance = null;
 
-    private SessionsService sessionsService;
+    private Sessions sessions;
     private Collections collectionsService;
     private ServiceStore serviceStore;
     private PermissionsService collectionPermissions;
 
-    CMDPermissionsServiceImpl(SessionsService sessionsService, Collections collectionsService,
+    CMDPermissionsServiceImpl(Sessions sessions, Collections collectionsService,
                               ServiceStore serviceStore, PermissionsService collectionPermissions) {
-        this.sessionsService = sessionsService;
+        this.sessions = sessions;
         this.collectionsService = collectionsService;
         this.serviceStore = serviceStore;
         this.collectionPermissions = collectionPermissions;
@@ -129,7 +129,7 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
 
         Session session = null;
         try {
-            session = sessionsService.get(sessionID);
+            session = sessions.get(sessionID);
         } catch (IOException ex) {
             error().exception(ex).log("user dataset permissions request failed error getting session");
             throw internalServerErrorException();
@@ -140,7 +140,7 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
             throw sessionNotFoundException();
         }
 
-        if (sessionsService.expired(session)) {
+        if (sessions.expired(session)) {
             info().log("user dataset permissions request denied session expired");
             throw sessionExpiredException();
         }
@@ -238,12 +238,12 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
         if (instance == null) {
             synchronized (CMDPermissionsServiceImpl.class) {
                 if (instance == null) {
-                    SessionsService sessionsService = Root.zebedee.getSessionsService();
+                    Sessions sessions = Root.zebedee.getSessions();
                     ServiceStore serviceStore = Root.zebedee.getServiceStore();
                     Collections collections = Root.zebedee.getCollections();
                     PermissionsService permissionsService = Root.zebedee.getPermissionsService();
 
-                    instance = new CMDPermissionsServiceImpl(sessionsService, collections, serviceStore,
+                    instance = new CMDPermissionsServiceImpl(sessions, collections, serviceStore,
                             permissionsService);
                 }
             }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/Sessions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/Sessions.java
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Date;
 
-public interface SessionsService {
+public interface Sessions {
 
     /**
      * Create a new {@link Session} for the user.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
@@ -24,7 +24,7 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 /**
  * Created by david on 12/03/2015.
  */
-public class SessionsServiceImpl extends TimerTask implements SessionsService {
+public class SessionsServiceImpl extends TimerTask implements Sessions {
 
     private static final String DELETING_SESSION_MSG = "Deleting expired session";
     private static final String SESSION_ID_PARAM = "sessionId";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
@@ -1,0 +1,249 @@
+package com.github.onsdigital.zebedee.session.service;
+
+import com.github.davidcarboni.cryptolite.Random;
+import com.github.onsdigital.zebedee.model.PathUtils;
+import com.github.onsdigital.zebedee.reader.util.RequestUtils;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.session.store.SessionsStoreImpl;
+import com.github.onsdigital.zebedee.user.model.User;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+
+/**
+ * Created by david on 12/03/2015.
+ */
+public class SessionsServiceImpl extends TimerTask implements SessionsService {
+
+    private static final String DELETING_SESSION_MSG = "Deleting expired session";
+    private static final String SESSION_ID_PARAM = "sessionId";
+
+    private Supplier<String> randomIdGenerator = () -> Random.id();
+    private SessionsStoreImpl sessionsStore;
+
+    int expiryUnit = Calendar.MINUTE;
+    int expiryAmount = 60;
+    Timer timer;
+    private Path sessionsPath;
+
+    public SessionsServiceImpl(Path sessionsPath) {
+        this.sessionsPath = sessionsPath;
+        this.sessionsStore = new SessionsStoreImpl(sessionsPath);
+
+        // Run every minute after the first minute:
+        timer = new Timer("Florence sessions timer", true);
+        timer.schedule(this, 60 * 1000, 60 * 1000);
+    }
+
+    public void setExpiry(int expiryAmount, int expiryUnit) {
+        this.expiryAmount = expiryAmount;
+        this.expiryUnit = expiryUnit;
+    }
+
+    /**
+     * This is the entrypoint for {@link java.util.TimerTask}.
+     */
+    @Override
+    public void run() {
+        try {
+            deleteExpiredSessions();
+        } catch (IOException e) {
+            // Not much we can do.
+            // This could periodically spam the logs
+            // so need to review at some point.
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Creates a new session.
+     *
+     * @param user the user to create a session for
+     * @return A session for the email. If one exists it returns that else it
+     * creates a new one. If the supplied email is blank then null will
+     * be returned.
+     * @throws java.io.IOException If a filesystem error occurs.
+     */
+    public Session create(User user) throws IOException {
+        Session session = null;
+
+        if (StringUtils.isNotBlank(user.getEmail())) {
+
+            // Check for an existing session:
+            session = find(user.getEmail());
+
+            // Otherwise go ahead and create
+            if (session == null) {
+                session = new Session();
+                session.setId(randomIdGenerator.get());
+                session.setEmail(user.getEmail());
+                sessionsStore.write(session);
+            }
+        }
+
+        return session;
+    }
+
+    /**
+     * Gets the record for an existing session.
+     *
+     * @param request The {@link HttpServletRequest}.
+     * @return The requested session, unless the ID is blank or no record exists
+     * for this ID.
+     * @throws java.io.IOException If a filesystem error occurs.
+     */
+    public Session get(HttpServletRequest request) throws IOException {
+        String token = RequestUtils.getSessionId(request);
+        return get(token);
+    }
+
+    /**
+     * Gets the record for an existing session.
+     *
+     * @param id The session ID in order to locate the session record.
+     * @return The requested session, unless the ID is blank or no record exists
+     * for this ID.
+     * @throws java.io.IOException If a filesystem error occurs.
+     */
+    public Session get(String id) throws IOException {
+        Session result = null;
+
+        // Check the session record exists:
+        if (sessionsStore.exists(id)) {
+            // Deserialise the json:
+            Session session = sessionsStore.read(sessionPath(id));
+            if (!expired(session)) {
+                updateLastAccess(session);
+                result = session;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Locates a session from the user's email address (user ID).
+     *
+     * @param email The email.
+     * @return An existing session, if found.
+     * @throws IOException If a filesystem error occurs.
+     */
+    public Session find(String email) throws IOException {
+        Session session = sessionsStore.find(email);
+        if (!expired(session)) {
+            updateLastAccess(session);
+        }
+        return session;
+    }
+
+    /**
+     * Determines whether a session exists for the given ID.
+     *
+     * @param id The ID to check.
+     * @return If the ID is not blank and a corresponding session exists, true.
+     * @throws IOException If a filesystem error occurs.
+     */
+    public boolean exists(String id) throws IOException {
+        return sessionsStore.exists(id);
+    }
+
+
+    /**
+     * Iterates all sessions and deletes expired ones.
+     *
+     * @throws IOException If a filesystem error occurs.
+     */
+    public void deleteExpiredSessions() throws IOException {
+        Predicate<Session> isExpired = (session) -> expired(session);
+        List<Session> expired = sessionsStore.filterSessions(isExpired);
+
+        for (Session s : expired) {
+            info().data("user", s.getEmail()).log(DELETING_SESSION_MSG);
+            sessionsStore.delete(sessionPath(s.getId()));
+        }
+    }
+
+    /**
+     * Determines whether the given session has expired.
+     *
+     * @param session The session to check.
+     * @return If the session is not null and the last access time is
+     * more than 60 minutes in the past, true.
+     */
+    public boolean expired(Session session) {
+        boolean result = false;
+
+        if (session != null) {
+            Calendar expiry = Calendar.getInstance();
+            expiry.add(expiryUnit, -expiryAmount);
+            result = session.getLastAccess().before(expiry.getTime());
+        }
+
+        return result;
+    }
+
+
+    /**
+     * Updates the last access time and saves the session to disk.
+     *
+     * @param session The session to update.
+     * @throws IOException If a filesystem error occurs.
+     */
+    public void updateLastAccess(Session session) throws IOException {
+        if (session != null) {
+            session.setLastAccess(new Date());
+            sessionsStore.write(session);
+        }
+    }
+
+    /**
+     * Determines the filesystem path for the given session ID.
+     *
+     * @param id The ID to get a path for.
+     * @return The path, or null if the ID is blank.
+     */
+    private Path sessionPath(String id) {
+        Path result = null;
+
+        if (StringUtils.isNotBlank(id)) {
+            String sessionFileName = PathUtils.toFilename(id);
+            sessionFileName += ".json";
+            result = sessionsPath.resolve(sessionFileName);
+        }
+
+        return result;
+    }
+
+    /**
+     * Reads the session with the given ID from disk.
+     *
+     * @param id The ID to be read.
+     * @return The session, or
+     * @throws IOException
+     */
+    public Session read(String id) throws IOException {
+        return sessionsStore.read(sessionPath(id));
+    }
+
+    public Date getExpiryDate(Session session) {
+        Date expiry = null;
+
+        if (session != null) {
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(session.getLastAccess());
+            calendar.add(expiryUnit, expiryAmount);
+            expiry = calendar.getTime();
+        }
+        return expiry;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ZebedeeCmsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ZebedeeCmsService.java
@@ -58,7 +58,7 @@ public class ZebedeeCmsService {
 
     public Session getSession(HttpServletRequest request) throws ZebedeeException {
         try {
-            return Root.zebedee.getSessionsService().get(request);
+            return Root.zebedee.getSessions().get(request);
         } catch (IOException e) {
             error().logException(e, SESSION_NOT_FOUND_MSG);
             throw new UnauthorizedException(SESSION_NOT_FOUND_MSG);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ServiceTest.java
@@ -6,7 +6,7 @@ import com.github.onsdigital.zebedee.model.ServiceAccount;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -45,7 +45,7 @@ public class ServiceTest {
     private PermissionsService permissionsService;
 
     @Mock
-    private SessionsService sessionsService;
+    private Sessions sessions;
 
     @Mock
     private PrintWriter printWriterMock;
@@ -58,7 +58,7 @@ public class ServiceTest {
 
         ReflectionTestUtils.setField(api, "serviceStore", serviceStore);
         ReflectionTestUtils.setField(api, "permissionsService", permissionsService);
-        ReflectionTestUtils.setField(api, "sessionsService", sessionsService);
+        ReflectionTestUtils.setField(api, "sessions", sessions);
     }
 
     @Test
@@ -67,12 +67,12 @@ public class ServiceTest {
         session.setEmail("other@ons.gov.uk");
         session.setId("123");
 
-        when(sessionsService.get(mockRequest)).thenReturn(session);
+        when(sessions.get(mockRequest)).thenReturn(session);
         when(permissionsService.isAdministrator(session)).thenReturn(true);
         when(serviceStore.store(Mockito.anyString(), any())).thenReturn(new ServiceAccount("123"));
         when(mockResponse.getWriter()).thenReturn(printWriterMock);
         api.createService(mockRequest, mockResponse);
-        verify(sessionsService, times(1)).get(mockRequest);
+        verify(sessions, times(1)).get(mockRequest);
         verify(permissionsService, times(1)).isAdministrator(session);
         verify(serviceStore, times(1)).store(Mockito.anyString(), any());
         verify(mockResponse).setStatus(HttpServletResponse.SC_CREATED);
@@ -84,11 +84,11 @@ public class ServiceTest {
         session.setEmail("other@ons.gov.uk");
         session.setId("123");
 
-        when(sessionsService.get(mockRequest)).thenReturn(session);
+        when(sessions.get(mockRequest)).thenReturn(session);
         when(permissionsService.isAdministrator(session)).thenReturn(false);
         when(serviceStore.store(Mockito.anyString(), any())).thenReturn(new ServiceAccount("123"));
         api.createService(mockRequest, mockResponse);
-        verify(sessionsService, times(1)).get(mockRequest);
+        verify(sessions, times(1)).get(mockRequest);
         verify(permissionsService, times(1)).isAdministrator(session);
         verify(serviceStore, times(0)).store(Mockito.anyString(), any());
         verify(mockResponse).setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -106,7 +106,7 @@ public class ServiceTest {
         api = new Service(false); // explicitly disable the feature for this test case.
         api.createService(mockRequest, mockResponse);
 
-        verifyZeroInteractions(sessionsService, permissionsService, serviceStore);
+        verifyZeroInteractions(sessions, permissionsService, serviceStore);
 
         verify(mockResponse, times(1)).getWriter();
         verify(mockResponse, times(1)).setCharacterEncoding(StandardCharsets.UTF_8.name());

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
@@ -2,7 +2,7 @@ package com.github.onsdigital.zebedee.api;
 
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -42,7 +42,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
     private TeamsService teamsService;
 
     @Mock
-    private SessionsService sessionsService;
+    private Sessions sessions;
 
     private TeamsReport api;
 
@@ -53,7 +53,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
         api = new TeamsReport();
 
         ServiceSupplier<TeamsService> teamsServiceSupplier = () -> teamsService;
-        ServiceSupplier<SessionsService> sessionsServiceSupplier = () -> sessionsService;
+        ServiceSupplier<Sessions> sessionsServiceSupplier = () -> sessions;
 
         ReflectionTestUtils.setField(api, "teamsServiceSupplier", teamsServiceSupplier);
         ReflectionTestUtils.setField(api, "serviceServiceSupplier", sessionsServiceSupplier);
@@ -66,7 +66,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
 
     @Test(expected = UnauthorizedException.class)
     public void getReport_ShouldProbegateExceptionFromTeamsService() throws Exception {
-        when(sessionsService.get(mockRequest))
+        when(sessions.get(mockRequest))
                 .thenReturn(session);
         when(teamsService.getTeamMembersSummary(any()))
                 .thenThrow(new UnauthorizedException(""));
@@ -74,7 +74,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
         try {
             api.getReport(mockRequest, mockResponse);
         } catch (UnauthorizedException e) {
-            verify(sessionsService, times(1)).get(mockRequest);
+            verify(sessions, times(1)).get(mockRequest);
             verify(teamsService, times(1)).getTeamMembersSummary(session);
             verify(mockResponse, never()).getOutputStream();
             throw e;
@@ -93,7 +93,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
         teamUserMapping.add(create("CTeam", "userA"));
         teamUserMapping.add(create("CTeam", "userC"));
 
-        when(sessionsService.get(mockRequest))
+        when(sessions.get(mockRequest))
                 .thenReturn(session);
         when(teamsService.getTeamMembersSummary(session))
                 .thenReturn(teamUserMapping);
@@ -109,7 +109,7 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
         assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
         assertThat(response.getContentType(), equalTo(MediaType.APPLICATION_OCTET_STREAM_VALUE));
 
-        verify(sessionsService, times(1)).get(mockRequest);
+        verify(sessions, times(1)).get(mockRequest);
         verify(teamsService, times(1)).getTeamMembersSummary(session);
 
         // assert that HSSFWorkbook is as expected.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyManagerTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyManagerTest.java
@@ -6,7 +6,7 @@ import com.github.onsdigital.zebedee.json.Keyring;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsServiceImpl;
 import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.session.service.SessionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import com.github.onsdigital.zebedee.user.service.UsersService;
@@ -56,7 +56,7 @@ public class KeyManagerTest {
     private Keyring keyring, userKeyring, user2Keyring;
 
     @Mock
-    private SessionsService sessionsService;
+    private Sessions sessions;
 
     @Mock
     private Session session, user2Session;
@@ -95,8 +95,8 @@ public class KeyManagerTest {
 
         when(zebedee.getUsersService())
                 .thenReturn(usersService);
-        when(zebedee.getSessionsService())
-                .thenReturn(sessionsService);
+        when(zebedee.getSessions())
+                .thenReturn(sessions);
         when(zebedee.getKeyringCache())
                 .thenReturn(keyringCache);
         when(zebedee.getPermissionsService())
@@ -127,7 +127,7 @@ public class KeyManagerTest {
     public void assignKeyToUser_Success() throws Exception {
         when(user.keyring())
                 .thenReturn(keyring);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
 
         when(keyringCache.get(session))
@@ -139,7 +139,7 @@ public class KeyManagerTest {
         verify(user, times(2)).getEmail();
         verify(zebedee, times(1)).getUsersService();
         verify(usersService, times(1)).addKeyToKeyring(EMAIL, COLLECTION_ID, secretKey);
-        verify(zebedee, times(1)).getSessionsService();
+        verify(zebedee, times(1)).getSessions();
         verify(zebedee, times(1)).getKeyringCache();
         verify(keyringCache, times(1)).get(session);
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
@@ -161,7 +161,7 @@ public class KeyManagerTest {
         verify(zebedee, times(1)).getUsersService();
         verify(usersService, times(1)).list();
         verifyNoMoreInteractions(zebedee, usersService);
-        verifyZeroInteractions(permissionsServiceImpl, keyringCache, keyring, sessionsService, secretKey);
+        verifyZeroInteractions(permissionsServiceImpl, keyringCache, keyring, sessions, secretKey);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class KeyManagerTest {
         verify(zebedee, times(1)).getUsersService();
         verify(usersService, times(1)).list();
         verifyNoMoreInteractions(zebedee, usersService);
-        verifyZeroInteractions(permissionsServiceImpl, keyringCache, keyring, sessionsService, secretKey);
+        verifyZeroInteractions(permissionsServiceImpl, keyringCache, keyring, sessions, secretKey);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class KeyManagerTest {
                 .thenReturn(false);
         when(permissionsServiceImpl.canEdit(EMAIL))
                 .thenReturn(false);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(keyringCache.get(session))
                 .thenReturn(keyring);
@@ -205,7 +205,7 @@ public class KeyManagerTest {
 
         verify(zebedee, times(2)).getUsersService();
         verify(zebedee, times(2)).getPermissionsService();
-        verify(zebedee, times(1)).getSessionsService();
+        verify(zebedee, times(1)).getSessions();
         verify(zebedee, times(1)).getKeyringCache();
         verify(permissionsServiceImpl, times(1)).isAdministrator(EMAIL);
         verify(permissionsServiceImpl, times(1)).canEdit(EMAIL);
@@ -213,10 +213,10 @@ public class KeyManagerTest {
         verify(keyring, times(1)).remove(COLLECTION_ID);
         verify(usersService, times(1)).list();
         verify(usersService, times(1)).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
-        verify(sessionsService, times(1)).find(EMAIL);
+        verify(sessions, times(1)).find(EMAIL);
         verify(user, times(5)).getEmail();
         verify(user, times(1)).keyring();
-        verifyNoMoreInteractions(zebedee, permissionsServiceImpl, usersService, sessionsService, keyringCache, user, keyring, session);
+        verifyNoMoreInteractions(zebedee, permissionsServiceImpl, usersService, sessions, keyringCache, user, keyring, session);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class KeyManagerTest {
                 .thenReturn(true);
         when(permissionsServiceImpl.canEdit(EMAIL))
                 .thenReturn(false);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(keyringCache.get(session))
                 .thenReturn(keyring);
@@ -241,7 +241,7 @@ public class KeyManagerTest {
 
         verify(zebedee, times(2)).getUsersService();
         verify(zebedee, times(1)).getPermissionsService();
-        verify(zebedee, times(1)).getSessionsService();
+        verify(zebedee, times(1)).getSessions();
         verify(zebedee, times(1)).getKeyringCache();
         verify(permissionsServiceImpl, times(1)).isAdministrator(EMAIL);
         verify(permissionsServiceImpl, never()).canEdit(EMAIL);
@@ -249,10 +249,10 @@ public class KeyManagerTest {
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
         verify(usersService, times(1)).list();
         verify(usersService, times(1)).addKeyToKeyring(EMAIL, COLLECTION_ID, secretKey);
-        verify(sessionsService, times(1)).find(EMAIL);
+        verify(sessions, times(1)).find(EMAIL);
         verify(user, times(4)).getEmail();
         verify(user, times(1)).keyring();
-        verifyNoMoreInteractions(zebedee, permissionsServiceImpl, usersService, sessionsService, keyringCache, user, keyring, session);
+        verifyNoMoreInteractions(zebedee, permissionsServiceImpl, usersService, sessions, keyringCache, user, keyring, session);
     }
 
     @Test
@@ -304,7 +304,7 @@ public class KeyManagerTest {
                 .thenReturn(false);
         when(permissionsServiceImpl.canView(user, collectionDescription))
                 .thenReturn(false);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(user.keyring())
                 .thenReturn(keyring);
@@ -319,8 +319,8 @@ public class KeyManagerTest {
         verify(permissionsServiceImpl, times(1)).canView(user, collectionDescription);
         verify(zebedee, times(1)).getUsersService();
         verify(usersService, times(1)).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
-        verify(zebedee, times(1)).getSessionsService();
-        verify(sessionsService, times(1)).find(EMAIL);
+        verify(zebedee, times(1)).getSessions();
+        verify(sessions, times(1)).find(EMAIL);
         verify(keyring, times(1)).remove(COLLECTION_ID);
     }
 
@@ -332,7 +332,7 @@ public class KeyManagerTest {
                 .thenReturn(secretKey);
         when(permissionsServiceImpl.isAdministrator(EMAIL))
                 .thenReturn(true);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(user.keyring())
                 .thenReturn(keyring);
@@ -343,9 +343,9 @@ public class KeyManagerTest {
         verify(keyringCache, times(2)).get(session);
         verify(keyring, times(1)).get(COLLECTION_ID);
         verify(user, times(1)).keyring();
-        verify(zebedee, times(1)).getSessionsService();
+        verify(zebedee, times(1)).getSessions();
         verify(usersService, times(1)).addKeyToKeyring(EMAIL, COLLECTION_ID, secretKey);
-        verify(sessionsService, times(1)).find(EMAIL);
+        verify(sessions, times(1)).find(EMAIL);
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
     }
 
@@ -366,9 +366,9 @@ public class KeyManagerTest {
                 .thenReturn(permissionsServiceImpl);
         when(permissionsServiceImpl.getCollectionAccessMapping(collection))
                 .thenReturn(keyRecipients);
-        when(zebedee.getSessionsService())
-                .thenReturn(sessionsService);
-        when(sessionsService.find(EMAIL))
+        when(zebedee.getSessions())
+                .thenReturn(sessions);
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
 
         KeyManager.distributeCollectionKey(zebedee, session, collection, true);
@@ -378,7 +378,7 @@ public class KeyManagerTest {
         verify(usersService, never()).addKeyToKeyring(USER2_EMAIL, COLLECTION_ID, secretKey);
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
 
-        verify(sessionsService, never()).find(USER2_EMAIL);
+        verify(sessions, never()).find(USER2_EMAIL);
         verify(user2Keyring, never()).put(COLLECTION_ID, secretKey);
     }
 
@@ -399,7 +399,7 @@ public class KeyManagerTest {
                 .thenReturn(null);
         when(usersService.list())
                 .thenReturn(users);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(keyringCache.getSchedulerCache())
                 .thenReturn(schedulerCache);
@@ -411,7 +411,7 @@ public class KeyManagerTest {
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
         verify(usersService, never()).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
-        verify(sessionsService, never()).find(EMAIL);
+        verify(sessions, never()).find(EMAIL);
         verify(keyring, never()).put(COLLECTION_ID, secretKey);
         verify(schedulerCache, times(1)).put(COLLECTION_ID, secretKey);
     }
@@ -440,9 +440,9 @@ public class KeyManagerTest {
                 .thenReturn(permittedUsers);
         when(usersService.list())
                 .thenReturn(allUsers);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
-        when(sessionsService.find(USER2_EMAIL))
+        when(sessions.find(USER2_EMAIL))
                 .thenReturn(user2Session);
         when(keyringCache.getSchedulerCache())
                 .thenReturn(schedulerCache);
@@ -452,8 +452,8 @@ public class KeyManagerTest {
         verify(zebedee, times(4)).getKeyringCache();
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
-        verify(sessionsService, times(1)).find(EMAIL);
-        verify(sessionsService, times(1)).find(USER2_EMAIL);
+        verify(sessions, times(1)).find(EMAIL);
+        verify(sessions, times(1)).find(USER2_EMAIL);
         verify(usersService, times(1)).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
         verify(usersService, times(1)).addKeyToKeyring(USER2_EMAIL, COLLECTION_ID, secretKey);
         verify(keyring, times(1)).remove(COLLECTION_ID);
@@ -478,7 +478,7 @@ public class KeyManagerTest {
                 .thenReturn(users);
         when(usersService.list())
                 .thenReturn(users);
-        when(sessionsService.find(EMAIL))
+        when(sessions.find(EMAIL))
                 .thenReturn(session);
         when(keyringCache.getSchedulerCache())
                 .thenReturn(schedulerCache);
@@ -491,7 +491,7 @@ public class KeyManagerTest {
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
         verify(usersService, never()).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
-        verify(sessionsService, times(1)).find(EMAIL);
+        verify(sessions, times(1)).find(EMAIL);
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
         verify(schedulerCache, times(1)).put(COLLECTION_ID, secretKey);
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsServiceServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsServiceServiceImplTest.java
@@ -41,9 +41,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Test verify behaviour or {@link SessionsService}.
+ * Test verify behaviour or {@link SessionsServiceImpl}.
  */
-public class SessionsServiceTest {
+public class SessionsServiceServiceImplTest {
 
     private static ObjectMapper OBJ_MAPPER = new ObjectMapper();
     private static final String EMAIL = "TEST@ons.gov.uk";
@@ -67,7 +67,7 @@ public class SessionsServiceTest {
     private Session sessionMock;
 
     private Credentials credentials;
-    private SessionsService sessionsService;
+    private SessionsServiceImpl sessionsServiceImpl;
     private Path sessionsPath;
     private User user;
 
@@ -95,7 +95,7 @@ public class SessionsServiceTest {
         credentials.email = EMAIL;
         credentials.password = PWD;
 
-        sessionsService = new SessionsService(sessionsPath);
+        sessionsServiceImpl = new SessionsServiceImpl(sessionsPath);
 
         user = new User();
         user.setEmail(EMAIL);
@@ -103,8 +103,8 @@ public class SessionsServiceTest {
         when(randomIdGenerator.get())
                 .thenReturn(SESSION_ID);
 
-        ReflectionTestUtils.setField(sessionsService, "randomIdGenerator", randomIdGenerator);
-        ReflectionTestUtils.setField(sessionsService, "sessionsStore", sessionsStore);
+        ReflectionTestUtils.setField(sessionsServiceImpl, "randomIdGenerator", randomIdGenerator);
+        ReflectionTestUtils.setField(sessionsServiceImpl, "sessionsStore", sessionsStore);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class SessionsServiceTest {
         expected.setEmail(EMAIL);
         expected.setId(SESSION_ID);
 
-        Session actual = sessionsService.create(user);
+        Session actual = sessionsServiceImpl.create(user);
 
         assertThat(expected, equalTo(actual));
         verify(sessionsStore, times(1)).write(expected);
@@ -122,7 +122,7 @@ public class SessionsServiceTest {
 
     @Test
     public void shouldNotCreateDuplicateSession() throws IOException, NotFoundException, BadRequestException {
-        ReflectionTestUtils.setField(sessionsService, "sessionsStore", sessionsStore);
+        ReflectionTestUtils.setField(sessionsServiceImpl, "sessionsStore", sessionsStore);
         Path p = sessionPath();
 
         when(sessionsStore.read(any()))
@@ -132,7 +132,7 @@ public class SessionsServiceTest {
         when(sessionMock.getLastAccess())
                 .thenReturn(new Date());
 
-        sessionsService.create(user);
+        sessionsServiceImpl.create(user);
 
         when(sessionsStore.find(EMAIL))
                 .thenReturn(sessionMock);
@@ -140,7 +140,7 @@ public class SessionsServiceTest {
         when(sessionsStore.read(any()))
                 .thenReturn(sessionMock);
 
-        sessionsService.create(user);
+        sessionsServiceImpl.create(user);
 
         verify(sessionsStore, times(2)).find(EMAIL);
         verify(sessionsStore, times(1)).write(sessionMock);
@@ -150,7 +150,7 @@ public class SessionsServiceTest {
     public void shouldGetSession() throws IOException, NotFoundException, BadRequestException {
         // Create a session.
         randomIdGenerator = () -> Random.id();
-        ReflectionTestUtils.setField(sessionsService, "randomIdGenerator", randomIdGenerator);
+        ReflectionTestUtils.setField(sessionsServiceImpl, "randomIdGenerator", randomIdGenerator);
 
 
         // create a session.
@@ -163,7 +163,7 @@ public class SessionsServiceTest {
         when(sessionsStore.read(sessionPath()))
                 .thenReturn(expected);
 
-        assertThat(sessionsService.get(SESSION_ID), equalTo(expected));
+        assertThat(sessionsServiceImpl.get(SESSION_ID), equalTo(expected));
         verify(sessionsStore, times(1)).exists(SESSION_ID);
         verify(sessionsStore, times(1)).read(sessionPath());
     }
@@ -173,14 +173,14 @@ public class SessionsServiceTest {
         when(sessionsStore.find(EMAIL))
                 .thenReturn(null);
 
-        assertThat(sessionsService.find(EMAIL), equalTo(null));
+        assertThat(sessionsServiceImpl.find(EMAIL), equalTo(null));
         verify(sessionsStore, times(1)).find(EMAIL);
         verify(sessionsStore, never()).write(any(Session.class));
     }
 
     @Test
     public void shouldReturnNullIfEmailIsEmptyOfNull() throws IOException, NotFoundException, BadRequestException {
-        Session result = sessionsService.create(new User());
+        Session result = sessionsServiceImpl.create(new User());
 
         assertNull(result);
         verify(sessionsStore, never()).find(anyString());
@@ -194,7 +194,7 @@ public class SessionsServiceTest {
         when(sessionMock.getLastAccess())
                 .thenReturn(new Date());
 
-        assertThat(sessionsService.find(EMAIL), equalTo(sessionMock));
+        assertThat(sessionsServiceImpl.find(EMAIL), equalTo(sessionMock));
         verify(sessionsStore, times(1)).find(EMAIL);
         verify(sessionMock, times(1)).setLastAccess(any(Date.class));
         verify(sessionMock, times(1)).getLastAccess();
@@ -206,7 +206,7 @@ public class SessionsServiceTest {
         when(sessionsStore.find(EMAIL))
                 .thenReturn(null);
 
-        assertNull(sessionsService.find(EMAIL));
+        assertNull(sessionsServiceImpl.find(EMAIL));
         verify(sessionsStore, times(1)).find(EMAIL);
         verify(sessionsStore, never()).write(any(Session.class));
     }
@@ -221,7 +221,7 @@ public class SessionsServiceTest {
         when(sessionMock.getId())
                 .thenReturn(SESSION_ID);
 
-        sessionsService.deleteExpiredSessions();
+        sessionsServiceImpl.deleteExpiredSessions();
 
         verify(sessionsStore, times(1)).filterSessions(any(Predicate.class));
         verify(sessionMock, times(1)).getId();
@@ -236,7 +236,7 @@ public class SessionsServiceTest {
         when(sessionMock.getLastAccess())
                 .thenReturn(currentTime.toDate());
 
-        Date result = sessionsService.getExpiryDate(sessionMock);
+        Date result = sessionsServiceImpl.getExpiryDate(sessionMock);
         DateTime actual = new DateTime(result);
 
         assertThat(actual.getYear(), equalTo(expected.getYear()));


### PR DESCRIPTION
Created a new `Sessions` interface to create an abstraction between Zebedee and the current file based sessions service impl. The interface defines the same methods as before so there should be no change in behaviour or functionality.

This is step one in splitting out the sessions functionality into its own service. Even if this never happens using interfaces is general considered best practice because:

- It decouples calling code from an implementation.
- It allows us to test code using the interface more easily with mocks.
- It allows us to change which implementation used with minimal impact on the rest of the code.


