### PR TITLE
Fix audit build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ audit : audit-cms
 
 .PHONY: audit-cms
 audit-cms:
+	mvn install -pl zebedee-reader -Dmaven.test.skip -Dossindex.skip=true
 	mvn ossindex:audit
 
 .PHONY: audit-reader

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -eux
 
 pushd zebedee
-    mvn clean install dependency:copy-dependencies -Dmaven.test.skip=true -Dossindex.skip=true
-
     if [[ "$APPLICATION" == "zebedee" ]]; then
         make audit-cms
     elif [[ "$APPLICATION" == "zebedee-reader" ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,6 @@
         <url>http://onsdigital.github.io/</url>
     </organization>
 
-    <scm>
-        <url>https://github.com/carboni/zebedee</url>
-        <connection>scm:git:git://github.com/Carboni/zebedee.git</connection>
-        <developerConnection>scm:git:git@github.com:Carboni/zebedee.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
     <properties>
         <java.version>1.8</java.version>
         <encoding>UTF-8</encoding>


### PR DESCRIPTION
### What

The audit job was failing due to `zebedee-reader` dependency not
existing at time of audit.

### How to review

Check that the audit job passes on this PR 🤞 

### Who can review

Anyone but me.
