### PR TITLE
Remove deprecated methods from the Sessions interface

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/cmd/CMDPermissionsServiceImpl.java
@@ -140,6 +140,7 @@ public class CMDPermissionsServiceImpl implements CMDPermissionsService {
             throw sessionNotFoundException();
         }
 
+        // todo - remove this deprecated call once the migration to the sessions API is complete.
         if (sessions.expired(session)) {
             info().log("user dataset permissions request denied session expired");
             throw sessionExpiredException();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/Sessions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/Sessions.java
@@ -5,7 +5,6 @@ import com.github.onsdigital.zebedee.user.model.User;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.Date;
 
 public interface Sessions {
 
@@ -46,16 +45,6 @@ public interface Sessions {
     Session find(String email) throws IOException;
 
     /**
-     * Check if an active {@link Session} exists with the provided ID.
-     *
-     * @param id the session ID to find.
-     * @return true if an active session exists with this ID, false otherwise.
-     * @throws IOException problem checking the session exists.
-     */
-    @Deprecated
-    boolean exists(String id) throws IOException;
-
-    /**
      * Check if the provided {@link Session} is expired.
      *
      * @param session the {@link Session} to check.
@@ -63,13 +52,4 @@ public interface Sessions {
      */
     @Deprecated
     boolean expired(Session session);
-
-    /**
-     * Get the expiry date of the provided {@link Session}
-     *
-     * @param session the  {@link Session} to use.
-     * @return the sessions expiration date time as a {@link Date} instance.
-     */
-    @Deprecated
-    Date getExpiryDate(Session session);
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsAPIServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsAPIServiceImpl.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.Date;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -119,19 +118,6 @@ public class SessionsAPIServiceImpl implements Sessions {
     }
 
     /**
-     * @param id the session ID to find.
-     * @return true if an active session exists with this ID, false otherwise.
-     * @throws IOException problem checking the session exists.
-     * @deprecated This is a deprecated method and not supported by this implementation
-     * <p>
-     * Check if an active {@link Session} exists with the provided ID.
-     */
-    @Override
-    public boolean exists(String id) throws IOException {
-        throw new UnsupportedOperationException("exists is a deprecated method and not supported by this sessions implementation.");
-    }
-
-    /**
      * @param session the {@link Session} to check.
      * @return true if expired, false otherwise.
      * @deprecated This is a deprecated method and not supported by this implementation
@@ -140,19 +126,7 @@ public class SessionsAPIServiceImpl implements Sessions {
      */
     @Override
     public boolean expired(Session session) {
-        throw new UnsupportedOperationException("expired is a deprecated method and not supported by this sessions implementation.");
-    }
-
-    /**
-     * @param session the  {@link Session} to use.
-     * @return the sessions expiration date time as a {@link Date} instance.
-     * @deprecated This is a deprecated method and not supported by this implementation
-     * <p>
-     * Get the expiry date of the provided {@link Session}
-     */
-    @Override
-    public Date getExpiryDate(Session session) {
-        throw new UnsupportedOperationException("getExpiryDate is a deprecated method and not supported by this sessions implementation.");
+        return session == null;
     }
 
     private Session createZebedeeSession(com.github.onsdigital.session.service.Session sess) throws IOException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/session/service/SessionsServiceImpl.java
@@ -147,23 +147,11 @@ public class SessionsServiceImpl extends TimerTask implements Sessions {
     }
 
     /**
-     * Determines whether a session exists for the given ID.
-     *
-     * @param id The ID to check.
-     * @return If the ID is not blank and a corresponding session exists, true.
-     * @throws IOException If a filesystem error occurs.
-     */
-    public boolean exists(String id) throws IOException {
-        return sessionsStore.exists(id);
-    }
-
-
-    /**
      * Iterates all sessions and deletes expired ones.
      *
      * @throws IOException If a filesystem error occurs.
      */
-    public void deleteExpiredSessions() throws IOException {
+    void deleteExpiredSessions() throws IOException {
         Predicate<Session> isExpired = (session) -> expired(session);
         List<Session> expired = sessionsStore.filterSessions(isExpired);
 
@@ -235,7 +223,7 @@ public class SessionsServiceImpl extends TimerTask implements Sessions {
         return sessionsStore.read(sessionPath(id));
     }
 
-    public Date getExpiryDate(Session session) {
+    Date getExpiryDate(Session session) {
         Date expiry = null;
 
         if (session != null) {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsAPIServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsAPIServiceImplTest.java
@@ -17,7 +17,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -465,34 +467,13 @@ public class SessionsAPIServiceImplTest {
     }
 
     @Test
-    public void testExists_shouldThrowUnsupportedOperationException() {
-        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class, () -> sessions.exists(null));
-        assertThat(ex.getMessage(), equalTo("exists is a deprecated method and not supported by this sessions implementation."));
-
-        ex = assertThrows(UnsupportedOperationException.class, () -> sessions.exists(""));
-        assertThat(ex.getMessage(), equalTo("exists is a deprecated method and not supported by this sessions implementation."));
-
-        ex = assertThrows(UnsupportedOperationException.class, () -> sessions.exists(TEST_ID));
-        assertThat(ex.getMessage(), equalTo("exists is a deprecated method and not supported by this sessions implementation."));
+    public void testExpired_shouldReturnTrueForNullSession() {
+        assertTrue(sessions.expired(null));
     }
 
     @Test
-    public void testExpired_shouldThrowUnsupportedOperationException() {
-        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class, () -> sessions.expired(null));
-        assertThat(ex.getMessage(), equalTo("expired is a deprecated method and not supported by this sessions implementation."));
-
-        ex = assertThrows(UnsupportedOperationException.class, () -> sessions.expired(new Session()));
-        assertThat(ex.getMessage(), equalTo("expired is a deprecated method and not supported by this sessions implementation."));
+    public void testExpired_shouldReturnFalseWithSession() {
+        assertFalse(sessions.expired(new Session()));
     }
-
-    @Test
-    public void testGetExpiryDate_shouldThrowUnsupportedOperationException() {
-        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class, () -> sessions.getExpiryDate(null));
-        assertThat(ex.getMessage(), equalTo("getExpiryDate is a deprecated method and not supported by this sessions implementation."));
-
-        ex = assertThrows(UnsupportedOperationException.class, () -> sessions.getExpiryDate(new Session()));
-        assertThat(ex.getMessage(), equalTo("getExpiryDate is a deprecated method and not supported by this sessions implementation."));
-    }
-
 
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsServiceServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/session/service/SessionsServiceServiceImplTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.when;
  */
 public class SessionsServiceServiceImplTest {
 
-    private static ObjectMapper OBJ_MAPPER = new ObjectMapper();
     private static final String EMAIL = "TEST@ons.gov.uk";
     private static final String PWD = "1 2 3 4";
     private static final String SESSION_ID = "1234567890";
@@ -53,9 +52,6 @@ public class SessionsServiceServiceImplTest {
 
     @Rule
     public TemporaryFolder rootDir = new TemporaryFolder();
-
-    @Mock
-    private UsersService usersService;
 
     @Mock
     private Supplier<String> randomIdGenerator;


### PR DESCRIPTION
### What
Remove deprecated methods from the Sessions interface

- Add implementation for SessionsAPIServiceImpl.expired() function, to prevent exception being thrown
- The methods are only used internally by the SessionsServiceImpl, so they have been removed from the public interface. They have been made private / package private in the SessionsServiceImpl.
- Remove SessionsServiceImpl.exists() function as it is only used in unit tests.
- remove unused usersService in SessionsServiceServiceImplTest.java
- remove redundant unit tests / mocking / assertions

### How to review
Review changes / check tests

### Who can review
Anyone
