### PR TITLE
Created new client and related classes for sending HTTP requests to t…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/GetContentHashEntity.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/GetContentHashEntity.java
@@ -1,0 +1,64 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * GetContentHashEntity POJO representing the http response entity returned from the Publishing API get content hash
+ * endpoint.
+ */
+public class GetContentHashEntity {
+
+    private String uri;
+    private String transactionId;
+    private String hash;
+
+    /**
+     * Construct a new GetContentHashEntity
+     *
+     * @param uri           the uri of the content the hash belongs too.
+     * @param transactionId the publishing transaction ID.
+     * @param hash          the file hash value of the the content at the requested uri.
+     */
+    public GetContentHashEntity(final String uri, final String transactionId, final String hash) {
+        this.uri = uri;
+        this.transactionId = transactionId;
+        this.hash = hash;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public String getTransactionId() {
+        return this.transactionId;
+    }
+
+    public String getHash() {
+        return this.hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetContentHashEntity entity = (GetContentHashEntity) o;
+
+        return new EqualsBuilder()
+                .append(getUri(), entity.getUri())
+                .append(getTransactionId(), entity.getTransactionId())
+                .append(getHash(), entity.getHash())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getUri())
+                .append(getTransactionId())
+                .append(getHash())
+                .toHashCode();
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClient.java
@@ -1,0 +1,23 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Defines the interface for HTTP client for the website publising API.
+ */
+public interface PublishingClient {
+
+    /**
+     * Get the file hash for the content at the specified uri from the publishing API.
+     *
+     * @param host          the host address of the publishing API.
+     * @param transactionId the publishing transaction ID which the content belongs to.
+     * @param uri           the uri of the content to get the hash for.
+     * @return {@link GetContentHashEntity} with the hash value.
+     * @throws IOException        problem executing the request.
+     * @throws URISyntaxException problem creating the request.
+     */
+    GetContentHashEntity getContentHash(String host, String transactionId, String uri) throws IOException,
+            URISyntaxException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientException.java
@@ -1,0 +1,52 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import java.text.MessageFormat;
+
+/**
+ * Exception for errors occurring while sending requests and receiving responses to/from the publishing API.
+ */
+public class PublishingClientException extends RuntimeException {
+
+    private String host;
+    private String transactionId;
+    private String uri;
+    private int httpStatus;
+
+    /**
+     * Construct a new PublishingClientException.
+     *
+     * @param host          the host address of the publishing API the {@link PublishingClient} was
+     *                      attempting to communticate with.
+     * @param transactionId the publishing transaction ID.
+     * @param uri           the uri of transaction content the error pertains too.
+     * @param httpStatus    the http status code returned by the publishing API.
+     */
+    public PublishingClientException(String host, String transactionId, String uri, int httpStatus) {
+        super("publishing client received an unexpected error");
+        this.host = host;
+        this.transactionId = transactionId;
+        this.uri = uri;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public String getTransactionId() {
+        return this.transactionId;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public int getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return MessageFormat.format("{0}, host: {1}, transactionId {2}, uri: {3}", super.getMessage(), host, transactionId, uri);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImpl.java
@@ -1,0 +1,69 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import com.google.gson.Gson;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of {@link PublishingClient}.
+ */
+public class PublishingClientImpl implements PublishingClient {
+
+    private PublishingRequestBuilder requestBuilder;
+    private Supplier<CloseableHttpClient> httpClientSupplier;
+
+    /**
+     * Constuct a new PublishingClientImpl instance using the default values.
+     */
+    public PublishingClientImpl() {
+        this.httpClientSupplier = () -> HttpClients.createDefault();
+        this.requestBuilder = new PublishingRequestBuilderImpl();
+    }
+
+    /**
+     * Construct a new PublishingClientImpl instance.
+     *
+     * @param httpClientSupplier a {@link Supplier} returning a {@link CloseableHttpClient}.
+     * @param requestBuilder     a {@link PublishingRequestBuilder} instance for creating HTTP requests to the publishing
+     *                           API.
+     */
+    public PublishingClientImpl(Supplier<CloseableHttpClient> httpClientSupplier,
+                                PublishingRequestBuilder requestBuilder) {
+        this.httpClientSupplier = httpClientSupplier;
+        this.requestBuilder = requestBuilder;
+    }
+
+    @Override
+    public GetContentHashEntity getContentHash(String host, String transactionId, String uri) throws IOException,
+            URISyntaxException {
+        HttpUriRequest request = requestBuilder.createGetContentHashRequest(host, transactionId, uri);
+
+        try (
+                CloseableHttpClient client = httpClientSupplier.get();
+                CloseableHttpResponse response = client.execute(request)
+        ) {
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new PublishingClientException(host, transactionId, uri, response.getStatusLine().getStatusCode());
+            }
+            return getResponseEntity(response.getEntity(), GetContentHashEntity.class);
+        }
+    }
+
+    private <T> T getResponseEntity(HttpEntity entity, Class<T> tClass) throws IOException {
+        try (
+                InputStream inputStream = entity.getContent();
+                InputStreamReader reader = new InputStreamReader(inputStream)
+        ) {
+            return new Gson().fromJson(reader, tClass);
+        }
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilder.java
@@ -1,0 +1,23 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import org.apache.http.client.methods.HttpUriRequest;
+
+import java.net.URISyntaxException;
+
+/**
+ * Defines the behaviour of a publishing API HTTP request builder.
+ */
+public interface PublishingRequestBuilder {
+
+    /**
+     * Create a new HTTP GET request to get the content hash for a given uri from the publishing API.
+     *
+     * @param host          the host address of the publishing API.
+     * @param transactionId the ID of the publishing transaction the content belongs to.
+     * @param uri           the uri of the content to get the file hash for
+     * @return a {@link HttpUriRequest}.
+     * @throws URISyntaxException       error creating the request.
+     * @throws IllegalArgumentException thrown if input paramerters are invalid/null/empty.
+     */
+    HttpUriRequest createGetContentHashRequest(String host, String transactionId, String uri) throws URISyntaxException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImpl.java
@@ -1,0 +1,48 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.net.URISyntaxException;
+
+/**
+ * Provides functionality for building HTTP requests to the publishing API.
+ */
+public class PublishingRequestBuilderImpl implements PublishingRequestBuilder {
+
+    private static final String TRANSACTION_ID_PARAM = "transactionId";
+
+    private static final String URI_PARAM = "uri";
+
+    private static final String GET_CONTENT_HASH_URI = "/contentHash";
+
+    @Override
+    public HttpUriRequest createGetContentHashRequest(String host, String transactionId, String uri) throws URISyntaxException {
+        validateGetContentHashRequestParams(host, transactionId, uri);
+
+        HttpGet httpGet = new HttpGet(host + GET_CONTENT_HASH_URI);
+
+        httpGet.setURI(new URIBuilder(httpGet.getURI())
+                .setParameter(TRANSACTION_ID_PARAM, transactionId)
+                .addParameter(URI_PARAM, uri)
+                .build());
+
+        return httpGet;
+    }
+
+    private void validateGetContentHashRequestParams(String host, String transactionId, String uri) {
+        if (StringUtils.isEmpty(host)) {
+            throw new IllegalArgumentException("host required for createGetContentHashRequest but none provided");
+        }
+
+        if (StringUtils.isEmpty(transactionId)) {
+            throw new IllegalArgumentException("transaction required for createGetContentHashRequest but none provided");
+        }
+
+        if (StringUtils.isEmpty(uri)) {
+            throw new IllegalArgumentException("uri required for createGetContentHashRequest but none provided");
+        }
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImplTest.java
@@ -1,0 +1,142 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import com.google.gson.Gson;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PublishingClientImplTest {
+
+    @Mock
+    private PublishingRequestBuilder requestBuilder;
+
+    @Mock
+    private CloseableHttpClient httpClient;
+
+    private PublishingClient client;
+    private Supplier<CloseableHttpClient> clientSupplier;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        clientSupplier = () -> httpClient;
+        this.client = new PublishingClientImpl(clientSupplier, requestBuilder);
+    }
+
+    @Test(expected = URISyntaxException.class)
+    public void testGetContentHash_requestBuilderException() throws Exception {
+        when(requestBuilder.createGetContentHashRequest(anyString(), anyString(), anyString()))
+                .thenThrow(new URISyntaxException("Ka", "Booom"));
+
+        client.getContentHash("", "", "");
+    }
+
+    @Test(expected = IOException.class)
+    public void testGetContentHash_clientIOEx() throws Exception {
+        HttpUriRequest request = mock(HttpUriRequest.class);
+
+        when(requestBuilder.createGetContentHashRequest("host", "transactionId", "uri"))
+                .thenReturn(request);
+
+        when(httpClient.execute(request))
+                .thenThrow(new IOException());
+
+        client.getContentHash("host", "transactionId", "uri");
+    }
+
+    @Test(expected = ClientProtocolException.class)
+    public void testGetContentHash_ClientProtocolException() throws Exception {
+        HttpUriRequest request = mock(HttpUriRequest.class);
+
+        when(requestBuilder.createGetContentHashRequest("host", "transactionId", "uri"))
+                .thenReturn(request);
+
+        when(httpClient.execute(request))
+                .thenThrow(new ClientProtocolException());
+
+        client.getContentHash("host", "transactionId", "uri");
+    }
+
+    @Test(expected = PublishingClientException.class)
+    public void testGetContentHash_non200Status() throws Exception {
+        HttpUriRequest request = mock(HttpUriRequest.class);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+
+        when(requestBuilder.createGetContentHashRequest("host", "transactionId", "uri"))
+                .thenReturn(request);
+
+        when(httpClient.execute(request))
+                .thenReturn(response);
+
+        when(response.getStatusLine())
+                .thenReturn(statusLine);
+
+        when(statusLine.getStatusCode())
+                .thenReturn(400);
+
+        try {
+            client.getContentHash("host", "transactionId", "uri");
+        } catch (PublishingClientException ex) {
+            assertThat(ex.getHost(), equalTo("host"));
+            assertThat(ex.getTransactionId(), equalTo("transactionId"));
+            assertThat(ex.getUri(), equalTo("uri"));
+            assertThat(ex.getHttpStatus(), equalTo(400));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testGetContentHash_success() throws Exception {
+        GetContentHashEntity expected = new GetContentHashEntity("uri", "transactionId", "1234567890");
+        String expectedJson = new Gson().toJson(expected);
+
+        try (InputStream responseBody = new ByteArrayInputStream(expectedJson.getBytes())) {
+            HttpUriRequest request = mock(HttpUriRequest.class);
+            when(requestBuilder.createGetContentHashRequest("host", "transactionId", "uri"))
+                    .thenReturn(request);
+
+            CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+            when(httpClient.execute(request))
+                    .thenReturn(response);
+
+            StatusLine statusLine = mock(StatusLine.class);
+            when(response.getStatusLine())
+                    .thenReturn(statusLine);
+
+            when(statusLine.getStatusCode())
+                    .thenReturn(200);
+
+            HttpEntity entity = mock(HttpEntity.class);
+            when(response.getEntity())
+                    .thenReturn(entity);
+
+            when(entity.getContent())
+                    .thenReturn(responseBody);
+
+            GetContentHashEntity actual = client.getContentHash("host", "transactionId", "uri");
+
+            assertThat(actual, equalTo(expected));
+        }
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImplTest.java
@@ -1,0 +1,88 @@
+package com.github.onsdigital.zebedee.model.publishing.client;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PublishingRequestBuilderImplTest {
+
+    private PublishingRequestBuilder requestBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        this.requestBuilder = new PublishingRequestBuilderImpl();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_hostNull() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest(null, null, null);
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("host required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_hostEmpty() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest("", null, null);
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("host required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_transactionIdNull() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest("host", null, null);
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("transaction required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_transactionIdEmpty() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest("host", "", null);
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("transaction required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_uriNull() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest("host", "transactionId", null);
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("uri required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateGetContentHashRequest_uriEmpty() throws Exception {
+        try {
+            requestBuilder.createGetContentHashRequest("host", "transactionId", "");
+        } catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), equalTo("uri required for createGetContentHashRequest but none provided"));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testCreateGetContentHashRequest_success() throws Exception {
+        HttpUriRequest getRequest = requestBuilder.createGetContentHashRequest("http://localhost:8080",
+                "transactionId", "uri");
+
+        assertThat(getRequest.getURI().getHost(), equalTo("localhost"));
+        assertThat(getRequest.getURI().getPath(), equalTo("/contentHash"));
+        assertThat(getRequest.getURI().getQuery(), equalTo("transactionId=transactionId&uri=uri"));
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImplTest.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
@@ -156,9 +158,16 @@ public class TeamsStoreFileSystemImplTest {
     public void listTeams_Success() throws Exception {
         ReflectionTestUtils.setField(store, "teamLock", rwLock);
 
-        List<Team> expected = createTeams();
+        // Sort teams by name to prevent any ordering weirdness
+        Comparator<Team> teamComparator = (c1, c2) -> c1.getName().compareTo(c2.getName());
 
-        assertThat(store.listTeams(), equalTo(expected));
+        List<Team> expected = createTeams();
+        Collections.sort(expected, teamComparator);
+
+        List<Team> actual = store.listTeams();
+        Collections.sort(actual, teamComparator);
+
+        assertThat(actual, equalTo(expected));
         verify(rwLock, times(2)).readLock();
         verify(lock, times(1)).lock();
         verify(lock, times(1)).unlock();


### PR DESCRIPTION
Part 1 of reintroducing the publishing verify step (also taking advantage to  break apart the monolithic publishing code). 

- Created new client for sending HTTP request to the Publishing API.
- Created exception types for related errors.
- Created  request builder.
- Added unit test for each of the above.

To avoid scope creep the existing publishing code will remain as is, only the new verify code will be part of the client. Provides a baseline that can be added to when we break apart the rest of the publishing code.

### How to review

Code review and unit tests - new functionality is not yet wired up.

### Who can review

@jessjenkins @eldeal @rhiGriff + anyone else who wants to follow me down the publishing rabbit hole 🐰 
