### PR TITLE
Updated dp-logging version to latest (v1.4.0) and added some minor tw…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/MDCFilter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/MDCFilter.java
@@ -2,18 +2,31 @@ package com.github.onsdigital.zebedee.filters;
 
 import com.github.davidcarboni.restolino.framework.Filter;
 import com.github.onsdigital.logging.util.RequestLogUtil;
+import org.slf4j.MDC;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 /**
  * Filter to add the X-Request-Id and remote address to the {@link org.slf4j.MDC} for logging.
  */
 public class MDCFilter implements Filter {
 
+    private static final String REQUEST_ID_KEY = "X-Request-Id";
+
+    private static final String TRACE_ID_KEY = "trace_id";
+
     @Override
     public boolean filter(HttpServletRequest req, HttpServletResponse res) {
+        MDC.put(TRACE_ID_KEY, getTraceID(req));
         RequestLogUtil.extractDiagnosticContext(req);
         return true;
+    }
+
+    private String getTraceID(HttpServletRequest req) {
+        return defaultIfBlank(req.getHeader(REQUEST_ID_KEY), UUID.randomUUID().toString());
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/logging/CMSLogEvent.java
@@ -118,4 +118,18 @@ public class CMSLogEvent extends BaseEvent<CMSLogEvent> {
         }
         return this;
     }
+
+    public CMSLogEvent host(String host) {
+        if (StringUtils.isNotEmpty(host)) {
+            data("host", host);
+        }
+        return this;
+    }
+
+    public CMSLogEvent transactionId(String transactionId) {
+        if (StringUtils.isNotEmpty(transactionId)) {
+            data("transaction_id", transactionId);
+        }
+        return this;
+    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
@@ -258,19 +258,18 @@ public class Publisher {
         PostMessageField msg = new PostMessageField("Error", ex.getMessage(), false);
         collectionAlarm(collection, "Exception publishAction collection", msg);
 
-        CMSLogEvent event = error().data("publishing", true).data("collectionId", collection.getDescription().getId());
+        CMSLogEvent err = error().data("publishing", true).collectionID(collection);
 
         // If an error was caught, attempt to roll back the transaction:
         Map<String, String> transactionIds = collection.getDescription().getPublishTransactionIds();
         if (transactionIds != null && transactionIds.size() > 0) {
-            event.data("hostToTransactionID", transactionIds)
-                    .exceptionAll(ex)
+            err.data("hostToTransactionID", transactionIds)
+                    .exception(ex)
                     .log("publish collection error, attempting to rollback collection");
 
             rollbackPublish(collection);
         } else {
-            event.exceptionAll(ex)
-                    .log("publish collection error. Unable rollback as no transaction IDs found for collection");
+            err.exception(ex).log("publish collection error. Unable rollback as no transaction IDs found for collection");
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingClientImpl.java
@@ -13,6 +13,8 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.function.Supplier;
 
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+
 /**
  * Implementation of {@link PublishingClient}.
  */
@@ -51,6 +53,13 @@ public class PublishingClientImpl implements PublishingClient {
                 CloseableHttpClient client = httpClientSupplier.get();
                 CloseableHttpResponse response = client.execute(request)
         ) {
+            info().request(request)
+                    .response(response)
+                    .uri(uri)
+                    .host(host)
+                    .transactionId(transactionId)
+                    .log("response received from publishing API for get content SHA-1 hash");
+
             if (response.getStatusLine().getStatusCode() != 200) {
                 throw non200ResponseStatusException(host, transactionId, uri, response.getStatusLine().getStatusCode());
             }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImpl.java
@@ -1,11 +1,17 @@
 package com.github.onsdigital.zebedee.model.publishing.client;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.message.BasicHeader;
+import org.slf4j.MDC;
 
 import java.net.URISyntaxException;
+import java.util.UUID;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 /**
  * Provides functionality for building HTTP requests to the publishing API.
@@ -15,6 +21,8 @@ public class PublishingRequestBuilderImpl implements PublishingRequestBuilder {
     private static final String TRANSACTION_ID_PARAM = "transactionId";
 
     private static final String URI_PARAM = "uri";
+
+    private static final String TRACE_ID_HEADER = "trace_id";
 
     private static final String GET_CONTENT_HASH_URI = "/contentHash";
 
@@ -28,6 +36,8 @@ public class PublishingRequestBuilderImpl implements PublishingRequestBuilder {
                 .setParameter(TRANSACTION_ID_PARAM, transactionId)
                 .addParameter(URI_PARAM, uri)
                 .build());
+
+        httpGet.setHeader(getTraceIDHeader());
 
         return httpGet;
     }
@@ -44,5 +54,19 @@ public class PublishingRequestBuilderImpl implements PublishingRequestBuilder {
         if (StringUtils.isEmpty(uri)) {
             throw new IllegalArgumentException("uri required for createGetContentHashRequest but none provided");
         }
+    }
+
+    private Header getTraceIDHeader() {
+        return new BasicHeader(TRACE_ID_HEADER, getTraceID());
+    }
+
+    /**
+     * Get the trace ID to use as for the request header. If a value exists in the {@link MDC} map use that otherwise
+     * generate a new random value.
+     *
+     * @return the trace ID to use for the request header.
+     */
+    private String getTraceID() {
+        return defaultIfBlank(MDC.get(TRACE_ID_HEADER), UUID.randomUUID().toString());
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/client/PublishingRequestBuilderImplTest.java
@@ -1,11 +1,13 @@
 package com.github.onsdigital.zebedee.model.publishing.client;
 
 import org.apache.http.client.methods.HttpUriRequest;
+import org.hamcrest.core.IsNull;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 public class PublishingRequestBuilderImplTest {
 
@@ -84,5 +86,6 @@ public class PublishingRequestBuilderImplTest {
         assertThat(getRequest.getURI().getHost(), equalTo("localhost"));
         assertThat(getRequest.getURI().getPath(), equalTo("/contentHash"));
         assertThat(getRequest.getURI().getQuery(), equalTo("transactionId=transactionId&uri=uri"));
+        assertThat(getRequest.getFirstHeader("trace_id"), is(IsNull.notNullValue()));
     }
 }

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-logging</artifactId>
-            <version>release~1.3.0</version>
+            <version>v1.4.0</version>
         </dependency>
 
         <dependency>

--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <property scope="context" name="default.logger.name" value="dp-logger-default"/>
+    <property scope="context" name="default.logger.name" value="zebedee-reader"/>
     <property scope="context" name="default.logger.formatted" value="false"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Updated to the latest version of dp-logger - `v1.4.0`. Latest version includes
-  Fix for incorrect HTTP request details being logged out when fanning out.
- 3rd party events now use the app namespace.

Other minor updated related to logging/using the latest version of the lib.

