### PR TITLE
fixed incorrect logic in remove previous versions code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
-            <url>https://splunk.artifactoryonline.com/splunk/ext-releases-local</url>
+            <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
         </repository>
     </repositories>
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1056,7 +1056,7 @@ public class Collection {
      */
     private boolean deletePreviousVersionFromReviewed(String targetURI) throws IOException {
         boolean deleteSuccessful = true;
-        List<String> versionedFiles = getPreviousVersionContentForURI(reviewedUris(), targetURI);
+        List<String> versionedFiles = versionsService.getPreviousVersionsOf(targetURI, reviewed);
 
         if (!versionedFiles.isEmpty()) {
             info().data("files", versionedFiles).uri(targetURI).log("deleting generated previous version files for uri");
@@ -1068,14 +1068,6 @@ public class Collection {
 
         return deleteSuccessful;
     }
-
-    List<String> getPreviousVersionContentForURI(List<String> reviewedURIs, String targetURI) throws IOException {
-        return reviewedURIs
-                .stream()
-                .filter(contentURI -> versionsService.isVersionOf(targetURI, contentURI))
-                .collect(Collectors.toList());
-    }
-
     /**
      * Delete all the content files in the directory of the given file.
      *

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1062,7 +1062,7 @@ public class Collection {
             info().collectionID(this)
                     .uri(targetURI)
                     .data("related_version_files", versionedFiles)
-                    .log("removing previous version files form reviewed content");
+                    .log("file deleted removing previous version content from collection reviewed dir");
 
             for (String f : versionedFiles) {
                 deleteSuccessful &= deleteFile(f);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1056,7 +1056,7 @@ public class Collection {
      */
     private boolean deletePreviousVersionFromReviewed(String targetURI) throws IOException {
         boolean deleteSuccessful = true;
-        List<String> versionedFiles = getReviewPreviousVersionContentForURI(reviewedUris(), targetURI);
+        List<String> versionedFiles = getPreviousVersionContentForURI(reviewedUris(), targetURI);
 
         if (!versionedFiles.isEmpty()) {
             info().data("files", versionedFiles).uri(targetURI).log("deleting generated previous version files for uri");
@@ -1069,7 +1069,7 @@ public class Collection {
         return deleteSuccessful;
     }
 
-    List<String> getReviewPreviousVersionContentForURI(List<String> reviewedURIs, String targetURI) throws IOException {
+    List<String> getPreviousVersionContentForURI(List<String> reviewedURIs, String targetURI) throws IOException {
         return reviewedURIs
                 .stream()
                 .filter(contentURI -> versionsService.isVersionOf(targetURI, contentURI))

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1037,7 +1037,7 @@ public class Collection {
         }
 
         if (deleteSuccessful) {
-            deleteSuccessful &= deleteRelatedVersionedContent(uri);
+            deleteSuccessful &= deletePreviousVersionsFromCollectionReviewed(checkURI);
         }
 
         return deleteSuccessful;
@@ -1051,20 +1051,20 @@ public class Collection {
      * newly created version is delete from the collection we need to tidy up these files as they can block users
      * from appoving the collection or adding the same content again.
      *
-     * @param uri
+     * @param targetURI
      * @return
      * @throws IOException
      */
-    private boolean deleteRelatedVersionedContent(String uri) throws IOException {
+    private boolean deletePreviousVersionsFromCollectionReviewed(String targetURI) throws IOException {
         boolean deleteSuccessful = true;
 
         List<String> versionedFiles = reviewedUris()
                 .stream()
-                .filter(contentURI -> contentURI.startsWith(contentURI) && isVersionedUri(contentURI))
+                .filter(contentURI -> contentURI.startsWith(targetURI) && isVersionedUri(contentURI))
                 .collect(Collectors.toList());
 
         if (!versionedFiles.isEmpty()) {
-            info().data("files", versionedFiles).data("uri", uri).log("deleting generated previous version files for uri");
+            info().data("files", versionedFiles).uri(targetURI).log("deleting generated previous version files for uri");
 
             for (String f : versionedFiles) {
                 deleteSuccessful &= deleteFile(f);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1059,7 +1059,10 @@ public class Collection {
         List<String> versionedFiles = versionsService.getPreviousVersionsOf(targetURI, reviewed);
 
         if (!versionedFiles.isEmpty()) {
-            info().data("files", versionedFiles).uri(targetURI).log("deleting generated previous version files for uri");
+            info().collectionID(this)
+                    .uri(targetURI)
+                    .data("related_version_files", versionedFiles)
+                    .log("removing previous version files form reviewed content");
 
             for (String f : versionedFiles) {
                 deleteSuccessful &= deleteFile(f);
@@ -1068,6 +1071,7 @@ public class Collection {
 
         return deleteSuccessful;
     }
+
     /**
      * Delete all the content files in the directory of the given file.
      *

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsService.java
@@ -25,4 +25,7 @@ public interface VersionsService {
 
     void verifyCollectionDatasets(ZebedeeReader cmsReader, Collection collection, CollectionReader reader,
                                   Session session) throws ZebedeeException, IOException, VersionNotFoundException;
+
+
+    boolean isVersionOf(String parentURI, String s);
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsService.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.util.versioning;
 import com.github.onsdigital.zebedee.content.page.statistics.dataset.Version;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Content;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -10,6 +11,7 @@ import com.github.onsdigital.zebedee.session.model.Session;
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 
 public interface VersionsService {
@@ -26,6 +28,7 @@ public interface VersionsService {
     void verifyCollectionDatasets(ZebedeeReader cmsReader, Collection collection, CollectionReader reader,
                                   Session session) throws ZebedeeException, IOException, VersionNotFoundException;
 
-
     boolean isVersionOf(String parentURI, String s);
+
+    List<String> getPreviousVersionsOf(String targetURI, Content content) throws IOException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
@@ -26,10 +26,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.github.onsdigital.zebedee.util.versioning.VersionNotFoundException.versionsNotFoundException;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class VersionsServiceImpl implements VersionsService {
 
     static final String VERSION_URI = "/previous/";
+    static final String VERSION_FILE_REGEX = "/previous/v\\d+/.+";
     static final Pattern VERSION_DIR_PATTERN = Pattern.compile("/previous/v\\d+");
     static final Pattern VALID_VERSION_DIR_PATTERN = Pattern.compile("v\\d+");
 
@@ -224,16 +226,31 @@ public class VersionsServiceImpl implements VersionsService {
         return StringUtils.isNotEmpty(uri) && uri.endsWith("data.json");
     }
 
+    /**
+     * Check if the URI is a previous version of the parent URI.
+     *
+     * @param parentURI the URI to compare files against.
+     * @param uri       the URI to check.
+     * @return true if the uri matches the pattern: parentURI + "/previous/v{d}/{filename}" return false otherwise.
+     */
     @Override
-    public boolean isVersionOf(String target, String input) {
-        if (!target.endsWith("/current")) {
+    public boolean isVersionOf(String parentURI, String uri) {
+        if (isEmpty(parentURI) || isEmpty(uri)) {
             return false;
         }
 
-        String regex = target + "/previous/v\\d+/.+";
-        return Pattern.compile(regex).matcher(input).matches();
+        String regex = parentURI + VERSION_FILE_REGEX;
+        return Pattern.compile(regex).matcher(uri).matches();
     }
 
+    /**
+     * Filter the content returning a list of URIS that are a previous version of the targetURI.
+     *
+     * @param targetURI the URI to compare against.
+     * @param content   the collection content to filter.
+     * @return {@link List} of URIs in the collection that are previous versions of targetURI.
+     * @throws IOException error getting the content URIs.
+     */
     @Override
     public List<String> getPreviousVersionsOf(String targetURI, Content content) throws IOException {
         return content.uris()

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
@@ -222,4 +222,14 @@ public class VersionsServiceImpl implements VersionsService {
     boolean isDataJson(String uri) {
         return StringUtils.isNotEmpty(uri) && uri.endsWith("data.json");
     }
+
+    @Override
+    public boolean isVersionOf(String target, String input) {
+        if (!target.endsWith("/current")) {
+            return false;
+        }
+
+        String regex = target +"/previous/v\\d+/.+";
+        return Pattern.compile(regex).matcher(input).matches();
+    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.zebedee.content.page.statistics.dataset.Version;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Content;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -229,7 +230,15 @@ public class VersionsServiceImpl implements VersionsService {
             return false;
         }
 
-        String regex = target +"/previous/v\\d+/.+";
+        String regex = target + "/previous/v\\d+/.+";
         return Pattern.compile(regex).matcher(input).matches();
+    }
+
+    @Override
+    public List<String> getPreviousVersionsOf(String targetURI, Content content) throws IOException {
+        return content.uris()
+                .stream()
+                .filter(contentURI -> isVersionOf(targetURI, contentURI))
+                .collect(Collectors.toList());
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1731,29 +1731,29 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     public void deleteDataJSONShouldDeletePreviousVersionFromReviewed() throws Exception {
         Collection c1 = createCollection(rootDir.getRoot().toPath(), "nargle");
 
-        assertTrue(c1.getComplete().getPath().resolve("a/b/c").toFile().mkdirs());
-        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/previous/v1").toFile().mkdirs());
+        assertTrue(c1.getComplete().getPath().resolve("a/b/c/current").toFile().mkdirs());
+        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1").toFile().mkdirs());
 
-        Path uri = Paths.get("a/b/c");
+        Path uri = Paths.get("a/b/c/current");
         assertTrue(c1.getComplete().getPath().resolve(uri).resolve("data.json").toFile().createNewFile());
         assertTrue(c1.getComplete().getPath().resolve(uri).resolve("abc123.json").toFile().createNewFile());
         assertTrue(c1.getComplete().getPath().resolve(uri).resolve("abc123.xls").toFile().createNewFile());
 
         // mock a previous version of the content in the reviewed dir.
-        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/data.json").toFile().createNewFile());
-        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/abc123.json").toFile().createNewFile());
-        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/abc123.xls").toFile().createNewFile());
+        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/data.json").toFile().createNewFile());
+        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/abc123.json").toFile().createNewFile());
+        assertTrue(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/abc123.xls").toFile().createNewFile());
 
-        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/data.json");
+        boolean deleteSuccessful = c1.deleteFileAndRelated("/a/b/c/current/data.json");
 
         assertTrue(deleteSuccessful);
         assertFalse(Files.exists(c1.getComplete().getPath().resolve("a/b/c/data.json")));
         assertFalse(Files.exists(c1.getComplete().getPath().resolve("a/b/c/abc123.json")));
         assertFalse(Files.exists(c1.getComplete().getPath().resolve("a/b/c/abc123.xls")));
 
-        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/data.json")));
-        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/abc123.json")));
-        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/previous/v1/abc123.xld")));
+        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/data.json")));
+        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/abc123.json")));
+        assertFalse(Files.exists(c1.getReviewed().getPath().resolve("a/b/c/current/previous/v1/abc123.xlsx")));
     }
 
     public static Collection createCollection(Path destination, String collectionName) throws CollectionNotFoundException, IOException {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/filter/MDCFilter.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/filter/MDCFilter.java
@@ -13,10 +13,19 @@ import static com.github.onsdigital.zebedee.logging.ReaderLogger.info;
  */
 public class MDCFilter implements Filter {
 
+    private static final String PING = "/ping";
+    private static final String REQUEST_RECEIVED = "request received";
+
+
     @Override
     public boolean filter(HttpServletRequest request, HttpServletResponse response) {
-        RequestLogUtil.extractDiagnosticContext(request);
-        info().beginHTTP(request).log("request receieved");
+        String uri = request.getRequestURI();
+
+        if (!uri.startsWith(PING)) {
+            RequestLogUtil.extractDiagnosticContext(request);
+            info().beginHTTP(request).log(REQUEST_RECEIVED);
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
Fix for defect where all dataset previous versions were being deleted from the collection if a dataset page or dataset landing page were deleted.

Filter logic was using incorrect variable was evaluating to true for all versioned URIs instead of only returning versioned URIs that are children of the target URI.

🤦‍♂ 