### PR TITLE
Feature/content hash verification task

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
@@ -24,7 +24,7 @@ public class CollectionDescription extends CollectionBase {
     public List<String> reviewedUris;
     public ApprovalStatus approvalStatus = ApprovalStatus.NOT_STARTED;
     public boolean publishComplete;
-    public Map<String, String> publishTransactionIds;
+    private Map<String, String> publishTransactionIds;
     public Date publishStartDate; // The date the publish process was actually started
     public Date publishEndDate; // The date the publish process ended.
     public boolean isEncrypted;
@@ -202,9 +202,10 @@ public class CollectionDescription extends CollectionBase {
 
     /**
      * Get the dataset version for the given values
+     *
      * @param datasetID - the dataset ID of the version
-     * @param edition - the dataset edition of the version
-     * @param version - the version
+     * @param edition   - the dataset edition of the version
+     * @param version   - the version
      * @return an optional containing the dataset version if it exists.
      */
     public Optional<CollectionDatasetVersion> getDatasetVersion(String datasetID, String edition, String version) {
@@ -222,6 +223,7 @@ public class CollectionDescription extends CollectionBase {
 
     /**
      * Add a dataset version to this collection.
+     *
      * @param version
      */
     public void addDatasetVersion(CollectionDatasetVersion version) {
@@ -243,5 +245,13 @@ public class CollectionDescription extends CollectionBase {
         if (this.datasetVersions == null) return;
 
         this.datasetVersions.remove(version);
+    }
+
+    public Map<String, String> getPublishTransactionIds() {
+        return this.publishTransactionIds;
+    }
+
+    public void setPublishTransactionIds(Map<String, String> publishTransactionIds) {
+        this.publishTransactionIds = publishTransactionIds;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PublishCollectionTask.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.zebedee.model.publishing.scheduled.task;
 
-import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.ZebedeeCollectionReader;
 import com.github.onsdigital.zebedee.model.publishing.Publisher;
@@ -10,9 +9,8 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 
 /**
@@ -29,8 +27,8 @@ public class PublishCollectionTask implements Callable<Boolean> {
     /**
      * Create a new task for a collection to be published.
      *
-     * @param collection         - The collection to publish.
-     * @param collectionReader   - The collection reader to read collection content.
+     * @param collection       - The collection to publish.
+     * @param collectionReader - The collection reader to read collection content.
      */
     public PublishCollectionTask(Collection collection, ZebedeeCollectionReader collectionReader, Map<String, String> hostToTransactionIdMap) {
         this.collection = collection;
@@ -58,26 +56,28 @@ public class PublishCollectionTask implements Callable<Boolean> {
             collection.getDescription().publishEndDate = new Date();
         } catch (Exception e) {
             // If an error was caught, attempt to roll back the transaction:
-            if (collection.getDescription().publishTransactionIds != null &&
-                    !collection.getDescription().publishTransactionIds.isEmpty()) {
-                error().data("collectionId", collectionId).data("hostToTransactionId", collection.getDescription().publishTransactionIds)
+            Map<String, String> transactionIdMap = collection.getDescription().getPublishTransactionIds();
+
+            if (transactionIdMap != null && !transactionIdMap.isEmpty()) {
+                error().data("collectionId", collectionId).data("hostToTransactionId", transactionIdMap)
                         .logException(e, "PUBLISH: FAILURE: exception while attempting to publish scheduled collection. " +
-                        "Publishing transaction IDS exist for collection, attempting to rollback");
+                                "Publishing transaction IDS exist for collection, attempting to rollback");
 
                 Publisher.rollbackPublish(collection);
 
             } else {
-                error().data("collectionId", collectionId).data("hostToTransactionId", collection.getDescription().publishTransactionIds)
+                error().data("collectionId", collectionId).data("hostToTransactionId", transactionIdMap)
                         .logException(e, "PUBLISH: FAILURE: no publishing transaction IDS found for collection, no rollback attempt will be made");
             }
         } finally {
+            Map<String, String> transactionIdMap = collection.getDescription().getPublishTransactionIds();
             try {
                 // Save any updates to the collection
-                info().data("collectionId", collectionId).data("hostToTransactionId", collection.getDescription().publishTransactionIds)
+                info().data("collectionId", collectionId).data("hostToTransactionId", transactionIdMap)
                         .log("PUBLISH: persiting changes to collection to disk");
                 collection.save();
             } catch (Exception e) {
-                error().data("collectionId", collectionId).data("hostToTransactionId", collection.getDescription().publishTransactionIds)
+                error().data("collectionId", collectionId).data("hostToTransactionId", transactionIdMap)
                         .logException(e, "PUBLISH: error while attempting to persist collection to disk");
                 throw e;
             }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/verify/ContentHashVerificationTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/verify/ContentHashVerificationTask.java
@@ -1,0 +1,222 @@
+package com.github.onsdigital.zebedee.model.publishing.verify;
+
+import com.github.onsdigital.zebedee.model.publishing.client.PublishingClient;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
+import com.github.onsdigital.zebedee.reader.Resource;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.text.MessageFormat;
+import java.util.concurrent.Callable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Task requests the SHA-1 file hash for a file in a publishing transaction from the Publishing API and
+ * compares it to the file hash generated from the local collection file - confirming the content was
+ * received successfully and not corrupted.
+ * <p></p>
+ * Implements {@link Callable} and returns true if the hash was as expected
+ * throws an {@link HashVerificationException} wrapped in an {@link java.util.concurrent.ExecutionException} otherwise.
+ */
+public class ContentHashVerificationTask implements Callable<Boolean> {
+
+    static final String HASH_INCORRECT_ERR = "file content hash from remote server did not match the expected value " +
+            "expected {0}, actual {1}";
+
+    static final String GENERATE_HASH_ERR = "error calculating content hash from local file";
+
+    private String collectionID;
+    private CollectionReader collectionReader;
+    private String host;
+    private String transactionId;
+    private String uri;
+    private PublishingClient publishingClient;
+
+    private ContentHashVerificationTask(Builder builder) {
+        this.collectionID = requireNonNull(builder.getCollectionID());
+        this.collectionReader = requireNonNull(builder.getReader());
+        this.host = requireNonNull(builder.getPublishingAPIHost());
+        this.transactionId = requireNonNull(builder.getTransactionId());
+        this.uri = requireNonNull(builder.getUri());
+        this.publishingClient = requireNonNull(builder.getPublishingClient());
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+        String actual = publishingClient.getContentHash(host, transactionId, uri).getHash();
+        String expected = getExpectedHashValue();
+
+        if (StringUtils.equals(expected, actual)) {
+            return true;
+        }
+
+        throw incorrectHashValueException(expected, actual);
+    }
+
+    private String getExpectedHashValue() {
+        try (
+                Resource resource = collectionReader.getResource(uri);
+                InputStream in = resource.getData();
+                BufferedInputStream buf = new BufferedInputStream(in)
+        ) {
+            return DigestUtils.sha1Hex(buf);
+        } catch (Exception ex) {
+            throw new HashVerificationException(GENERATE_HASH_ERR, ex, collectionID, host, transactionId, uri);
+        }
+    }
+
+    private HashVerificationException incorrectHashValueException(String expected, String actual) {
+        String msg = MessageFormat.format(HASH_INCORRECT_ERR, expected, actual);
+        throw new HashVerificationException(msg, collectionID, host, transactionId, uri);
+    }
+
+    public String getCollectionID() {
+        return this.collectionID;
+    }
+
+    public CollectionReader getCollectionReader() {
+        return this.collectionReader;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public String getTransactionId() {
+        return this.transactionId;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public PublishingClient getPublishingClient() {
+        return this.publishingClient;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ContentHashVerificationTask that = (ContentHashVerificationTask) o;
+
+        return new EqualsBuilder()
+                .append(this.collectionID, that.collectionID)
+                .append(this.collectionReader, that.collectionReader)
+                .append(this.host, that.host)
+                .append(this.transactionId, that.transactionId)
+                .append(this.uri, that.uri)
+                .append(this.publishingClient, that.publishingClient)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(this.collectionID)
+                .append(this.collectionReader)
+                .append(this.host)
+                .append(this.transactionId)
+                .append(this.uri)
+                .append(this.publishingClient)
+                .toHashCode();
+    }
+
+    /**
+     * Class provides a <i>builder</i> style interface for creating a new {@link ContentHashVerificationTask} instance.
+     */
+    public static class Builder {
+        private String collectionID;
+        private CollectionReader reader;
+        private String publishingAPIHost;
+        private String transactionId;
+        private String uri;
+        private PublishingClient publishingClient;
+
+        /**
+         * Set the collection ID of the content to verify.
+         */
+        public Builder collectionID(String collectionID) {
+            this.collectionID = collectionID;
+            return this;
+        }
+
+        /**
+         * Set a {@link CollectionReader} implementation to read the collection content with.
+         */
+        public Builder collectionReader(CollectionReader reader) {
+            this.reader = reader;
+            return this;
+        }
+
+        /**
+         * Set the publishing API host address to request the remote hash value from.
+         */
+        public Builder publishingAPIHost(String host) {
+            this.publishingAPIHost = host;
+            return this;
+        }
+
+        /**
+         * Set the publishing transaction ID the remote file belongs to.
+         */
+        public Builder transactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        /**
+         * Set the URI of the content to verify.
+         */
+        public Builder contentURI(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        /**
+         * Set the {@link PublishingClient} instance to use to communicate with the publishing API.
+         */
+        public Builder publishingClient(PublishingClient publishingClient) {
+            this.publishingClient = publishingClient;
+            return this;
+        }
+
+        /**
+         * Construct a new {@link ContentHashVerificationTask} instance.
+         */
+        public ContentHashVerificationTask build() {
+            return new ContentHashVerificationTask(this);
+        }
+
+        public String getCollectionID() {
+            return this.collectionID;
+        }
+
+        public CollectionReader getReader() {
+            return this.reader;
+        }
+
+        public String getPublishingAPIHost() {
+            return this.publishingAPIHost;
+        }
+
+        public String getTransactionId() {
+            return this.transactionId;
+        }
+
+        public String getUri() {
+            return this.uri;
+        }
+
+        public PublishingClient getPublishingClient() {
+            return this.publishingClient;
+        }
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/verify/HashVerificationException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/verify/HashVerificationException.java
@@ -1,0 +1,43 @@
+package com.github.onsdigital.zebedee.model.publishing.verify;
+
+public class HashVerificationException extends RuntimeException {
+
+    private String collectionId;
+    private String host;
+    private String transactionId;
+    private String uri;
+
+    public HashVerificationException(String message, String collectionId, String host, String transactionId,
+                                     String uri) {
+        super(message);
+        this.collectionId = collectionId;
+        this.host = host;
+        this.transactionId = transactionId;
+        this.uri = uri;
+    }
+
+    public HashVerificationException(String message, Throwable cause, String collectionId, String host,
+                                     String transactionId, String uri) {
+        super(message, cause);
+        this.collectionId = collectionId;
+        this.host = host;
+        this.transactionId = transactionId;
+        this.uri = uri;
+    }
+
+    public String getCollectionId() {
+        return this.collectionId;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public String getTransactionId() {
+        return this.transactionId;
+    }
+
+    public String getUri() {
+        return this.uri;
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/verify/ContentHashVerificationTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/verify/ContentHashVerificationTaskTest.java
@@ -1,0 +1,222 @@
+package com.github.onsdigital.zebedee.model.publishing.verify;
+
+import com.github.onsdigital.zebedee.model.publishing.client.GetContentHashEntity;
+import com.github.onsdigital.zebedee.model.publishing.client.PublishingClient;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
+import com.github.onsdigital.zebedee.reader.Resource;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+import java.util.concurrent.Callable;
+
+import static com.github.onsdigital.zebedee.model.publishing.verify.ContentHashVerificationTask.GENERATE_HASH_ERR;
+import static com.github.onsdigital.zebedee.model.publishing.verify.ContentHashVerificationTask.HASH_INCORRECT_ERR;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+public class ContentHashVerificationTaskTest {
+
+    private static final String COLLECTION_ID = "666";
+    private static final String HOST = "localhost";
+    private static final String TRANSACTION_ID = "1";
+    private static final String URI = "/helloworld";
+
+    @Mock
+    private CollectionReader collectionReader;
+
+    @Mock
+    private Resource resource;
+
+    @Mock
+    private PublishingClient publishingClient;
+
+    private Callable<Boolean> task;
+
+    private GetContentHashEntity entity;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        task = new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(HOST)
+                .transactionId(TRANSACTION_ID)
+                .contentURI(URI)
+                .publishingClient(publishingClient)
+                .build();
+
+        entity = new GetContentHashEntity(URI, TRANSACTION_ID, "1234567890");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_collectionIdNull() {
+        new ContentHashVerificationTask.Builder().build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_collectionReaderNull() {
+        new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(null)
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_hostNull() {
+        new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(null)
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_transactionIdNull() {
+        new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(HOST)
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_uriNull() {
+        new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(HOST)
+                .transactionId(TRANSACTION_ID)
+                .build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuilder_publishingClientNull() {
+        new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(HOST)
+                .transactionId(TRANSACTION_ID)
+                .contentURI(URI)
+                .build();
+    }
+
+    @Test
+    public void testBuilder_success() {
+        ContentHashVerificationTask actual = new ContentHashVerificationTask.Builder()
+                .collectionID(COLLECTION_ID)
+                .collectionReader(collectionReader)
+                .publishingAPIHost(HOST)
+                .transactionId(TRANSACTION_ID)
+                .contentURI(URI)
+                .publishingClient(publishingClient)
+                .build();
+
+        assertThat(actual.getCollectionID(), equalTo(COLLECTION_ID));
+        assertThat(actual.getCollectionReader(), equalTo(collectionReader));
+        assertThat(actual.getHost(), equalTo(HOST));
+        assertThat(actual.getTransactionId(), equalTo(TRANSACTION_ID));
+        assertThat(actual.getUri(), equalTo(URI));
+        assertThat(actual.getPublishingClient(), equalTo(publishingClient));
+    }
+
+    @Test(expected = IOException.class)
+    public void testCall_publishingClientIOException() throws Exception {
+        when(publishingClient.getContentHash(HOST, TRANSACTION_ID, URI))
+                .thenThrow(new IOException());
+
+        task.call();
+    }
+
+    @Test(expected = URISyntaxException.class)
+    public void testCall_publishingClientURISyntaxException() throws Exception {
+        when(publishingClient.getContentHash(HOST, TRANSACTION_ID, URI))
+                .thenThrow(new URISyntaxException("", ""));
+
+        task.call();
+    }
+
+    @Test(expected = HashVerificationException.class)
+    public void testCall_collectionReaderIOException() throws Exception {
+        when(publishingClient.getContentHash(HOST, TRANSACTION_ID, URI))
+                .thenReturn(entity);
+
+        IOException cause = new IOException("collectioncReader get resource exeption");
+        when(collectionReader.getResource(URI))
+                .thenThrow(cause);
+
+        try {
+            task.call();
+        } catch (HashVerificationException ex) {
+            assertThat(ex.getMessage(), equalTo(GENERATE_HASH_ERR));
+            assertThat(ex.getCause(), equalTo(cause));
+            assertThat(ex.getHost(), equalTo(HOST));
+            assertThat(ex.getUri(), equalTo(URI));
+            assertThat(ex.getTransactionId(), equalTo(TRANSACTION_ID));
+            throw ex;
+        }
+    }
+
+    @Test(expected = HashVerificationException.class)
+    public void testCall_hashValuesDoNotMatch() throws Exception {
+        byte[] testData = "Hello world".getBytes();
+
+        String expected;
+        try (InputStream inputStream = new ByteArrayInputStream(testData)) {
+            expected = DigestUtils.sha1Hex(inputStream);
+        }
+
+        when(publishingClient.getContentHash(HOST, TRANSACTION_ID, URI))
+                .thenReturn(entity);
+
+        when(collectionReader.getResource(URI))
+                .thenReturn(resource);
+
+        try (InputStream inputStream = new ByteArrayInputStream(testData)) {
+            when(resource.getData()).thenReturn(inputStream);
+        }
+
+        try {
+            task.call();
+        } catch (HashVerificationException ex) {
+            assertThat(ex.getMessage(), equalTo(MessageFormat.format(HASH_INCORRECT_ERR, expected, "1234567890")));
+            assertThat(ex.getHost(), equalTo(HOST));
+            assertThat(ex.getUri(), equalTo(URI));
+            assertThat(ex.getTransactionId(), equalTo(TRANSACTION_ID));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testCall_matchingHashValues() throws Exception {
+        byte[] testData = "Hello world".getBytes();
+
+        GetContentHashEntity entity;
+        try (InputStream inputStream = new ByteArrayInputStream(testData)) {
+            entity = new GetContentHashEntity(URI, TRANSACTION_ID, DigestUtils.sha1Hex(inputStream));
+        }
+
+        when(publishingClient.getContentHash(HOST, TRANSACTION_ID, URI))
+                .thenReturn(entity);
+
+        when(collectionReader.getResource(URI))
+                .thenReturn(resource);
+
+        try (InputStream inputStream = new ByteArrayInputStream(testData)) {
+            when(resource.getData()).thenReturn(inputStream);
+        }
+
+        assertThat(task.call(), is(true));
+    }
+}


### PR DESCRIPTION
### What

#### Re-add publish verify step part 2 ####
- Refactored `collection.description.publishTransactionIds` to be private and added getter/setter methods to follow good Java coding standards.
- Added new `HashVerificationException` for errors relating to the hash verification process.
- Added new `ContentHashVerificationTask` - this carries out the verification steps.
- Added unit tests for the above

### How to review

Unit tests and code review - new features are no yet wired into the publishing process.

### Who can review

Anyone.
