### PR TITLE
fixed content type header and added unit tests

### DIFF
--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -113,6 +113,12 @@
             <version>${fasterxml.jackson.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.12</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.12</version>
+            <version>1.25</version>
         </dependency>
 
     </dependencies>

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
@@ -19,10 +19,10 @@ import com.github.onsdigital.zebedee.util.PathUtils;
 import com.github.onsdigital.zebedee.util.URIUtils;
 import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.tika.Tika;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLConnection;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -45,7 +45,6 @@ import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.newDirectoryStream;
 import static java.nio.file.Files.newInputStream;
-import static java.nio.file.Files.probeContentType;
 import static java.nio.file.Files.size;
 import static org.apache.commons.lang3.StringUtils.removeEnd;
 
@@ -58,6 +57,14 @@ import static org.apache.commons.lang3.StringUtils.removeEnd;
  * <p>
  */
 public class FileSystemContentReader implements ContentReader {
+
+    private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+
+    /**
+     * Apache TIKA is a library providing helper methods for determining the MIME type of files. Using this in place
+     * of {@link Files#probeContentType(Path)} due to know issues and bugs depending on the OS its used on.
+     */
+    private static Tika tika = new Tika();
 
     private final Path ROOT_FOLDER;
     private ContentLanguage language = ContentLanguage.en;
@@ -82,17 +89,8 @@ public class FileSystemContentReader implements ContentReader {
      * @throws IOException
      */
     protected static String determineMimeType(Path path) throws IOException {
-        String mimeType = probeContentType(path);
-
-        // probeContentType returning null for a number of file types. (images on mac at least)
-        // using another method as a fallback.
-        if (mimeType == null)
-            mimeType = URLConnection.guessContentTypeFromName(path.getFileName().toString());
-
-        if (mimeType == null)
-            mimeType = "application/octet-stream";
-
-        return mimeType;
+        String mimeType = tika.detect(path);
+        return StringUtils.defaultIfEmpty(mimeType, DEFAULT_MIME_TYPE);
     }
 
     /**
@@ -224,7 +222,8 @@ public class FileSystemContentReader implements ContentReader {
     }
 
     @Override
-    public DirectoryStream<Path> getDirectoryStream(String path, String filter) throws BadRequestException, IOException {
+    public DirectoryStream<Path> getDirectoryStream(String path, String filter) throws
+            BadRequestException, IOException {
         Path node = resolvePath(path);
         return newDirectoryStream(node, filter);
     }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
@@ -84,13 +84,12 @@ public class FileSystemContentReader implements ContentReader {
     /**
      * Determine the mime type of the file at the given path.
      *
-     * @param path
-     * @return
-     * @throws IOException
+     * @param path the file path of the content to check.
+     * @return the MIME type for the file, (default is application/octet-stream).
+     * @throws IOException error determining MIME type.
      */
     protected static String determineMimeType(Path path) throws IOException {
-        String mimeType = tika.detect(path);
-        return StringUtils.defaultIfEmpty(mimeType, DEFAULT_MIME_TYPE);
+        return StringUtils.defaultIfEmpty(tika.detect(path), DEFAULT_MIME_TYPE);
     }
 
     /**

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/FileSystemContentReaderTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/FileSystemContentReaderTest.java
@@ -1,0 +1,51 @@
+package com.github.onsdigital.zebedee.reader;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FileSystemContentReaderTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void shouldReturnCorrectMimeType_forCssFile() throws Exception {
+        assertFileMimeType("test.css", "text/css");
+    }
+
+    @Test
+    public void shouldReturnCorrectMimeType_forJSFile() throws Exception {
+        assertFileMimeType("test.js", "application/javascript");
+    }
+
+    @Test
+    public void shouldReturnCorrectMimeType_forHTMLFile() throws Exception {
+        assertFileMimeType("test.html", "text/html");
+    }
+
+    @Test
+    public void shouldReturnCorrectMimeType_forJSONFile() throws Exception {
+        assertFileMimeType("test.json", "application/json");
+    }
+
+    @Test
+    public void shouldReturnCorrectMimeType_forPNGFile() throws Exception {
+        assertFileMimeType("test.png", "image/png");
+    }
+
+    void assertFileMimeType(String filename, String expectedMimeType) throws Exception {
+        File f = temporaryFolder.newFile(filename);
+        try {
+            assertThat(FileSystemContentReader.determineMimeType(f.toPath()), equalTo(expectedMimeType));
+        } finally {
+            Files.deleteIfExists(f.toPath());
+        }
+    }
+}


### PR DESCRIPTION
### What

Fix for defect in detecting file `MIME` types.

Existing logic to determined the `MIME` type for requested content was always returning null and defaulting to `application/octet-stream`. This was breaking data visualisations as the css files were not being returned with the correct content type header to be recognised.

The `Files.probeContentType()` method in the Java standard lib is apparent buggy and OS dependant 
https://stackoverflow.com/questions/12407479/why-does-files-probecontenttype-return-null

I've updated it to use `apache Tika` and added unit tests to prove it is resolving the types corrently.

### How to review

PR

### Who can review

Anyone.
