### PR TITLE
removed service account tokens from log output

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/cmd/ServiceInstancePermissions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/cmd/ServiceInstancePermissions.java
@@ -59,6 +59,6 @@ public class ServiceInstancePermissions extends PermissionsAPIBase {
             throw serviceTokenNotProvidedException();
         }
 
-        info().serviceAccountID(serviceToken).log("handling valid service instance permissions request");
+        info().log("handling valid service instance permissions request");
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
@@ -6,6 +6,7 @@ import com.github.onsdigital.logging.v2.event.Severity;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.model.ClickEvent;
 import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.ServiceAccount;
 import com.github.onsdigital.zebedee.permissions.cmd.CRUD;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.apache.commons.lang3.StringUtils;
@@ -79,16 +80,9 @@ public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
         return this;
     }
 
-    public CMSLogEvent serviceAccountID(String serviceAccountID) {
-        if (StringUtils.isNotEmpty(serviceAccountID)) {
-            data("service_account_id", serviceAccountID);
-        }
-        return this;
-    }
-
-    public CMSLogEvent serviceAccountToken(String serviceAccountToken) {
-        if (StringUtils.isNotEmpty(serviceAccountToken)) {
-            data("service_account_token", serviceAccountToken);
+    public CMSLogEvent serviceAccountID(ServiceAccount account) {
+        if (account != null && StringUtils.isNotEmpty(account.getID())) {
+            data("service_account_id", account.getID());
         }
         return this;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
@@ -95,7 +95,7 @@ public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
     }
 
     public CMSLogEvent florenceClickEvent(ClickEvent e) {
-        if (null != e) {
+        if (null != e && e.getCollection() != null) {
             collectionID(e.getCollection().getId());
             data("trigger", e.getTrigger());
             user(e.getUser());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
@@ -181,15 +181,12 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
         try {
             account = serviceStore.get(serviceToken);
         } catch (IOException ex) {
-            error().exception(ex)
-                    .serviceAccountToken(serviceToken)
-                    .log("service dataset permissons request failed error getting service account");
+            error().exception(ex).log("service dataset permissons request failed error getting service account");
             throw internalServerErrorException();
         }
 
         if (account == null) {
-            error().serviceAccountToken(serviceToken)
-                    .log("service dataset permissons request denied service account not found");
+            error().log("service dataset permissons request denied service account not found");
             throw serviceAccountNotFoundException();
         }
         return account;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CRUD.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CRUD.java
@@ -55,7 +55,7 @@ public class CRUD {
 
     public static CRUD grantServiceAccountDatasetCreateReadUpdateDelete(GetPermissionsRequest request,
                                                                         ServiceAccount serviceAccount) {
-        info().serviceAccountID(serviceAccount.getID())
+        info().serviceAccountID(serviceAccount)
                 .datasetID(request.getDatasetID())
                 .log("granting full CRUD permissions to service account");
         return new CRUD().permit(CREATE, READ, UPDATE, DELETE);
@@ -92,7 +92,7 @@ public class CRUD {
 
     public static CRUD grantServiceAccountInstanceCreateReadUpdateDelete(GetPermissionsRequest request,
                                                                         ServiceAccount serviceAccount) {
-        info().serviceAccountID(serviceAccount.getID())
+        info().serviceAccountID(serviceAccount)
                 .datasetID(request.getDatasetID())
                 .log("granting full CRUD instance permissions to service account");
         return new CRUD().permit(CREATE, READ, UPDATE, DELETE);


### PR DESCRIPTION
### What

- Updated logging/log event to ensure `service account tokens` are not output to logs (whoops).
- Fixed null pointer exception in click event logging for events without a collection.

### How to review

Code review.

### Who can review

@janderson2 @jessjenkins @eldeal 
