### PR TITLE
code changes to clean up properly after deleting content

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
@@ -11,6 +11,8 @@ import com.github.onsdigital.zebedee.permissions.cmd.CRUD;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.apache.commons.lang3.StringUtils;
 
+import java.nio.file.Path;
+
 import static com.github.onsdigital.logging.v2.DPLogger.logConfig;
 
 public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
@@ -90,6 +92,20 @@ public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
     public CMSLogEvent datasetPermissions(CRUD CRUD) {
         if (CRUD != null) {
             data("dataset_permissions", CRUD);
+        }
+        return this;
+    }
+
+    public CMSLogEvent uri(Path uri) {
+        if (uri != null) {
+            uri(uri.toString());
+        }
+        return this;
+    }
+
+    public CMSLogEvent uri(String uri) {
+        if (StringUtils.isNotEmpty(uri)) {
+            data("uri", uri);
         }
         return this;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -987,7 +987,7 @@ public class Collection {
     }
 
     /**
-     * Delete a content page and clean up any related/generated files.
+     * Delete a data.json page and any related/generated files.
      * <p>
      * Delete the specified data.json and any other files in the same directory - non data.json files in the same
      * directory are supplimentary files related to the page content - tables, charts, images etc. Also deletes any
@@ -995,7 +995,7 @@ public class Collection {
      *
      * @return true the delete is successful, false otherwise.
      */
-    public boolean deleteDataJSON(String uri) throws IOException {
+    public boolean deleteFileAndRelated(String uri) throws IOException {
         boolean deleteSuccessful = false;
 
         String checkURI = uri;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -78,6 +78,7 @@ import java.util.stream.Collectors;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
+import static com.github.onsdigital.zebedee.model.content.item.VersionedContentItem.isVersionedUri;
 import static com.github.onsdigital.zebedee.persistence.CollectionEventType.COLLECTION_CONTENT_REVIEWED;
 import static com.github.onsdigital.zebedee.persistence.CollectionEventType.COLLECTION_CREATED;
 import static com.github.onsdigital.zebedee.persistence.CollectionEventType.COLLECTION_NAME_CHANGED;
@@ -983,6 +984,69 @@ public class Collection {
             return reviewed.delete(uri);
         }
         return false;
+    }
+
+    /**
+     * Delete a content page and clean up any related/generated files.
+     * <p>
+     * Delete the specified data.json and any other files in the same directory - non data.json files in the same
+     * directory are supplimentary files related to the page content - tables, charts, images etc. Also deletes any
+     * files in the reviewed dir that are version URIs and start with the same dir path.
+     *
+     * @return true the delete is successful, false otherwise.
+     */
+    public boolean deleteDataJSON(String uri) throws IOException {
+        boolean deleteSuccessful = false;
+
+        String checkURI = uri;
+        if (Content.isDataJsonFile(uri)) {
+            checkURI = Paths.get(uri).getParent().toString();
+        }
+
+        if (isInProgress(checkURI)) {
+            deleteSuccessful = inProgress.deleteContentJson(uri);
+        } else if (isComplete(checkURI)) {
+            deleteSuccessful = complete.deleteContentJson(uri);
+        } else if (isReviewed(checkURI)) {
+            deleteSuccessful = reviewed.deleteContentJson(uri);
+        }
+
+        if (deleteSuccessful) {
+            deleteSuccessful &= deleteRelatedVersionedContent(uri);
+        }
+
+        return deleteSuccessful;
+    }
+
+    /**
+     * Delete all previous version content that is a child of the privided URI from the collection reviewed dir.
+     * <p>
+     * When new version of certain content types is created the previous versions are automagically
+     * calculated and put straight into reviewed state. Previous versions are not visible via Florence so if the
+     * newly created version is delete from the collection we need to tidy up these files as they can block users
+     * from appoving the collection or adding the same content again.
+     *
+     * @param uri
+     * @return
+     * @throws IOException
+     */
+    private boolean deleteRelatedVersionedContent(String uri) throws IOException {
+        boolean deleteSuccessful = true;
+
+        List<String> versionedFiles = reviewedUris()
+                .stream()
+                .filter(contentURI -> contentURI.startsWith(contentURI) && isVersionedUri(contentURI))
+                .collect(Collectors.toList());
+
+        if (!versionedFiles.isEmpty()) {
+            info().data("files", versionedFiles).data("uri", uri).log("deleting generated previous version files for uri");
+
+            for (String f : versionedFiles) {
+                deleteSuccessful &= deleteFile(f);
+            }
+        }
+
+        return deleteSuccessful;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -744,10 +744,10 @@ public class Collections {
         CMSLogEvent event = info().collectionID(collection).uri(contentTargetPath);
 
         if (isDataVisualisationFile(contentTargetPath)) {
-            event.log("deleting data viz zip form collection content");
+            event.log("deleting data viz zip from collection content");
             deleted = collection.deleteDataVisContent(session, Paths.get(uri));
         } else if (Files.isDirectory(contentTargetPath)) {
-            event.log("deleting directory form collection content");
+            event.log("deleting directory from collection content");
             deleted = collection.deleteContentDirectory(session.getEmail(), uri);
         } else if (Content.isDataJsonFile(uri)) {
             event.log("deleting data.json and related files from collection content");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -734,7 +734,7 @@ public class Collections {
         } else if (Files.isDirectory(path)) {
             deleted = collection.deleteContentDirectory(session.getEmail(), uri);
         } else {
-            deleted = collection.deleteFile(uri);
+            deleted = deleteFile(collection, uri);
         }
 
         eventType = COLLECTION_CONTENT_DELETED;
@@ -746,6 +746,18 @@ public class Collections {
                     eventType, uri));
         }
         return deleted;
+    }
+
+    private boolean deleteFile(Collection collection, String uri) throws IOException {
+        boolean deleteSuccessful;
+
+        if (Content.isDataJsonFile(uri)) {
+            deleteSuccessful = collection.deleteDataJSON(uri);
+        } else {
+            deleteSuccessful = collection.deleteFile(uri);
+        }
+
+        return deleteSuccessful;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -413,8 +413,8 @@ public class Content {
                     .filter(p -> p.toFile().isFile())
                     .collect(Collectors.toList());
 
-            for (Path p : filesToDelete) {
-                deleteSuccessful &= Files.deleteIfExists(p);
+            for (Path uri : filesToDelete) {
+                deleteSuccessful &= Files.deleteIfExists(uri);
             }
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -388,7 +388,7 @@ public class Content {
             deleteSuccessful = false;
         } else if (isDataJsonFile(pathToDelete)) {
             Path parentDir = pathToDelete.getParent();
-            deleteSuccessful = deleteDataJsonFile(parentDir);
+            deleteSuccessful = deleteDataJsonFileAndRelatedPreviousVersionFiles(parentDir);
         } else {
             deleteSuccessful = Files.deleteIfExists(pathToDelete);
         }
@@ -404,7 +404,7 @@ public class Content {
      * Delete files from the specified collection directory. directories and cy_data.json are exluded all other files
      * will be deleted.
      */
-    boolean deleteDataJsonFile(Path path) throws IOException {
+    boolean deleteDataJsonFileAndRelatedPreviousVersionFiles(Path path) throws IOException {
         boolean deleteSuccessful = true;
 
         if (!Files.isDirectory(path)) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -32,20 +32,10 @@ public class Content {
     public static final String DATA_VIS_DIR = "visualisations";
     public static final String TIME_SERIES_KEYWORD = "timeseries";
     private static final String DATA_JSON = "data.json";
-    private static final String WELSH_DATA_JSON = "cy_data.json";
+    private static final String WELSH_DATA_JSON = "data_cy.json";
 
     private static final Predicate<Path> IS_DATA_VIZ_FILE = (p) -> p != null && p.toFile().isDirectory() &&
             DATA_VIS_DIR.equals(p.getFileName().toString());
-
-    private static final Predicate<Path> IS_CONTENT_DELETE = (p) -> {
-        boolean canDelete;
-        if (p == null) {
-            canDelete = false;
-        } else {
-            canDelete = !p.toFile().isDirectory() && !StringUtils.equals(p.toFile().getName(), WELSH_DATA_JSON);
-        }
-        return canDelete;
-    };
 
     public final Path path;
     public final Path dataVisualisationsPath;
@@ -389,9 +379,6 @@ public class Content {
         return false;
     }
 
-    /**
-     *
-     */
     public boolean deleteContentJson(String uri) throws IOException {
         boolean deleteSuccessful;
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1665,7 +1665,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertTrue(c1.getInProgress().getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
         assertTrue(c1.getInProgress().getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
 
-        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/data.json");
 
         assertTrue(deleteSuccessful);
         assertTrue(c1.getInProgress().getPath().toFile().list().length == 0);
@@ -1688,7 +1688,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
         assertTrue(c1.complete.getPath().resolve("a/b/c/d").resolve("data.json").toFile().createNewFile());
 
-        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/data.json");
 
         assertTrue(deleteSuccessful);
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
@@ -1712,7 +1712,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
         assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
 
-        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/data.json");
 
         assertTrue(deleteSuccessful);
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
@@ -1742,7 +1742,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.json").toFile().createNewFile());
         assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.xls").toFile().createNewFile());
 
-        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/data.json");
 
         assertTrue(deleteSuccessful);
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1698,6 +1698,30 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     /**
+     * deleteDataJSON should all files at the specified URI but should not delete any cy_data.json files if they exist.
+     */
+    @Test
+    public void deleteDataJSONShouldNotDeleteCYDataFiles() throws Exception {
+        Collection c1 = createCollection(rootDir.getRoot().toPath(), "nargle");
+
+        assertTrue(c1.complete.getPath().resolve("a/b/c").toFile().mkdirs());
+
+        Path uri = Paths.get("a/b/c");
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("cy_data.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
+
+        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+
+        assertTrue(deleteSuccessful);
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.xls")));
+        assertTrue(Files.exists(c1.complete.getPath().resolve("a/b/c/cy_data.json")));
+    }
+
+    /**
      * deleteDataJSON should delete all files at the specified URI and should also delete an previous version of
      * the URI that has been created in the reviewed dir.
      */

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1708,7 +1708,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         Path uri = Paths.get("a/b/c");
         assertTrue(c1.complete.getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
-        assertTrue(c1.complete.getPath().resolve(uri).resolve("cy_data.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("data_cy.json").toFile().createNewFile());
         assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
         assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
 
@@ -1718,7 +1718,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.json")));
         assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.xls")));
-        assertTrue(Files.exists(c1.complete.getPath().resolve("a/b/c/cy_data.json")));
+        assertTrue(Files.exists(c1.complete.getPath().resolve("a/b/c/data_cy.json")));
     }
 
     /**

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -30,8 +30,9 @@ import com.github.onsdigital.zebedee.util.ContentDetailUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,6 +59,9 @@ import static org.mockito.Mockito.spy;
 
 public class CollectionTest extends ZebedeeTestBaseFixture {
 
+    @Rule
+    public TemporaryFolder rootDir = new TemporaryFolder();
+
     private static final boolean recursive = false;
     Collection collection;
     Session publisherSession;
@@ -65,6 +69,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     FakeCollectionWriter collectionWriter;
 
     public void setUp() throws Exception {
+        rootDir.create();
 
         collection = new Collection(builder.collections.get(1), zebedee);
 
@@ -740,7 +745,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test(expected = UnauthorizedException.class)
-    public void shouldNotReviewAsPublisher() throws IOException, ZebedeeException{
+    public void shouldNotReviewAsPublisher() throws IOException, ZebedeeException {
 
         // Given
         // The content exists, has been edited and complete by publisher1:
@@ -876,7 +881,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test(expected = BadRequestException.class)
-    public void shouldNotReviewIfAlreadyReviewed() throws IOException, ZebedeeException{
+    public void shouldNotReviewIfAlreadyReviewed() throws IOException, ZebedeeException {
 
         // Given
         // The content already exists:
@@ -1461,7 +1466,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Given an empty collection
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath, "isAllContentReviewed");
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
         // When isAllContentReviewed() is called
         boolean allContentReviewed = collection.isAllContentReviewed();
@@ -1476,7 +1481,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         // Given a collection with a file in progress
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
         Collection collection = spy(
-                CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed"));
+                CollectionTest.createCollection(collectionPath, "isAllContentReviewed"));
 
         ArrayList<String> uriList = new ArrayList<>(Arrays.asList("/some/uri"));
         doReturn(uriList).when(collection).inProgressUris();
@@ -1494,7 +1499,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         // Given a collection with a file in complete
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
         Collection collection = spy(
-                CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed"));
+                CollectionTest.createCollection(collectionPath, "isAllContentReviewed"));
 
         ArrayList<String> uriList = new ArrayList<>(Arrays.asList("/some/uri"));
         doReturn(uriList).when(collection).completeUris();
@@ -1514,7 +1519,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
             System.setProperty("ENABLE_DATASET_IMPORT", "true");
             // Given a collection with a dataset that has not been set to reviewed.
             Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-            Collection collection = CollectionTest.CreateCollection(collectionPath, "isAllContentReviewed");
+            Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
             CollectionDataset dataset = new CollectionDataset();
             dataset.setState(ContentStatus.Complete);
@@ -1540,7 +1545,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
             // Given a collection with a dataset version that has not been set to reviewed.
             Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-            Collection collection = CollectionTest.CreateCollection(collectionPath, "isAllContentReviewed");
+            Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
             CollectionDatasetVersion datasetVersion = new CollectionDatasetVersion();
             datasetVersion.setState(ContentStatus.Complete);
@@ -1562,7 +1567,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Given a collection with a dataset that has been set to reviewed.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed");
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
         CollectionDataset dataset = new CollectionDataset();
         dataset.setState(ContentStatus.Reviewed);
@@ -1580,7 +1585,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Given a collection with a dataset version that has been set to reviewed.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed");
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
         CollectionDatasetVersion datasetVersion = new CollectionDatasetVersion();
         datasetVersion.setState(ContentStatus.Reviewed);
@@ -1598,7 +1603,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Given a collection with a dataset.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed");
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
         CollectionDataset dataset = new CollectionDataset();
         dataset.setUri("http://localhost:1234/datasets/123");
@@ -1621,7 +1626,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Given a collection with a dataset version.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath,"isAllContentReviewed");
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
 
         CollectionDatasetVersion datasetVersion = new CollectionDatasetVersion();
         datasetVersion.setId("123");
@@ -1635,7 +1640,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         // Then the expected values have been set
         ContentDetail versionDetail = datasetContent.get(0);
-        assertEquals( "/datasets/123/editions/2015/versions/1", versionDetail.uri);
+        assertEquals("/datasets/123/editions/2015/versions/1", versionDetail.uri);
         assertEquals(PageType.api_dataset.toString(), versionDetail.type);
         assertEquals(datasetVersion.getTitle(), versionDetail.description.title);
 
@@ -1646,7 +1651,86 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertEquals(datasetVersion.getTitle(), datasetDetail.description.title);
     }
 
-    public static Collection CreateCollection(Path destination, String collectionName) throws CollectionNotFoundException, IOException {
+    /**
+     * deleteDataJSON should delete the data.json at the specified URI and any other files in the same directory.
+     */
+    @Test
+    public void shouldDeleteDataJsonAndAllSupplimentaryFiles() throws IOException, CollectionNotFoundException {
+        Collection c1 = createCollection(rootDir.getRoot().toPath(), "nargle");
+
+        assertTrue(c1.getInProgress().getPath().resolve("a/b/c").toFile().mkdirs());
+
+        Path uri = Paths.get("a/b/c");
+        assertTrue(c1.getInProgress().getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
+        assertTrue(c1.getInProgress().getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
+        assertTrue(c1.getInProgress().getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
+
+        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+
+        assertTrue(deleteSuccessful);
+        assertTrue(c1.getInProgress().getPath().toFile().list().length == 0);
+        assertTrue(c1.complete.getPath().toFile().list().length == 0);
+        assertTrue(c1.reviewed.getPath().toFile().list().length == 0);
+    }
+
+    /**
+     * deleteDataJSON should all files at the specified URI but should not delete any sub directories or thier content.
+     */
+    @Test
+    public void deleteDataJSONShouldNotDeleteSubDirs() throws Exception {
+        Collection c1 = createCollection(rootDir.getRoot().toPath(), "nargle");
+
+        assertTrue(c1.complete.getPath().resolve("a/b/c/d").toFile().mkdirs());
+
+        Path uri = Paths.get("a/b/c");
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve("a/b/c/d").resolve("data.json").toFile().createNewFile());
+
+        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+
+        assertTrue(deleteSuccessful);
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.xls")));
+        assertTrue(Files.exists(c1.complete.getPath().resolve("a/b/c/d/data.json")));
+    }
+
+    /**
+     * deleteDataJSON should delete all files at the specified URI and should also delete an previous version of
+     * the URI that has been created in the reviewed dir.
+     */
+    @Test
+    public void deleteDataJSONShouldDeletePreviousVersionFromReviewed() throws Exception {
+        Collection c1 = createCollection(rootDir.getRoot().toPath(), "nargle");
+
+        assertTrue(c1.complete.getPath().resolve("a/b/c").toFile().mkdirs());
+        assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1").toFile().mkdirs());
+
+        Path uri = Paths.get("a/b/c");
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
+        assertTrue(c1.complete.getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
+
+        // mock a previous version of the content in the reviewed dir.
+        assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1/data.json").toFile().createNewFile());
+        assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.json").toFile().createNewFile());
+        assertTrue(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.xls").toFile().createNewFile());
+
+        boolean deleteSuccessful = c1.deleteDataJSON("/a/b/c/data.json");
+
+        assertTrue(deleteSuccessful);
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/data.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.json")));
+        assertFalse(Files.exists(c1.complete.getPath().resolve("a/b/c/abc123.xls")));
+
+        assertFalse(Files.exists(c1.reviewed.getPath().resolve("a/b/c/previous/v1/data.json")));
+        assertFalse(Files.exists(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.json")));
+        assertFalse(Files.exists(c1.reviewed.getPath().resolve("a/b/c/previous/v1/abc123.xld")));
+    }
+
+    public static Collection createCollection(Path destination, String collectionName) throws CollectionNotFoundException, IOException {
 
         CollectionDescription collection = new CollectionDescription(collectionName);
         collection.setType(CollectionType.manual);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -956,36 +956,6 @@ public class CollectionsTest {
         }
     }
 
-/*    @Test
-    public void shouldDeleteFile() throws IOException, ZebedeeException {
-        Path uri = rootDir.newFile("data.json").toPath();
-
-*//*        when(permissionsServiceMock.canEdit(TEST_EMAIL))
-                .thenReturn(true);*//*
-
-        String uriStr = uri.toString();
-
-        when(collectionMock.find(uriStr))
-                .thenReturn(uri);
-        when(collectionMock.isInCollection(uri.toString()))
-                .thenReturn(true);
-        when(collectionMock.deleteFile(uri.toString()))
-                .thenReturn(true);
-
-
-        assertThat(collections.deleteContent(collectionMock, uri.toString(), sessionMock), is(true));
-
-        verify(permissionsServiceMock, times(1)).canEdit(TEST_EMAIL);
-        verify(collectionMock, times(1)).find(uri.toString());
-        verify(collectionMock, times(1)).isInCollection(uri.toString());
-        verify(collectionMock, times(2)).getDescription();
-        verify(collectionMock, never()).deleteContentDirectory(any(), any());
-        verify(collectionMock, never()).deleteContentDirectory(anyString(), anyString());
-        verify(collectionMock, times(1)).deleteFile(uri.toString());
-        verify(collectionMock, times(1)).save();
-        verify(collectionHistoryDaoMock, times(1)).saveCollectionHistoryEvent(any(CollectionHistoryEvent.class));
-    }*/
-
     @Test
     public void shouldDeleteFolderRecursively() throws IOException, ZebedeeException {
         Path uri = collectionsPath.resolve("inprogress");

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -978,7 +978,7 @@ public class CollectionsTest {
         verify(permissionsServiceMock, times(1)).canEdit(TEST_EMAIL);
         verify(collectionMock, times(1)).find(uri.toString());
         verify(collectionMock, times(1)).isInCollection(uri.toString());
-        verify(collectionMock, times(2)).getDescription();
+        verify(collectionMock, times(4)).getDescription();
         /*verify(collectionMock, never()).deleteContentDirectory(any(), any());*/
         verify(collectionMock, times(1)).deleteContentDirectory(TEST_EMAIL, uri.toString());
         verify(collectionMock, never()).deleteFile(uri.toString());
@@ -1109,7 +1109,7 @@ public class CollectionsTest {
         when(collectionMock.isInCollection(uri.toString()))
                 .thenReturn(true);
 
-        when(collectionMock.deleteDataJSON(uri.toString()))
+        when(collectionMock.deleteFileAndRelated(uri.toString()))
                 .thenAnswer(i -> Files.deleteIfExists(uri));
 
         boolean deleteSuccessful = collections.deleteContent(collectionMock, uri.toString(), sessionMock);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -89,7 +89,7 @@ public class ApproveTaskTest {
     public void createPublishNotificationShouldIncludePendingDeletes() throws Exception {
         // Given a collection that contains pending deletes.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
-        Collection collection = CollectionTest.CreateCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
+        Collection collection = CollectionTest.createCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
         String uriToDelete = "some/uri/to/check";
         ContentDetail contentDetail = new ContentDetail("Title", uriToDelete, "type");
         PendingDelete pendingDelete = new PendingDelete("", contentDetail);


### PR DESCRIPTION
### Fix delete content defect.

#### The issue
When page is deleted from a collection the current implementation only deletes that page file. This is a problem if that page has created supplementary files - tables, charts, images etc. In this case only the page file (`data.json`) is deleted and the other files are left behind. 

These files are not visible or assessable to Florence users but prevent them from deleting files from the collection or the collection its self and/or from approving the collection.
