### PR TITLE
Send slack notifications on startup for collection approval status IN_PROGESS or ERROR

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -189,7 +189,7 @@ public class Root {
 
     static void alertOnInProgressCollections(Collections.CollectionList collections, Notifier notifier) {
         info().log("zebedee root: checking existing collections for in progress approvals");
-        collections.withApprovalInProgress().forEach(c -> {
+        collections.withApprovalInProgressOrError().forEach(c -> {
             info().data("collectionId", c.getDescription().getId())
                     .data("type", c.getDescription().getType().name())
                     .log("zebedee root: collection approval is in error or in progress state on zebedee startup");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -131,7 +131,7 @@ public class Root {
             alertOnInProgressCollections(collections, new SlackNotifier());
             loadExistingCollectionsIntoScheduler(collections);
         } catch (IOException e) {
-            error().logException(e, "zebedee root: failed to load collections list check in progress approvals");
+            error().logException(e, "zebedee root: failed to load collections list on startup");
         }
 
         initialiseCsdbImportKeys();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -3,7 +3,6 @@ package com.github.onsdigital.zebedee.model;
 import com.github.davidcarboni.encryptedfileupload.EncryptedFileItemFactory;
 import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.api.Root;
-import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
 import com.github.onsdigital.zebedee.content.util.ContentUtil;
 import com.github.onsdigital.zebedee.data.json.DirectoryListing;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
@@ -991,6 +990,12 @@ public class Collections {
             return getCollectionByName(name) != null;
         }
 
+        public List<Collection> withApprovalInProgress() {
+            return this.stream()
+                    .filter(c -> c.getDescription().getApprovalStatus() == ApprovalStatus.IN_PROGRESS
+                            || c.getDescription().getApprovalStatus() == ApprovalStatus.ERROR)
+                    .collect(Collectors.toList());
+        }
     }
 
     public void verifyDatasetVersions(Collection collection, CollectionReader collectionReader, Session session) throws ZebedeeException, IOException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -990,7 +990,7 @@ public class Collections {
             return getCollectionByName(name) != null;
         }
 
-        public List<Collection> withApprovalInProgress() {
+        public List<Collection> withApprovalInProgressOrError() {
             return this.stream()
                     .filter(c -> c.getDescription().getApprovalStatus() == ApprovalStatus.IN_PROGRESS
                             || c.getDescription().getApprovalStatus() == ApprovalStatus.ERROR)

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
@@ -28,9 +28,13 @@ import java.util.concurrent.TimeUnit;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
+
 /**
  * Sends messages to slack.
+ *
+ * @deprecated - If possible use the non-static wrapper implementation {@link SlackNotification}
  */
+@Deprecated
 public class SlackNotification {
 
     public enum CollectionStage {
@@ -138,7 +142,6 @@ public class SlackNotification {
                             attch.getFields().add(new PostMessageField("Example page", "https://www.ons.gov.uk" + urlInfo.uri.substring(0, urlInfo.uri.length() - (DATA_JSON).length()), false));
                         });
             }
-
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/Notifier.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/Notifier.java
@@ -1,0 +1,17 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.zebedee.model.Collection;
+
+
+/**
+ * Notifier is a generic interface for sending notifications to external systems such as Slack
+ */
+public interface Notifier {
+
+    /**
+     * @param c - the collection the notification relates to.
+     * @param alarm - the string message to apply to the notification.
+     * @param args - additional arguments to add to the notification.
+     */
+    void collectionAlarm(Collection c, String alarm, PostMessageField... args);
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/Notifier.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/Notifier.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.util.slack;
 
 import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.util.SlackNotification;
 
 
 /**
@@ -9,9 +10,19 @@ import com.github.onsdigital.zebedee.model.Collection;
 public interface Notifier {
 
     /**
+     * Create a new collection specific alarm notification.
+     *
      * @param c - the collection the notification relates to.
      * @param alarm - the string message to apply to the notification.
      * @param args - additional arguments to add to the notification.
      */
     void collectionAlarm(Collection c, String alarm, PostMessageField... args);
+
+    /**
+     * Create a new alarm notification.
+     *
+     * @param alarm - the string message to apply to the notification.
+     * @param args - additional arguments to add to the notification.
+     */
+    void alarm(String alarm, PostMessageField... args);
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/SlackNotifier.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/SlackNotifier.java
@@ -1,0 +1,22 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.util.SlackNotification;
+
+
+/**
+ * SlackNotifier provides a slack specific Notifier implementation.
+ * It wraps the original SlackNotification static class, to enable dependency injection in dependent code.
+ */
+public class SlackNotifier implements Notifier {
+
+    /**
+     * @param c - the collection the notification relates to.
+     * @param alarm - the string message to apply to the notification.
+     * @param args - additional arguments to add to the notification.
+     */
+    @Override
+    public void collectionAlarm(Collection c, String alarm, PostMessageField... args) {
+        SlackNotification.collectionAlarm(c, alarm, args);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/SlackNotifier.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/SlackNotifier.java
@@ -11,6 +11,8 @@ import com.github.onsdigital.zebedee.util.SlackNotification;
 public class SlackNotifier implements Notifier {
 
     /**
+     * Send a collection specific alarm to Slack.
+     *
      * @param c - the collection the notification relates to.
      * @param alarm - the string message to apply to the notification.
      * @param args - additional arguments to add to the notification.
@@ -18,5 +20,16 @@ public class SlackNotifier implements Notifier {
     @Override
     public void collectionAlarm(Collection c, String alarm, PostMessageField... args) {
         SlackNotification.collectionAlarm(c, alarm, args);
+    }
+
+    /**
+     * Send a collection specific alarm to Slack.
+     *
+     * @param alarm - the string message to apply to the notification.
+     * @param args - additional arguments to add to the notification.
+     */
+    @Override
+    public void alarm(String alarm, PostMessageField... args) {
+        SlackNotification.alarm(alarm, args);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/RootTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/RootTest.java
@@ -1,0 +1,155 @@
+package com.github.onsdigital.zebedee.api;
+
+import com.github.onsdigital.zebedee.json.ApprovalStatus;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Collections;
+import com.github.onsdigital.zebedee.util.slack.Notifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RootTest {
+
+    @Mock
+    Notifier notifier;
+
+    @Mock
+    Collection notStartedCollection;
+
+    @Mock
+    Collection inProgressCollection;
+
+    @Mock
+    Collection erroredCollection;
+
+    public static final String EXPECTED_MESSAGE = "Collection approval is in IN_PROGRESS or ERROR state on zebedee startup. It may need to be re-approved manually.";
+
+    @Before
+    public void setUp() throws Exception {
+
+        CollectionDescription notStartedDescription = new CollectionDescription();
+        notStartedDescription.setApprovalStatus(ApprovalStatus.NOT_STARTED);
+        notStartedDescription.setType(CollectionType.scheduled);
+        when(notStartedCollection.getDescription()).thenReturn(notStartedDescription);
+
+        CollectionDescription inProgressDescription = new CollectionDescription();
+        inProgressDescription.setApprovalStatus(ApprovalStatus.IN_PROGRESS);
+        inProgressDescription.setType(CollectionType.scheduled);
+        when(inProgressCollection.getDescription()).thenReturn(inProgressDescription);
+
+        CollectionDescription erroredDescription = new CollectionDescription();
+        erroredDescription.setApprovalStatus(ApprovalStatus.ERROR);
+        erroredDescription.setType(CollectionType.scheduled);
+        when(erroredCollection.getDescription()).thenReturn(erroredDescription);
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_emptyCollectionsList() {
+
+        // Given an empty list of collections
+        Collections.CollectionList collections = new Collections.CollectionList();
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then no notifications are sent
+        verify(notifier, never()).collectionAlarm(any(), anyString());
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_noInProgressCollections() {
+
+        // Given a list of collections with none in approval state IN_PROGRESS or ERROR
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(notStartedCollection);
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then no notifications are sent
+        verify(notifier, never()).collectionAlarm(any(), anyString());
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_inProgressCollection() {
+
+        // Given a list of collections with one in progress approval state
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(notStartedCollection);
+        collections.add(inProgressCollection);
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then a notification is sent for the in progress collection
+        verify(notifier, times(1)).collectionAlarm(inProgressCollection, EXPECTED_MESSAGE);
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_erroredCollection() {
+
+        // Given a list of collections with one in errored approval state
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(notStartedCollection);
+        collections.add(erroredCollection);
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then a notification is sent for the errored collection
+        verify(notifier, times(1)).collectionAlarm(erroredCollection, EXPECTED_MESSAGE);
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_erroredAndInProgressCollections() {
+
+        // Given a list of collections with collections in both ERROR and IN_PROGRESS approval states
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(inProgressCollection);
+        collections.add(notStartedCollection);
+        collections.add(erroredCollection);
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then a notification is sent for the errored collection
+        verify(notifier, times(1)).collectionAlarm(erroredCollection, EXPECTED_MESSAGE);
+
+        // Then a notification is sent for the in progress collection
+        verify(notifier, times(1)).collectionAlarm(inProgressCollection, EXPECTED_MESSAGE);
+    }
+
+    @Test
+    public void testAlertOnInProgressCollections_multipleCollections() {
+
+        // Given a list of collections with multiple collections in both ERROR and IN_PROGRESS approval states
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(inProgressCollection);
+        collections.add(inProgressCollection);
+        collections.add(notStartedCollection);
+        collections.add(notStartedCollection);
+        collections.add(erroredCollection);
+        collections.add(erroredCollection);
+
+        // When the alertOnInProgressCollections function is called
+        Root.alertOnInProgressCollections(collections, notifier);
+
+        // Then notifications is sent for each errored collection
+        verify(notifier, times(2)).collectionAlarm(erroredCollection, EXPECTED_MESSAGE);
+
+        // Then notifications are sent for each in progress collection
+        verify(notifier, times(2)).collectionAlarm(inProgressCollection, EXPECTED_MESSAGE);
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -59,6 +59,8 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -1135,7 +1137,6 @@ public class CollectionsTest {
         assertThat(collectionsPath.resolve("col1/inprogress").toFile().list().length, equalTo(0));
     }
 
-
     @Test
     public void skipDatasetVersionsValidation_userKeyNull_shouldReturnFalse() throws IOException {
         assertFalse(collections.skipDatasetVersionsValidation(null, null, null));
@@ -1203,5 +1204,126 @@ public class CollectionsTest {
 
         Event event = description.events.get(0);
         assertThat(event.getType(), equalTo(EventType.VERSION_VERIFICATION_BYPASSED));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_emptyCollectionsList() {
+
+        // Given an empty list of collections
+        Collections.CollectionList collections = new Collections.CollectionList();
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then an empty collection is returned
+        assertThat(withApprovalInProgress, hasSize(0));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_noInProgressCollections() {
+
+        // Given a list of collections with none in approval state IN_PROGRESS or ERROR
+        Collections.CollectionList collections = new Collections.CollectionList();
+        Collection collection = getMockCollection(ApprovalStatus.NOT_STARTED);
+        collections.add(collection);
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then an empty collection is returned
+        assertThat(withApprovalInProgress, hasSize(0));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_inProgressCollection() {
+
+        // Given a list of collections with one in approval state IN_PROGRESS
+        Collections.CollectionList collections = new Collections.CollectionList();
+        Collection collection = getMockCollection(ApprovalStatus.IN_PROGRESS);
+        collections.add(collection);
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then the list returned contains the collection
+        assertThat(withApprovalInProgress, hasSize(1));
+        assertThat(withApprovalInProgress, contains(collection));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_erroredCollection() {
+
+        // Given a list of collections with one in approval state ERROR
+        Collections.CollectionList collections = new Collections.CollectionList();
+        Collection collection = getMockCollection(ApprovalStatus.ERROR);
+        collections.add(collection);
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then the list returned contains the collection
+        assertThat(withApprovalInProgress, hasSize(1));
+        assertThat(withApprovalInProgress, contains(collection));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_erroredAndInProgressCollections() {
+
+        // Given a list of collections with collections in both ERROR and IN_PROGRESS approval states
+        Collection inProgressCollection = getMockCollection(ApprovalStatus.IN_PROGRESS);
+        Collection erroredCollection = getMockCollection(ApprovalStatus.ERROR);
+        Collection notStartedCollection = getMockCollection(ApprovalStatus.NOT_STARTED);
+
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(inProgressCollection);
+        collections.add(notStartedCollection);
+        collections.add(erroredCollection);
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then the list returned contains only the collections in ERROR and IN_PROGRESS approval states
+        assertThat(withApprovalInProgress, hasSize(2));
+        assertThat(withApprovalInProgress, contains(inProgressCollection, erroredCollection));
+    }
+
+    @Test
+    public void collectionsList_withApprovalInProgress_multipleCollections() {
+
+        // Given a list of collections with multiple collections in both ERROR and IN_PROGRESS approval states
+        Collection inProgressCollection1 = getMockCollection(ApprovalStatus.IN_PROGRESS);
+        Collection inProgressCollection2 = getMockCollection(ApprovalStatus.IN_PROGRESS);
+        Collection erroredCollection1 = getMockCollection(ApprovalStatus.ERROR);
+        Collection erroredCollection2 = getMockCollection(ApprovalStatus.ERROR);
+        Collection notStartedCollection1 = getMockCollection(ApprovalStatus.NOT_STARTED);
+        Collection notStartedCollection2 = getMockCollection(ApprovalStatus.NOT_STARTED);
+
+        Collections.CollectionList collections = new Collections.CollectionList();
+        collections.add(inProgressCollection1);
+        collections.add(inProgressCollection2);
+        collections.add(notStartedCollection1);
+        collections.add(notStartedCollection2);
+        collections.add(erroredCollection1);
+        collections.add(erroredCollection2);
+
+        // When the withApprovalInProgress function is called
+        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+
+        // Then the list returned contains only the collections in ERROR and IN_PROGRESS approval states
+        assertThat(withApprovalInProgress, hasSize(4));
+        assertThat(withApprovalInProgress, contains(
+                inProgressCollection1,
+                inProgressCollection2,
+                erroredCollection1,
+                erroredCollection2));
+    }
+
+    private Collection getMockCollection(ApprovalStatus approvalStatus) {
+        Collection collection = mock(Collection.class);
+        CollectionDescription description = new CollectionDescription();
+        description.setApprovalStatus(approvalStatus);
+        description.setType(CollectionType.scheduled);
+        when(collection.getDescription()).thenReturn(description);
+        return collection;
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -1207,67 +1207,67 @@ public class CollectionsTest {
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_emptyCollectionsList() {
+    public void collectionsList_withApprovalInProgressOrError_emptyCollectionsList() {
 
         // Given an empty list of collections
         Collections.CollectionList collections = new Collections.CollectionList();
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then an empty collection is returned
-        assertThat(withApprovalInProgress, hasSize(0));
+        assertThat(filteredCollections, hasSize(0));
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_noInProgressCollections() {
+    public void collectionsList_withApprovalInProgressOrError_noInProgressCollections() {
 
         // Given a list of collections with none in approval state IN_PROGRESS or ERROR
         Collections.CollectionList collections = new Collections.CollectionList();
         Collection collection = getMockCollection(ApprovalStatus.NOT_STARTED);
         collections.add(collection);
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then an empty collection is returned
-        assertThat(withApprovalInProgress, hasSize(0));
+        assertThat(filteredCollections, hasSize(0));
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_inProgressCollection() {
+    public void collectionsList_withApprovalInProgressOrError_inProgressCollection() {
 
         // Given a list of collections with one in approval state IN_PROGRESS
         Collections.CollectionList collections = new Collections.CollectionList();
         Collection collection = getMockCollection(ApprovalStatus.IN_PROGRESS);
         collections.add(collection);
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then the list returned contains the collection
-        assertThat(withApprovalInProgress, hasSize(1));
-        assertThat(withApprovalInProgress, contains(collection));
+        assertThat(filteredCollections, hasSize(1));
+        assertThat(filteredCollections, contains(collection));
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_erroredCollection() {
+    public void collectionsList_withApprovalInProgressOrError_erroredCollection() {
 
         // Given a list of collections with one in approval state ERROR
         Collections.CollectionList collections = new Collections.CollectionList();
         Collection collection = getMockCollection(ApprovalStatus.ERROR);
         collections.add(collection);
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then the list returned contains the collection
-        assertThat(withApprovalInProgress, hasSize(1));
-        assertThat(withApprovalInProgress, contains(collection));
+        assertThat(filteredCollections, hasSize(1));
+        assertThat(filteredCollections, contains(collection));
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_erroredAndInProgressCollections() {
+    public void collectionsList_withApprovalInProgressOrError_erroredAndInProgressCollections() {
 
         // Given a list of collections with collections in both ERROR and IN_PROGRESS approval states
         Collection inProgressCollection = getMockCollection(ApprovalStatus.IN_PROGRESS);
@@ -1279,16 +1279,16 @@ public class CollectionsTest {
         collections.add(notStartedCollection);
         collections.add(erroredCollection);
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then the list returned contains only the collections in ERROR and IN_PROGRESS approval states
-        assertThat(withApprovalInProgress, hasSize(2));
-        assertThat(withApprovalInProgress, contains(inProgressCollection, erroredCollection));
+        assertThat(filteredCollections, hasSize(2));
+        assertThat(filteredCollections, contains(inProgressCollection, erroredCollection));
     }
 
     @Test
-    public void collectionsList_withApprovalInProgress_multipleCollections() {
+    public void collectionsList_withApprovalInProgressOrError_multipleCollections() {
 
         // Given a list of collections with multiple collections in both ERROR and IN_PROGRESS approval states
         Collection inProgressCollection1 = getMockCollection(ApprovalStatus.IN_PROGRESS);
@@ -1306,12 +1306,12 @@ public class CollectionsTest {
         collections.add(erroredCollection1);
         collections.add(erroredCollection2);
 
-        // When the withApprovalInProgress function is called
-        final List<Collection> withApprovalInProgress = collections.withApprovalInProgress();
+        // When the withApprovalInProgressOrError function is called
+        final List<Collection> filteredCollections = collections.withApprovalInProgressOrError();
 
         // Then the list returned contains only the collections in ERROR and IN_PROGRESS approval states
-        assertThat(withApprovalInProgress, hasSize(4));
-        assertThat(withApprovalInProgress, contains(
+        assertThat(filteredCollections, hasSize(4));
+        assertThat(filteredCollections, contains(
                 inProgressCollection1,
                 inProgressCollection2,
                 erroredCollection1,


### PR DESCRIPTION
### What
Send slack notifications on startup for collection approval status IN_PROGESS or ERROR
  - remove redundant indexPublishedCollections function.
  - move the loading of collections out of the `loadExistingCollectionsIntoScheduler` function, allowing it to be reused in the `alertOnInProgressCollections` function.
  - Added Notifier interface and SlackNotifier implementation
  - Add @deprecated annotation to the existing SlackNotification class

### How to review
Review changes / tests. If you want to test locally you can create a collection in Florence and manually change the approval state in the collection json file.

### Who can review
Anyone
