### PR TITLE
removed redundant logging calls and moved health check from CMS to re…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Identity.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Identity.java
@@ -16,10 +16,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import java.io.IOException;
 
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.extractServiceAccountTokenFromAuthHeader;
 import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.isValidServiceAuthorizationHeader;
 import static com.github.onsdigital.zebedee.service.ServiceTokenUtils.isValidServiceToken;
@@ -101,7 +101,6 @@ public class Identity {
     }
 
     private ServiceAccount handleServiceAccountRequest(HttpServletRequest request) throws IOException {
-        info().log("identity: handling service identity request");
         String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
 
         ServiceAccount serviceAccount = null;
@@ -123,7 +122,7 @@ public class Identity {
             if (serviceAccount == null) {
                 warn().log("service account not found for service token");
             } else {
-                info().data("service_id", serviceAccount.getID()).log("identified valid service account");
+                info().serviceAccountID(serviceAccount).log("identified valid service account");
             }
         } catch (Exception ex) {
             error().exception(ex).log("unexpected error getting service account from service store");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
@@ -6,7 +6,7 @@ import com.github.davidcarboni.restolino.json.Serialiser;
 import com.github.onsdigital.zebedee.api.ClickEventLog;
 import com.github.onsdigital.zebedee.api.CsdbKey;
 import com.github.onsdigital.zebedee.api.CsdbNotify;
-import com.github.onsdigital.zebedee.api.Health;
+import com.github.onsdigital.zebedee.reader.api.endpoint.Health;
 import com.github.onsdigital.zebedee.api.Identity;
 import com.github.onsdigital.zebedee.api.Login;
 import com.github.onsdigital.zebedee.api.Password;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ServiceTokenUtils.java
@@ -38,7 +38,6 @@ public class ServiceTokenUtils {
 
         if (matches(token)) {
             isValid = true;
-            info().log("valid service token");
         } else {
             warn().log("invalid service token value: service tokens must contain 16 or more alphanumerica only characters");
         }
@@ -80,10 +79,7 @@ public class ServiceTokenUtils {
 
         } else if (!serviceAuthHeader.startsWith(BEARER_PREFIX_UC)) {
             warn().log("invalid service authorization header value not prefixed with Bearer (case sensitive)");
-            return false;
-
-        } else {
-            info().log("service authorization header valid");
+            isValid = false;
         }
 
         return isValid;
@@ -103,8 +99,8 @@ public class ServiceTokenUtils {
             warn().log("cannot remove Bearer prefix from null or empty service authorization header value");
         } else {
             serviceToken = rawHeader.replaceFirst(BEARER_PREFIX_UC, "").trim();
-            info().log("bearer prefix removed from service auth header");
         }
+
         return serviceToken;
     }
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/Health.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/Health.java
@@ -1,4 +1,4 @@
-package com.github.onsdigital.zebedee.api;
+package com.github.onsdigital.zebedee.reader.api.endpoint;
 
 import com.github.davidcarboni.restolino.framework.Api;
 import org.apache.http.HttpStatus;
@@ -6,6 +6,8 @@ import org.apache.http.HttpStatus;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
+
+import static com.github.onsdigital.zebedee.logging.ReaderLogger.info;
 
 /**
  * health endpoint always returns 200 OK.

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/endpoint/HealthTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/endpoint/HealthTest.java
@@ -1,0 +1,37 @@
+package com.github.onsdigital.zebedee.reader.api.endpoint;
+
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class HealthTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    private Health api;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        this.api = new Health();
+    }
+
+    @Test
+    public void getHealth_shouldReturnStatusOK() {
+        api.getHealth(request, response);
+
+        verify(response, times(1)).setStatus(HttpStatus.SC_OK);
+    }
+}


### PR DESCRIPTION
#### Fix healthcheck
- New Health check api was added to Zebedee CMS so was only ever available when running in CMS mode so moved into Zebedee reader - it will be available in both reader and CMS.

### Logging
- Removed redundant logging calls. Logs for service accounts and Identity are very noisy. Removed log events adding little/no value.
