### PR TITLE
Feature/populate keyring on login

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -70,7 +70,7 @@ public class Zebedee {
     private final PublishedCollections publishedCollections;
     private final Collections collections;
     private final Content published;
-    private final KeyringCache keyringCache;
+    private final KeyringCache legacyKeyringCache;
     private final Path publishedContentPath;
     private final Path path;
     private final PermissionsService permissionsService;
@@ -91,7 +91,7 @@ public class Zebedee {
         this.path = configuration.getZebedeePath();
         this.publishedContentPath = configuration.getPublishedContentPath();
         this.sessions = configuration.getSessions();
-        this.keyringCache = configuration.getKeyringCache();
+        this.legacyKeyringCache = configuration.getKeyringCache();
         this.permissionsService = configuration.getPermissionsService();
         this.published = configuration.getPublished();
         this.dataIndex = configuration.getDataIndex();
@@ -294,7 +294,7 @@ public class Zebedee {
         }
 
         applicationKeys.populateCacheFromUserKeyring(user.keyring());
-        keyringCache.put(user, session);
+        legacyKeyringCache.put(user, session);
 
         // Return a session
         return session;
@@ -328,8 +328,9 @@ public class Zebedee {
         return this.publishedCollections;
     }
 
-    public KeyringCache getKeyringCache() {
-        return this.keyringCache;
+    @Deprecated
+    public KeyringCache getLegacyKeyringCache() {
+        return this.legacyKeyringCache;
     }
 
     public ApplicationKeys getApplicationKeys() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.json.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.model.Content;
@@ -81,6 +82,7 @@ public class Zebedee {
     private final DataIndex dataIndex;
     private final DatasetService datasetService;
     private final ServiceStoreImpl serviceStoreImpl;
+    private final CollectionKeyring collectionKeyring;
 
     /**
      * Create a new instance of Zebedee setting.
@@ -103,6 +105,7 @@ public class Zebedee {
         this.verificationAgent = configuration.getVerificationAgent(isVerificationEnabled(), this);
         this.datasetService = configuration.getDatasetService();
         this.serviceStoreImpl = configuration.getServiceStore();
+        this.collectionKeyring = configuration.getCollectionKeyring();
 
         this.collectionsPath = configuration.getCollectionsPath();
         this.publishedCollectionsPath = configuration.getPublishedCollectionsPath();
@@ -295,6 +298,7 @@ public class Zebedee {
 
         applicationKeys.populateCacheFromUserKeyring(user.keyring());
         legacyKeyringCache.put(user, session);
+        collectionKeyring.populateFromUser(user);
 
         // Return a session
         return session;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -4,6 +4,9 @@ import com.github.onsdigital.session.service.client.Http;
 import com.github.onsdigital.session.service.client.SessionClient;
 import com.github.onsdigital.session.service.client.SessionClientImpl;
 import com.github.onsdigital.zebedee.data.processing.DataIndex;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyringImpl;
+import com.github.onsdigital.zebedee.keyring.NopCollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.cache.KeyringCache;
 import com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl;
 import com.github.onsdigital.zebedee.keyring.store.KeyringStore;
@@ -97,6 +100,7 @@ public class ZebedeeConfiguration {
     private DatasetService datasetService;
     private SessionClient sessionClient;
     private KeyringCache keyringCache;
+    private CollectionKeyring collectionKeyring;
 
 
     /**
@@ -154,6 +158,11 @@ public class ZebedeeConfiguration {
 
             KeyringCacheImpl.init(keyStore);
             KeyringCache keyringCache = KeyringCacheImpl.getInstance();
+
+            CollectionKeyringImpl.init(keyringCache);
+            this.collectionKeyring = CollectionKeyringImpl.getInstance();
+        } else {
+            this.collectionKeyring = new NopCollectionKeyring();
         }
 
         // Initialise legacy keyring regardless - they will dual run until we cut over to new impl.
@@ -328,6 +337,10 @@ public class ZebedeeConfiguration {
 
     public ServiceStoreImpl getServiceStore() {
         return new ServiceStoreImpl(servicePath);
+    }
+
+    public CollectionKeyring getCollectionKeyring() {
+        return this.collectionKeyring;
     }
 
     private Path createDir(Path root, String dirName) throws IOException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -128,7 +128,7 @@ public class Collection {
 
         info().data("user", session.getEmail()).log("create collection endpoint: user granted canEdit permission");
 
-        Keyring keyring = Root.zebedee.getKeyringCache().get(session);
+        Keyring keyring = Root.zebedee.getLegacyKeyringCache().get(session);
         if (keyring == null) {
             warn().data("user", session.getEmail()).log("create collection endpoint: request unsuccessful Keyring is not initialised");
             throw new UnauthorizedException("Keyring is not initialised.");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
@@ -44,7 +44,7 @@ public class CsdbNotify {
                 csdbId,
                 dylanClient,
                 Root.zebedee.getCollections(),
-                Root.zebedee.getKeyringCache().getSchedulerCache());
+                Root.zebedee.getLegacyKeyringCache().getSchedulerCache());
 
         Audit.Event.CSDB_NEW_FILE_NOTIFICATION
                 .parameters()

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
@@ -44,7 +44,7 @@ public class CsdbNotify {
                 csdbId,
                 dylanClient,
                 Root.zebedee.getCollections(),
-                Root.zebedee.getKeyringCache().schedulerCache);
+                Root.zebedee.getKeyringCache().getSchedulerCache());
 
         Audit.Event.CSDB_NEW_FILE_NOTIFICATION
                 .parameters()

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImpl.java
@@ -76,6 +76,15 @@ public class CollectionKeyringImpl implements CollectionKeyring {
     }
 
     /**
+     * Initalise a NOP impl.
+     */
+    public static void initNoOp() {
+        if (INSTANCE == null) {
+            INSTANCE = new NopCollectionKeyring();
+        }
+    }
+
+    /**
      * @return a singleton instance of the CollectionKeyring
      * @throws KeyringException CollectionKeyring has not been initalised before being accessed.
      */

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImpl.java
@@ -77,7 +77,7 @@ public class CollectionKeyringImpl implements CollectionKeyring {
 
     /**
      * @return a singleton instance of the CollectionKeyring
-     * @throws KeyringException CollectionKeyring has not been initalised.
+     * @throws KeyringException CollectionKeyring has not been initalised before being accessed.
      */
     public static CollectionKeyring getInstance() throws KeyringException {
         if (INSTANCE == null) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/NopCollectionKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/NopCollectionKeyring.java
@@ -1,0 +1,11 @@
+package com.github.onsdigital.zebedee.keyring;
+
+import com.github.onsdigital.zebedee.user.model.User;
+
+public class NopCollectionKeyring implements CollectionKeyring {
+
+    @Override
+    public void populateFromUser(User user) throws KeyringException {
+        // DO NOTHING.
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImpl.java
@@ -34,11 +34,20 @@ public class KeyringCacheImpl implements KeyringCache {
     static final String KEY_NOT_FOUND_ERR = "SecretKey not found for this collection ID";
     static final String LOAD_KEYS_NULL_ERR = "error loading keystore expected map but was null";
     static final String KEYSTORE_NULL_ERR = "collection key store required but was null";
+    static final String NOT_INITIALISED_ERR = "keyringCache accessed but not yet initialised";
 
     private KeyringStore keyStore;
     private Map<String, SecretKey> cache;
 
     private static KeyringCache INSTANCE = null;
+
+    /**
+     * KeyringCache is a singleton instance. Use {@link KeyringCacheImpl#init(KeyringStore)} to initialise and
+     * {@link KeyringCacheImpl#getInstance()} to access the singleton.
+     */
+    private KeyringCacheImpl() {
+        // private constructor to force use of static get instance method.
+    }
 
     /**
      * Create a new instance of the Keyring. Use {@link KeyringCacheImpl#init(KeyringStore)} to constuct a new
@@ -198,13 +207,23 @@ public class KeyringCacheImpl implements KeyringCache {
      * @return a new {@link KeyringCache} instance.
      * @throws KeyringException problem initalising the keyring.
      */
-    public static KeyringCache init(KeyringStore keystore) throws KeyringException {
+    public static void init(KeyringStore keystore) throws KeyringException {
         if (INSTANCE == null) {
             synchronized (KeyringCacheImpl.class) {
                 if (INSTANCE == null) {
                     INSTANCE = new KeyringCacheImpl(keystore);
                 }
             }
+        }
+    }
+
+    /**
+     * @return a singleton instance of the {@link KeyringCache}
+     * @throws KeyringException the instance has not been initalised before being accessed.
+     */
+    public static KeyringCache getInstance() throws KeyringException {
+        if (INSTANCE == null) {
+            throw new KeyringException(NOT_INITIALISED_ERR);
         }
         return INSTANCE;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/store/KeyringStoreImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/store/KeyringStoreImpl.java
@@ -46,7 +46,7 @@ public class KeyringStoreImpl implements KeyringStore {
     static final String KEYRING_DIR_DOES_NOT_EXIST_ERR = "error reading collectionKey keyring dir not found";
     static final String ENCRYPTION_ALGORITHM = "AES";
     static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
-    static final String KEY_EXT = ".key";
+    static final String KEY_EXT = ".cek"; // Collection Encryption Key obviously...
 
     private Path keyringDir;
     private SecretKey masterKey;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -463,7 +463,7 @@ public class Collections {
             return true;
         }
 
-        Keyring keyring = zebedeeSupplier.get().getKeyringCache().get(session);
+        Keyring keyring = zebedeeSupplier.get().getLegacyKeyringCache().get(session);
         if (keyring == null) {
             throw new UnauthorizedException("No keyring is available for " + session.getEmail());
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
@@ -49,7 +49,7 @@ public class KeyManager {
      */
     public static synchronized void distributeCollectionKey(Zebedee zebedee, Session session, Collection collection,
                                                             boolean isNewCollection) throws IOException {
-        SecretKey key = zebedee.getKeyringCache()
+        SecretKey key = zebedee.getLegacyKeyringCache()
                 .get(session)
                 .get(collection.getDescription().getId());
 
@@ -75,7 +75,7 @@ public class KeyManager {
             assignKeyToUser(zebedee, recipient, collection.getDescription().getId(), key);
         }
 
-        zebedee.getKeyringCache()
+        zebedee.getLegacyKeyringCache()
                 .getSchedulerCache()
                 .put(collection.getDescription().getId(), key);
     }
@@ -123,7 +123,7 @@ public class KeyManager {
 
         // Put the Key in the schedule cache.
         collectionKeyTasks.add(() -> {
-            zebedee.getKeyringCache().getSchedulerCache().put(collection.getDescription().getId(), secretKey);
+            zebedee.getLegacyKeyringCache().getSchedulerCache().put(collection.getDescription().getId(), secretKey);
             return true;
         });
         return collectionKeyTasks;
@@ -162,7 +162,7 @@ public class KeyManager {
      * @throws IOException
      */
     public static void distributeKeyToUser(Zebedee zebedee, Collection collection, Session session, User user) throws IOException {
-        SecretKey key = zebedee.getKeyringCache().get(session).get(collection.getDescription().getId());
+        SecretKey key = zebedee.getLegacyKeyringCache().get(session).get(collection.getDescription().getId());
         distributeKeyToUser(zebedee, collection, key, user);
     }
 
@@ -194,7 +194,7 @@ public class KeyManager {
         // If the user is logged in assign the key to their cached keyring
         Session session = zebedee.getSessions().find(user.getEmail());
         if (session != null) {
-            Keyring keyring = zebedee.getKeyringCache().get(session);
+            Keyring keyring = zebedee.getLegacyKeyringCache().get(session);
             try {
                 if (keyring != null) {
                     keyring.put(keyIdentifier, key);
@@ -224,7 +224,7 @@ public class KeyManager {
         // If the user is logged in remove the key from their cached keyring
         Session session = zebedee.getSessions().find(user.getEmail());
         if (session != null) {
-            Keyring keyring = zebedee.getKeyringCache().get(session);
+            Keyring keyring = zebedee.getLegacyKeyringCache().get(session);
             try {
                 if (keyring != null) {
                     keyring.remove(keyIdentifier);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
@@ -13,13 +13,15 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Provides an basic in-memory cache for {@link Keyring} instances.
  */
+@Deprecated
 public class KeyringCache {
 
     // Publisher keyring keeps all available secret keys available
-    public Map<String, SecretKey> schedulerCache = new ConcurrentHashMap<>();
+    private Map<String, SecretKey> schedulerCache = new ConcurrentHashMap<>();
     private Map<Session, Keyring> keyringMap = new ConcurrentHashMap<>();
     private Sessions sessions;
 
+    @Deprecated
     public KeyringCache(Sessions sessions) {
         this.sessions = sessions;
     }
@@ -30,6 +32,7 @@ public class KeyringCache {
      * @param user The user whose {@link Keyring} is to be stored.
      * @throws IOException If a general error occurs.
      */
+    @Deprecated
     public void put(User user, Session session) throws IOException {
         if (user != null && user.keyring() != null && user.keyring().isUnlocked()) {
             if (session != null) {
@@ -52,6 +55,7 @@ public class KeyringCache {
      * @return The {@link Keyring} if present, or null.
      * @throws IOException If a general error occurs.
      */
+    @Deprecated
     public Keyring get(User user) throws IOException {
         Keyring result = null;
 
@@ -72,6 +76,7 @@ public class KeyringCache {
      * @return The {@link Keyring} if present, or null.
      * @throws IOException If a general error occurs.
      */
+    @Deprecated
     public Keyring get(Session session) throws IOException {
         Keyring result = null;
 
@@ -87,12 +92,14 @@ public class KeyringCache {
      * @param session The expired {@link Session} for which the {@link Keyring} is to be removed.
      * @throws IOException If a general error occurs.
      */
+    @Deprecated
     public void remove(Session session) throws IOException {
         if (session != null) {
             keyringMap.remove(session);
         }
     }
 
+    @Deprecated
     public Map<String, SecretKey> getSchedulerCache() {
         return this.schedulerCache;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -30,7 +30,7 @@ public class ZebedeeCollectionReader extends CollectionReader {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
-        Keyring keyring = zebedee.getKeyringCache().get(session);
+        Keyring keyring = zebedee.getLegacyKeyringCache().get(session);
         if (keyring == null) throw new UnauthorizedException("No keyring is available for " + session.getEmail());
 
         SecretKey key = keyring.get(collection.getDescription().getId());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
@@ -40,7 +40,7 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
-        Keyring keyring = zebedee.getKeyringCache().get(session);
+        Keyring keyring = zebedee.getLegacyKeyringCache().get(session);
         if (keyring == null) throw new UnauthorizedException("No keyring is available for " + session.getEmail());
 
         SecretKey key = keyring.get(collection.getDescription().getId());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
@@ -226,7 +226,7 @@ public class CsdbImporter {
      * @throws ZebedeeException
      */
     public void preProcessCollection(Collection collection) throws IOException, ZebedeeException, URISyntaxException {
-        SecretKey collectionKey = Root.zebedee.getKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
+        SecretKey collectionKey = Root.zebedee.getLegacyKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
         CollectionReader collectionReader = new ZebedeeCollectionReader(collection, collectionKey);
         CollectionWriter collectionWriter = new ZebedeeCollectionWriter(collection, collectionKey);
         ContentReader publishedReader = new FileSystemContentReader(Root.zebedee.getPublished().path);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/csdb/CsdbImporter.java
@@ -226,7 +226,7 @@ public class CsdbImporter {
      * @throws ZebedeeException
      */
     public void preProcessCollection(Collection collection) throws IOException, ZebedeeException, URISyntaxException {
-        SecretKey collectionKey = Root.zebedee.getKeyringCache().schedulerCache.get(collection.getDescription().getId());
+        SecretKey collectionKey = Root.zebedee.getKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
         CollectionReader collectionReader = new ZebedeeCollectionReader(collection, collectionKey);
         CollectionWriter collectionWriter = new ZebedeeCollectionWriter(collection, collectionKey);
         ContentReader publishedReader = new FileSystemContentReader(Root.zebedee.getPublished().path);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
@@ -17,9 +17,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 
 public class PublishTask implements Runnable {
 
@@ -62,7 +62,8 @@ public class PublishTask implements Runnable {
                 // Publish the s
                 boolean skipVerification = false;
 
-                ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, zebedee.getKeyringCache().schedulerCache.get(collectionId));
+                ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection,
+                        zebedee.getKeyringCache().getSchedulerCache().get(collectionId));
                 long publishStart = System.currentTimeMillis();
                 publishComplete = Publisher.publish(collection, "System", collectionReader);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/PublishTask.java
@@ -63,7 +63,7 @@ public class PublishTask implements Runnable {
                 boolean skipVerification = false;
 
                 ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection,
-                        zebedee.getKeyringCache().getSchedulerCache().get(collectionId));
+                        zebedee.getLegacyKeyringCache().getSchedulerCache().get(collectionId));
                 long publishStart = System.currentTimeMillis();
                 publishComplete = Publisher.publish(collection, "System", collectionReader);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -151,7 +151,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         // send versioned files manifest ahead of time. allowing files to be copied from the website into the transaction.
                         Publisher.sendManifest(collection);
 
-                        SecretKey key = zebedee.getKeyringCache().schedulerCache.get(collection.getDescription().getId());
+                        SecretKey key = zebedee.getKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
                         ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, key);
                         PublishCollectionTask publishCollectionTask = new PublishCollectionTask(collection, collectionReader, hostToTransactionIdMap);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -151,7 +151,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         // send versioned files manifest ahead of time. allowing files to be copied from the website into the transaction.
                         Publisher.sendManifest(collection);
 
-                        SecretKey key = zebedee.getKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
+                        SecretKey key = zebedee.getLegacyKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
                         ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, key);
                         PublishCollectionTask publishCollectionTask = new PublishCollectionTask(collection, collectionReader, hostToTransactionIdMap);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -241,7 +241,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
 
         // Then null is returned
         assertThat(actual, is(nullValue()));
-        verifyZeroInteractions(sessions, usersService, applicationKeys, legacyKeyringCache);
+        verifyZeroInteractions(sessions, usersService, applicationKeys, legacyKeyringCache, collectionKeyring);
     }
 
     @Test
@@ -263,7 +263,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo("boom"));
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
-        verifyZeroInteractions(sessions, usersService, applicationKeys, legacyKeyringCache);
+        verifyZeroInteractions(sessions, usersService, applicationKeys, legacyKeyringCache, collectionKeyring);
     }
 
     @Test
@@ -286,7 +286,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         assertThat(actual, is(nullValue()));
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
 
-        verifyZeroInteractions(sessions, applicationKeys, legacyKeyringCache);
+        verifyZeroInteractions(sessions, applicationKeys, legacyKeyringCache, collectionKeyring);
     }
 
     @Test
@@ -314,7 +314,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(sessions, times(1)).create(user);
         verify(user, never()).keyring();
 
-        verifyZeroInteractions(applicationKeys, legacyKeyringCache);
+        verifyZeroInteractions(applicationKeys, legacyKeyringCache, collectionKeyring);
     }
 
     @Test
@@ -349,7 +349,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(user, times(1)).keyring();
         verify(legacyKeyring, times(1)).unlock(any());
 
-        verifyZeroInteractions(applicationKeys, legacyKeyringCache);
+        verifyZeroInteractions(applicationKeys, legacyKeyringCache, collectionKeyring);
     }
 
     @Test
@@ -387,6 +387,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(legacyKeyring, times(1)).unlock(any());
         verify(applicationKeys, times(1)).populateCacheFromUserKeyring(legacyKeyring);
         verify(legacyKeyringCache, times(1)).put(user, userSession);
+        verify(collectionKeyring, never()).populateFromUser(any());
     }
 
     @Test
@@ -421,6 +422,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(legacyKeyring, times(1)).unlock(any());
         verify(applicationKeys, times(1)).populateCacheFromUserKeyring(legacyKeyring);
         verify(legacyKeyringCache, times(1)).put(user, userSession);
+        verify(collectionKeyring, times(1)).populateFromUser(user);
     }
 
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee;
 
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.json.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
@@ -64,6 +65,9 @@ public abstract class ZebedeeTestBaseFixture {
     protected KeyringCache legacyKeyringCache;
 
     @Mock
+    protected CollectionKeyring collectionKeyring;
+
+    @Mock
     protected Credentials credentials;
 
     @Mock
@@ -95,7 +99,7 @@ public abstract class ZebedeeTestBaseFixture {
         ReflectionTestUtils.setField(zebedee, "usersService", usersService);
         ReflectionTestUtils.setField(zebedee.getPermissionsService(), "usersServiceSupplier", usersServiceServiceSupplier);
         ReflectionTestUtils.setField(zebedee, "sessions", sessionsService);
-        ReflectionTestUtils.setField(zebedee, "keyringCache", new KeyringCache(sessionsService));
+        ReflectionTestUtils.setField(zebedee, "legacyKeyringCache", new KeyringCache(sessionsService));
 
         ServiceSupplier<CollectionHistoryDao> collectionHistoryDaoServiceSupplier = () -> collectionHistoryDao;
 
@@ -158,6 +162,9 @@ public abstract class ZebedeeTestBaseFixture {
 
         when(zebCfg.getKeyringCache())
                 .thenReturn(legacyKeyringCache);
+
+        when(zebCfg.getCollectionKeyring())
+                .thenReturn(collectionKeyring);
     }
 
     public abstract void setUp() throws Exception;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -206,6 +207,20 @@ public class CollectionKeyringImplTest {
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo("keyringCache required but was null"));
+    }
+
+    @Test
+    public void test_InitNop() throws Exception {
+        resetInstanceToNull();
+
+        // Given init NOP is invoked.
+        CollectionKeyringImpl.initNoOp();
+
+        // When getInstance is called
+        CollectionKeyring collectionKeyring = CollectionKeyringImpl.getInstance();
+
+        // That a Nop instance is returned
+        assertTrue(collectionKeyring instanceof NopCollectionKeyring);
     }
 
     private void resetInstanceToNull() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImplTest.java
@@ -17,7 +17,11 @@ import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.KEYST
 import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.KEY_MISMATCH_ERR;
 import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.KEY_NOT_FOUND_ERR;
 import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.LOAD_KEYS_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.NOT_INITIALISED_ERR;
+import static com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl.getInstance;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -433,10 +437,34 @@ public class KeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(keys);
 
-        KeyringCache keyringCache = KeyringCacheImpl.init(keyStore);
+        KeyringCacheImpl.init(keyStore);
+        KeyringCache keyringCache = getInstance();
 
         assertThat(keyringCache.get(TEST_COLLECTION_ID), equalTo(secretKey));
         verify(keyStore, times(1)).readAll();
+    }
+
+    @Test
+    public void testGetInstance_notInitialised() {
+        // Given the KeyringCache has not been initalised
+
+        // When getInstance is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> KeyringCacheImpl.getInstance());
+
+        // Then an exception is thrown
+        assertThat(ex.getMessage(), equalTo(NOT_INITIALISED_ERR));
+    }
+
+    @Test
+    public void testGetInstance_success() throws Exception {
+        // Given the KeyringCache has been initalised
+        KeyringCacheImpl.init(keyStore);
+
+        // When getInstance is called
+        KeyringCache actual = KeyringCacheImpl.getInstance();
+
+        // Then the singleton instance is returned
+        assertThat(actual, is(notNullValue()));
     }
 
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/store/KeyringStoreImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/store/KeyringStoreImplTest.java
@@ -108,7 +108,7 @@ public class KeyringStoreImplTest {
 
         // write the key to the store.
         store.write(TEST_COLLECTION_ID, collectionKey);
-        assertTrue(Files.exists(keyringDir.toPath().resolve(TEST_COLLECTION_ID + ".key")));
+        assertTrue(Files.exists(keyringDir.toPath().resolve(TEST_COLLECTION_ID + KEY_EXT)));
 
         // retrieve the key from the store.
         SecretKey keyReturned = store.read(TEST_COLLECTION_ID);
@@ -179,7 +179,7 @@ public class KeyringStoreImplTest {
         store.write(TEST_COLLECTION_ID, collectionKey);
 
         // check the file exists
-        File f = keyringDir.toPath().resolve(TEST_COLLECTION_ID + ".key").toFile();
+        File f = keyringDir.toPath().resolve(TEST_COLLECTION_ID + KEY_EXT).toFile();
         assertTrue(Files.exists(f.toPath()));
 
         // Attempt to decrypt the file - if successful we can assume the encryption was also successful.
@@ -229,7 +229,7 @@ public class KeyringStoreImplTest {
     public void testExists_keyFileExist_shouldReturnTrue() throws Exception {
         store = new KeyringStoreImpl(keyringDir.toPath(), null, null);
 
-        Path p = Files.createFile(keyringDir.toPath().resolve(TEST_COLLECTION_ID + ".key"));
+        Path p = Files.createFile(keyringDir.toPath().resolve(TEST_COLLECTION_ID + KEY_EXT));
         assertTrue(Files.exists(p));
 
         assertTrue(store.exists(TEST_COLLECTION_ID));
@@ -331,7 +331,7 @@ public class KeyringStoreImplTest {
         store = new KeyringStoreImpl(keyringDir.toPath(), null, null);
 
         createPlainTextCollectionKeyFile(TEST_COLLECTION_ID);
-        Path p = keyringDir.toPath().resolve(TEST_COLLECTION_ID + ".key");
+        Path p = keyringDir.toPath().resolve(TEST_COLLECTION_ID + KEY_EXT);
         assertTrue(Files.exists(p));
 
         store.delete(TEST_COLLECTION_ID);
@@ -355,7 +355,7 @@ public class KeyringStoreImplTest {
     }
 
     void createPlainTextCollectionKeyFile(String collectionID) throws Exception {
-        Path p = keyringDir.toPath().resolve(collectionID + ".key");
+        Path p = keyringDir.toPath().resolve(collectionID + KEY_EXT);
         FileUtils.writeByteArrayToFile(p.toFile(), "This is not a valid secret key".getBytes());
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyManagerTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyManagerTest.java
@@ -97,7 +97,7 @@ public class KeyManagerTest {
                 .thenReturn(usersService);
         when(zebedee.getSessions())
                 .thenReturn(sessions);
-        when(zebedee.getKeyringCache())
+        when(zebedee.getLegacyKeyringCache())
                 .thenReturn(keyringCache);
         when(zebedee.getPermissionsService())
                 .thenReturn(permissionsServiceImpl);
@@ -140,7 +140,7 @@ public class KeyManagerTest {
         verify(zebedee, times(1)).getUsersService();
         verify(usersService, times(1)).addKeyToKeyring(EMAIL, COLLECTION_ID, secretKey);
         verify(zebedee, times(1)).getSessions();
-        verify(zebedee, times(1)).getKeyringCache();
+        verify(zebedee, times(1)).getLegacyKeyringCache();
         verify(keyringCache, times(1)).get(session);
         verify(keyring, times(1)).put(COLLECTION_ID, secretKey);
     }
@@ -206,7 +206,7 @@ public class KeyManagerTest {
         verify(zebedee, times(2)).getUsersService();
         verify(zebedee, times(2)).getPermissionsService();
         verify(zebedee, times(1)).getSessions();
-        verify(zebedee, times(1)).getKeyringCache();
+        verify(zebedee, times(1)).getLegacyKeyringCache();
         verify(permissionsServiceImpl, times(1)).isAdministrator(EMAIL);
         verify(permissionsServiceImpl, times(1)).canEdit(EMAIL);
         verify(keyringCache, times(1)).get(session);
@@ -242,7 +242,7 @@ public class KeyManagerTest {
         verify(zebedee, times(2)).getUsersService();
         verify(zebedee, times(1)).getPermissionsService();
         verify(zebedee, times(1)).getSessions();
-        verify(zebedee, times(1)).getKeyringCache();
+        verify(zebedee, times(1)).getLegacyKeyringCache();
         verify(permissionsServiceImpl, times(1)).isAdministrator(EMAIL);
         verify(permissionsServiceImpl, never()).canEdit(EMAIL);
         verify(keyringCache, times(1)).get(session);
@@ -311,7 +311,7 @@ public class KeyManagerTest {
 
         KeyManager.distributeKeyToUser(zebedee, collection, session, user);
 
-        verify(zebedee, times(2)).getKeyringCache();
+        verify(zebedee, times(2)).getLegacyKeyringCache();
         verify(keyringCache, times(2)).get(session);
         verify(keyring, times(1)).get(COLLECTION_ID);
         verify(zebedee, times(2)).getPermissionsService();
@@ -339,7 +339,7 @@ public class KeyManagerTest {
 
         KeyManager.distributeKeyToUser(zebedee, collection, session, user);
 
-        verify(zebedee, times(2)).getKeyringCache();
+        verify(zebedee, times(2)).getLegacyKeyringCache();
         verify(keyringCache, times(2)).get(session);
         verify(keyring, times(1)).get(COLLECTION_ID);
         verify(user, times(1)).keyring();
@@ -387,7 +387,7 @@ public class KeyManagerTest {
         UserList users = new UserList();
         users.add(user);
 
-        when(zebedee.getKeyringCache())
+        when(zebedee.getLegacyKeyringCache())
                 .thenReturn(keyringCache);
         when(keyringCache.get(session))
                 .thenReturn(keyring);
@@ -407,7 +407,7 @@ public class KeyManagerTest {
         KeyManager.distributeCollectionKey(zebedee, session, collection, true);
 
         verify(usersService, never()).addKeyToKeyring(any(), any(), any());
-        verify(zebedee, times(2)).getKeyringCache();
+        verify(zebedee, times(2)).getLegacyKeyringCache();
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
         verify(usersService, never()).removeKeyFromKeyring(EMAIL, COLLECTION_ID);
@@ -426,7 +426,7 @@ public class KeyManagerTest {
         List<User> permittedUsers = new ArrayList<>();
         permittedUsers.add(user2);
 
-        when(zebedee.getKeyringCache())
+        when(zebedee.getLegacyKeyringCache())
                 .thenReturn(keyringCache);
         when(keyringCache.get(session))
                 .thenReturn(keyring);
@@ -449,7 +449,7 @@ public class KeyManagerTest {
 
         KeyManager.distributeCollectionKey(zebedee, session, collection, false);
 
-        verify(zebedee, times(4)).getKeyringCache();
+        verify(zebedee, times(4)).getLegacyKeyringCache();
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
         verify(sessions, times(1)).find(EMAIL);
@@ -466,7 +466,7 @@ public class KeyManagerTest {
         UserList users = new UserList();
         users.add(user);
 
-        when(zebedee.getKeyringCache())
+        when(zebedee.getLegacyKeyringCache())
                 .thenReturn(keyringCache);
         when(keyringCache.get(session))
                 .thenReturn(keyring);
@@ -487,7 +487,7 @@ public class KeyManagerTest {
 
         verify(usersService, times(1)).addKeyToKeyring(EMAIL, COLLECTION_ID, secretKey);
         verify(usersService, never()).removeKeyFromKeyring(any(), any());
-        verify(zebedee, times(3)).getKeyringCache();
+        verify(zebedee, times(3)).getLegacyKeyringCache();
         verify(zebedee, times(1)).getPermissionsService();
         verify(permissionsServiceImpl, times(1)).getCollectionAccessMapping(collection);
         verify(usersService, never()).removeKeyFromKeyring(EMAIL, COLLECTION_ID);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyringCacheCacheTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/KeyringCacheCacheTest.java
@@ -24,7 +24,7 @@ public class KeyringCacheCacheTest extends ZebedeeTestBaseFixture {
 
     @Override
     public void setUp() throws Exception {
-        keyringCache = zebedee.getKeyringCache();
+        keyringCache = zebedee.getLegacyKeyringCache();
 
         user = user();
 
@@ -44,7 +44,7 @@ public class KeyringCacheCacheTest extends ZebedeeTestBaseFixture {
         // When
         // We put the user's keyring
         keyringCache.put(user, session);
-        Keyring keyring = zebedee.getKeyringCache().get(user);
+        Keyring keyring = zebedee.getLegacyKeyringCache().get(user);
 
         // Then
         // We should be able to get the user's keyring
@@ -102,11 +102,11 @@ public class KeyringCacheCacheTest extends ZebedeeTestBaseFixture {
 
         // When
         // We remove the user's keyring
-        zebedee.getKeyringCache().remove(session);
+        zebedee.getLegacyKeyringCache().remove(session);
 
         // Then
         // The user's keyring should not be present in the cache
-        assertNull(zebedee.getKeyringCache().get(user));
+        assertNull(zebedee.getLegacyKeyringCache().get(user));
     }
 
     @Test


### PR DESCRIPTION
### What

- Renamed old `keyringCache` to `legacyKeyringCache` to avoid confusion.
- Added `@Deprecated` flag to legacy keyring and methods.
- Populate new cache from user keyring on start up.
- Added tests to cover above.
- Renamed key file ext to `.cek`  (**C**ollection **E**ncryption **K**ey)
- Added new `NopCollectionKeyring` impl to smooth transition with feature flag.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
