### PR TITLE
Fix for publishing being broken from getter/setter updated

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
@@ -5,15 +5,14 @@ import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
-
 
 public class PublishedCollection extends CollectionBase {
 
-    private CollectionDataset[] datasets;
-    private CollectionDatasetVersion[] datasetVersions;
+    private List<CollectionDataset> datasets = new ArrayList<CollectionDataset>();
+    private List<CollectionDatasetVersion> datasetVersions = new ArrayList<CollectionDatasetVersion>();
 
     public PublishedCollection(String id, String name, CollectionType type, Date publishDate) {
         this.id = id;
@@ -37,19 +36,19 @@ public class PublishedCollection extends CollectionBase {
      */
     public List<Result> publishResults;
 
-    public CollectionDataset[] getDatasets() {
+    public List<CollectionDataset> getDatasets() {
         return this.datasets;
     }
 
-    public void setDatasets(CollectionDataset[] datasets) {
+    public void setDatasets(List<CollectionDataset> datasets) {
         this.datasets = datasets;
     }
 
-    public CollectionDatasetVersion[] getDatasetVersions() {
+    public List<CollectionDatasetVersion> getDatasetVersions() {
         return this.datasetVersions;
     }
 
-    public void setDatasetVersions(CollectionDatasetVersion[] datasetVersions) {
+    public void setDatasetVersions(List<CollectionDatasetVersion> datasetVersions) {
         this.datasetVersions = datasetVersions;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/publishing/PublishedCollection.java
@@ -12,8 +12,8 @@ import java.util.Set;
 
 public class PublishedCollection extends CollectionBase {
 
-    private CollectionDataset datasets;
-    private CollectionDatasetVersion datasetVersions;
+    private CollectionDataset[] datasets;
+    private CollectionDatasetVersion[] datasetVersions;
 
     public PublishedCollection(String id, String name, CollectionType type, Date publishDate) {
         this.id = id;
@@ -37,19 +37,19 @@ public class PublishedCollection extends CollectionBase {
      */
     public List<Result> publishResults;
 
-    public CollectionDataset getDatasets() {
+    public CollectionDataset[] getDatasets() {
         return this.datasets;
     }
 
-    public void setDatasets(CollectionDataset datasets) {
+    public void setDatasets(CollectionDataset[] datasets) {
         this.datasets = datasets;
     }
 
-    public CollectionDatasetVersion getDatasetVersions() {
+    public CollectionDatasetVersion[] getDatasetVersions() {
         return this.datasetVersions;
     }
 
-    public void setDatasetVersions(CollectionDatasetVersion datasetVersions) {
+    public void setDatasetVersions(CollectionDatasetVersion[] datasetVersions) {
         this.datasetVersions = datasetVersions;
     }
 


### PR DESCRIPTION
### What

The change from java.utils.Set to getters and setters changed the expected input
- input is an array of objects, this was trying to marshal the array as a single object

e.g. 
```
"datasets":[{"id":"cpih01","title":"Consumer Prices Index including owner occupiers? housing costs (CPIH)","state":"Reviewed","uri":"http://localhost:22000/datasets/cpih01","lastEditedBy":"florence@magicroundabout.ons.gov.uk"}],"datasetVersions":[{"id":"cpih01","title":"Consumer Prices Index including owner occupiers? housing costs (CPIH)","edition":"time-series","version":"15","uri":"http://localhost:22000/datasets/cpih01/editions/time-series/versions/15","state":"Reviewed","lastEditedBy":"florence@magicroundabout.ons.gov.uk"}]
```
### How to review

Try to publish something and view the report screen

### Who can review

Anyone except me