### PR TITLE
added new secureKeyring impl + unit tests

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyring.java
@@ -7,7 +7,7 @@ public interface SecureKeyring {
     /**
      * Populate the Keyring from an unlocked {@link User#keyring()}
      *
-     * @param user the user to use to populate the keyring.
+     * @param user the user that populates the keyring.
      * @throws KeyringException problem populating the keyring.
      */
     void populateFromUser(User user) throws KeyringException;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyring.java
@@ -1,0 +1,14 @@
+package com.github.onsdigital.zebedee.keyring;
+
+import com.github.onsdigital.zebedee.user.model.User;
+
+public interface SecureKeyring {
+
+    /**
+     * Populate the Keyring from an unlocked {@link User#keyring()}
+     *
+     * @param user the user to use to populate the keyring.
+     * @throws KeyringException problem populating the keyring.
+     */
+    void populateFromUser(User user) throws KeyringException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SecureKeyringImpl.java
@@ -1,0 +1,41 @@
+package com.github.onsdigital.zebedee.keyring;
+
+import com.github.onsdigital.zebedee.user.model.User;
+
+/**
+ * SecureKeyringImpl adds a permissions check wrapper around a {@link Keyring} instance to ensure only authorised
+ * users can access collection encryption keys
+ */
+public class SecureKeyringImpl implements SecureKeyring {
+
+    static final String USER_NULL_ERR = "user required but was null";
+    static final String USER_KEYRING_NULL_ERR = "user keyring required but was null";
+    static final String USER_KEYRING_LOCKED_ERR = "error user keyring is locked";
+
+    private final Keyring centralKeyring;
+
+    public SecureKeyringImpl(Keyring centralKeyring) {
+        this.centralKeyring = centralKeyring;
+    }
+
+    @Override
+    public void populateFromUser(User user) throws KeyringException {
+        if (user == null) {
+            throw new KeyringException(USER_NULL_ERR);
+        }
+
+        if (user.keyring() == null) {
+            throw new KeyringException(USER_KEYRING_NULL_ERR);
+        }
+
+        if (!user.keyring().isUnlocked()) {
+            throw new KeyringException(USER_KEYRING_LOCKED_ERR);
+        }
+
+        if (!user.keyring().list().isEmpty()) {
+            for (String collectionID : user.keyring().list()) {
+                centralKeyring.add(collectionID, user.keyring().get(collectionID));
+            }
+        }
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/SecureKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/SecureKeyringImplTest.java
@@ -1,0 +1,162 @@
+package com.github.onsdigital.zebedee.keyring;
+
+import com.github.onsdigital.zebedee.user.model.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.crypto.SecretKey;
+import java.util.HashSet;
+
+import static com.github.onsdigital.zebedee.keyring.SecureKeyringImpl.USER_KEYRING_LOCKED_ERR;
+import static com.github.onsdigital.zebedee.keyring.SecureKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.SecureKeyringImpl.USER_NULL_ERR;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class SecureKeyringImplTest {
+
+    static final String TEST_COLLECTION_ID = "44";
+
+    private SecureKeyring keyring;
+
+    @Mock
+    private Keyring centralKeyring;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private com.github.onsdigital.zebedee.json.Keyring userKeyring;
+
+    @Mock
+    private SecretKey secretKey;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        keyring = new SecureKeyringImpl(centralKeyring);
+    }
+
+    @Test
+    public void testPopulateFromUser_userNull() {
+        // Given the user is null
+        // when populateFromUser is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(null));
+
+        // then a Keyring exeption is thrown.
+        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void testPopulateFromUser_userKeyringNull() {
+        // Given the user keyring is null
+        when(user.keyring())
+                .thenReturn(null);
+
+        // When populateFromUser is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+
+        // Then a Keyring exeption is thrown.
+        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void testPopulateFromUser_userKeyringIsLocked() {
+        // Given the user keyring is locked
+        when(user.keyring())
+                .thenReturn(userKeyring);
+
+        when(userKeyring.isUnlocked())
+                .thenReturn(false);
+
+        // When populateFromUser is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+
+        // Then a Keyring exeption is thrown.
+        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void testPopulateFromUser_userKeyringIsEmpty() throws Exception {
+        // Given the user keyring is empty
+        when(user.keyring())
+                .thenReturn(userKeyring);
+
+        when(userKeyring.isUnlocked())
+                .thenReturn(true);
+
+        when(userKeyring.list())
+                .thenReturn(new HashSet<>());
+
+        // When populateFromUser is called
+        keyring.populateFromUser(user);
+
+        // Then the central keyring is not updated.
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void testPopulateFromUser_addThrowsException() throws Exception {
+        // Given central keyring.add throws an exception
+        when(user.keyring())
+                .thenReturn(userKeyring);
+
+        when(userKeyring.isUnlocked())
+                .thenReturn(true);
+
+        when(userKeyring.list())
+                .thenReturn(new HashSet<String>() {{
+                    add(TEST_COLLECTION_ID);
+                }});
+
+        when(userKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
+        doThrow(KeyringException.class)
+                .when(centralKeyring)
+                .add(any(), any());
+
+        // When populateFromUser is called
+        assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+
+        // Then the central keyring is not updated.
+        verify(centralKeyring, times(1)).add(any(), any());
+    }
+
+    @Test
+    public void testPopulateFromUser_success() throws Exception {
+        // Given a populated user keyring
+        when(user.keyring())
+                .thenReturn(userKeyring);
+
+        when(userKeyring.isUnlocked())
+                .thenReturn(true);
+
+        when(userKeyring.list())
+                .thenReturn(new HashSet<String>() {{
+                    add(TEST_COLLECTION_ID);
+                }});
+
+        when(userKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
+        // When populateFromUser is called
+        keyring.populateFromUser(user);
+
+        // Then the central keyring is updated with each entry in the user keyring.
+        verify(centralKeyring, times(1)).add(TEST_COLLECTION_ID, secretKey);
+    }
+}


### PR DESCRIPTION
### What

Created new `SecureKeyring` implementation and added unit tests for new functionality.
- Added `populateFromUser` method.
- Added unit tests for new functionality.

### How to review

The intention is for `SecureKeyring` to be a permissions wrapper around the new `Keyring` implementation. This keeps the keyring & permissions logic separate allowing us to transition over to the new world Permissions API without any changes required to the core keyring logic.

`populateFromUser` populates the new central keyring from the legacy keyring of an authenticated `User`. This is a temporary hook to allows us to migrate from the old keyring to the new keyring without losing any of the existing collection keys. The plan is to "dual run" the legacy and new keyring implementations for a bit. Once we're confident its all working as expected we can remove the legacy keyring without losing any data.

### Who can review

Anyone.
