### PR TITLE
set 3rd party log events to level WARN to reduce unncessary spam

### DIFF
--- a/zebedee-reader/src/main/resources/logback.xml
+++ b/zebedee-reader/src/main/resources/logback.xml
@@ -45,7 +45,7 @@
     </logger>
 
 
-    <root level="info">
+    <root level="WARN">
         <appender-ref ref="THIRD_PARTY"/>
     </root>
 


### PR DESCRIPTION
Changed 3rd party log event level to `WARN` to reduce unnecessary logging output. 
