### PR TITLE
Skip publishing of created/deleted images

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
@@ -41,20 +41,7 @@ public class ImageServiceImpl implements ImageService {
                 .log("publishing images in collection");
 
         for (Image image : images.getItems()) {
-            switch (image.getState()) {
-                case STATE_CREATED:
-                case STATE_DELETED:
-                    info().data("publishing", true).data("collectionId", collection.getId())
-                            .data("imageId", image.getId())
-                            .data("imageState",image.getState())
-                            .log("skipping publish of image");
-                    break;
-                default:
-                    info().data("publishing", true).data("collectionId", collection.getId())
-                            .data("imageId", image.getId())
-                            .log("publishing image");
-                    imageClient.publishImage(image.getId());
-            }
+            publishImage(image, collection.getId());
         }
 
         // Image API does not implement paging. Capture scenario if it is implemented unexpectedly.
@@ -63,4 +50,23 @@ public class ImageServiceImpl implements ImageService {
         }
     }
 
+    /**
+     * Publish an image unless its state is 'created' or 'cancelled'
+     */
+    private void publishImage(Image image, String collectionId) throws IOException, ImageAPIException {
+        switch (image.getState()) {
+            case STATE_CREATED:
+            case STATE_DELETED:
+                info().data("publishing", true).data("collectionId", collectionId)
+                        .data("imageId", image.getId())
+                        .data("imageState", image.getState())
+                        .log("skipping publish of image");
+                break;
+            default:
+                info().data("publishing", true).data("collectionId", collectionId)
+                        .data("imageId", image.getId())
+                        .log("publishing image");
+                imageClient.publishImage(image.getId());
+        }
+    }
 }


### PR DESCRIPTION
### What

When publishing images in a collection, skip over any that have been deleted or that have been created but not uploaded. The latter will be common because image records are created as soon as the user opens the homepage section in florence and if they cancel without uploading the record will be forgotten. We should not try to publish these images it will cause an exception that will fail the publish of that collection. 

Also improve logging of image publishing.

### How to review

Check the code and ensure a test is in place to cover this scenario.

### Who can review

Anyone but me