### PR TITLE
Upgrade spring dependency

### DIFF
--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -30,7 +30,7 @@
     </repositories>
 
     <properties>
-        <spring.version>4.2.6.RELEASE</spring.version>
+        <spring.version>5.2.5.RELEASE</spring.version>
     </properties>
 
     <dependencies>
@@ -144,6 +144,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -173,7 +174,8 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.3.8.RELEASE</version>
+            <version>${spring.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -172,13 +172,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>${spring.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>26.0-jre</version>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
@@ -15,11 +15,12 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
-import org.springframework.http.HttpStatus;
+import org.apache.http.HttpStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
+import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -29,7 +30,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.text.MessageFormat.format;
-import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 
 /**
  * API endpoint for generating Team members XLS report.
@@ -63,9 +63,9 @@ public class TeamsReport {
     public void getReport(HttpServletRequest request, HttpServletResponse response) throws IOException,
             BadRequestException, UnauthorizedException, ForbiddenException {
         Session session = serviceServiceSupplier.getService().get(request);
-        response.setContentType(APPLICATION_OCTET_STREAM_VALUE);
+        response.setContentType(MediaType.APPLICATION_OCTET_STREAM);
         response.setHeader(CONTENT_DISPOSITION_HEADER, format(CONTENT_DISPOSITION_VALUE, getDateString()));
-        response.setStatus(HttpStatus.OK.value());
+        response.setStatus(HttpStatus.SC_OK);
         createWorkbook(session, response);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
@@ -36,8 +36,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-//import org.springframework.mock.web.MockHttpServletResponse;
-
 /**
  * Verify the behaviour of the {@link TeamsReport} API.
  */

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
@@ -10,8 +10,8 @@ import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import javax.ws.rs.core.MediaType;
+import org.apache.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -106,8 +106,8 @@ public class TeamsReportTest extends ZebedeeAPIBaseTestCase {
         HSSFWorkbook result = new HSSFWorkbook(in);
         HSSFSheet sheet = result.getSheetAt(0);
 
-        assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
-        assertThat(response.getContentType(), equalTo(MediaType.APPLICATION_OCTET_STREAM_VALUE));
+        assertThat(response.getStatus(), equalTo(HttpStatus.SC_OK));
+        assertThat(response.getContentType(), equalTo(MediaType.APPLICATION_OCTET_STREAM));
 
         verify(sessions, times(1)).get(mockRequest);
         verify(teamsService, times(1)).getTeamMembersSummary(session);


### PR DESCRIPTION
### What

Upgraded spring dependency to 5.2.5 (latest)
This is mainly used for testing, although there was one main usage (TeamsReport) where it was being used for a couple of constants. I switched those constants to ones from other libraries to be consistent with other classes in the app. This allowed me to scope spring to just the test lifecycle. 
 
### How to review

Ensure zebedee builds, tests and runs successfully.
Ensure spring dependencies are of version 5.2.5 (5.1.1 or later required for security auditing resolution)

### Who can review

Anyone but me