### PR TITLE
Base Docker image now uses openjdk:8-jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8-jre
 
 # Add the repo source
 WORKDIR /usr/src

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8-jre
 
 WORKDIR /usr/src
 

--- a/zebedee-reader/Dockerfile
+++ b/zebedee-reader/Dockerfile
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8-jre
 
 # Add the repo source
 WORKDIR /usr/src

--- a/zebedee-reader/Dockerfile.concourse
+++ b/zebedee-reader/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM openjdk:8-jre
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
### What

CMS and Reader variations of Zebedee have had their base image changed from onsdigital/java-component to openjdk:8-jre

This has been changed for both the concourse docker files and the local docker files

### Why is this changing

We are moving towards using a version of Java that supports being in a docker container. This should help resolve some of the OOM issues we have been having recently.

### How to review

Check that all four docker images have been updated and Zebedee works as normal

### Who can review

Anyone except me
