### PR TITLE
Update batik dependency (SVG->PNG conversion)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,17 +65,17 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
-            <version>1.8</version>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-codec</artifactId>
-            <version>1.8</version>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
-            <version>1.5</version>
+            <version>2.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What

Updated `batik` library dependencies to fix some critical security vulnerabilities. This is the library used for SVG to PNG conversion (for equations).

### How to review

Ensure equations successfully generate a PNG in the same zebedee content dir as the SVG. 
NB. Looking at Babbage, the png isn't actually used presently (https://github.com/ONSdigital/babbage/blob/develop/src/main/web/templates/handlebars/partials/equation.handlebars#L8)

### Who can review

Anyone but me