### PR TITLE
Slack alert then ignore unpublished images

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/Publisher.java
@@ -137,7 +137,7 @@ public class Publisher {
                 }
                 ImageServicePublishingResult result = imageFuture.get();
 
-                if (result.getUnpublishedImages() != null && result.getUnpublishedImages().size() > 0) {
+                if (result != null && result.getUnpublishedImages() != null && result.getUnpublishedImages().size() > 0) {
                     notifyUnpublishedImages(collection, result);
                 }
             } catch (Exception e) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageService.java
@@ -13,6 +13,6 @@ public interface ImageService {
     /**
      * Publish the images contained in the given collection.
      */
-    void publishImagesInCollection(Collection collection) throws IOException, ImageAPIException;
+    ImageServicePublishingResult publishImagesInCollection(Collection collection) throws IOException, ImageAPIException;
 
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
@@ -17,6 +17,7 @@ public class ImageServiceImpl implements ImageService {
 
     public static final String STATE_CREATED = "created";
     public static final String STATE_DELETED = "deleted";
+    public static final String STATE_UPLOADED = "uploaded";
     public static final String STATE_IMPORTING = "importing";
     public static final String STATE_FAILED_IMPORT = "failed_import";
     private ImageClient imageClient;
@@ -74,6 +75,7 @@ public class ImageServiceImpl implements ImageService {
                         .log("silently skipping publish of image");
                 status = PublishStatus.SKIPPED;
                 break;
+            case STATE_UPLOADED:
             case STATE_IMPORTING:
             case STATE_FAILED_IMPORT:
                 info().data("publishing", true).data("collectionId", collectionId)

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
@@ -9,6 +9,7 @@ import com.github.onsdigital.zebedee.model.Collection;
 import java.io.IOException;
 
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 
 /**
  * Image related services
@@ -69,25 +70,27 @@ public class ImageServiceImpl implements ImageService {
         switch (image.getState()) {
             case STATE_CREATED:
             case STATE_DELETED:
-                info().data("publishing", true).data("collectionId", collectionId)
+                info().data("publishing", true).collectionID(collectionId)
                         .data("imageId", image.getId())
                         .data("imageState", image.getState())
-                        .log("silently skipping publish of image");
+                        .log("skipping publish of abandoned image");
                 status = PublishStatus.SKIPPED;
                 break;
             case STATE_UPLOADED:
             case STATE_IMPORTING:
             case STATE_FAILED_IMPORT:
-                info().data("publishing", true).data("collectionId", collectionId)
+                warn().data("publishing", true).collectionID(collectionId)
                         .data("imageId", image.getId())
                         .data("imageState", image.getState())
-                        .log("skipping publish of image with warning");
+                        .log("skipping publish of un-imported image with warning");
                 status = PublishStatus.UNPUBLISHED;
                 break;
             default:
-                info().data("publishing", true).data("collectionId", collectionId)
+                info().data("publishing", true).collectionID(collectionId)
                         .data("imageId", image.getId())
                         .log("publishing image");
+
+                //Publish the image
                 imageClient.publishImage(image.getId());
                 status = PublishStatus.PUBLISHED;
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServiceImpl.java
@@ -59,7 +59,9 @@ public class ImageServiceImpl implements ImageService {
     }
 
     /**
-     * Publish an image unless its state is 'created' or 'cancelled'
+     * Publish an image unless…
+     *  - its state is 'created' or 'cancelled'; then skip silently
+     *  - its state is 'importing' or 'failed_import'; then skip and notify
      */
     private PublishStatus publishImage(Image image, String collectionId) throws IOException, ImageAPIException {
         PublishStatus status;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
@@ -1,0 +1,44 @@
+package com.github.onsdigital.zebedee.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImageServicePublishingResult {
+    private int totalImages;
+    private List<ImageDetails> unpublishedImages = new ArrayList<>();
+
+    public ImageServicePublishingResult(int totalImages) {
+        this.totalImages = totalImages;
+    }
+
+    public int getTotalImages() {
+        return totalImages;
+    }
+
+    public List<ImageDetails> getUnpublishedImages() {
+        return unpublishedImages;
+    }
+
+    public void addUnpublishedImage(String id, String status) {
+        unpublishedImages.add(new ImageDetails(id, status));
+    }
+
+    public static class ImageDetails {
+        private String id;
+        private String status;
+
+        public ImageDetails(String id, String status) {
+            this.id = id;
+            this.status = status;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
@@ -3,10 +3,18 @@ package com.github.onsdigital.zebedee.service;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Class to contain details of the result of publishing images
+ */
 public class ImageServicePublishingResult {
     private int totalImages;
     private List<ImageDetails> unpublishedImages = new ArrayList<>();
 
+    /**
+     * Construct a new instance for the given number of images
+     *
+     * @param totalImages Total number of images in the collection
+     */
     public ImageServicePublishingResult(int totalImages) {
         this.totalImages = totalImages;
     }
@@ -19,14 +27,29 @@ public class ImageServicePublishingResult {
         return unpublishedImages;
     }
 
+    /**
+     * Add details of an unpublished image to the results
+     *
+     * @param id     ID of the unpublished image
+     * @param status Status of the unpublished image
+     */
     public void addUnpublishedImage(String id, String status) {
         unpublishedImages.add(new ImageDetails(id, status));
     }
 
+    /**
+     * Details of a specific image
+     */
     public static class ImageDetails {
         private String id;
         private String status;
 
+        /**
+         * Constuct an instancce of ImageDetails with a given ID and Status
+         *
+         * @param id     ID of the image
+         * @param status Status of the  image
+         */
         public ImageDetails(String id, String status) {
             this.id = id;
             this.status = status;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ImageServicePublishingResult.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 public class ImageServicePublishingResult {
     private int totalImages;
-    private List<ImageDetails> unpublishedImages = new ArrayList<>();
+    private List<ImageDetails> unpublishedImages;
 
     /**
      * Construct a new instance for the given number of images
@@ -17,6 +17,7 @@ public class ImageServicePublishingResult {
      */
     public ImageServicePublishingResult(int totalImages) {
         this.totalImages = totalImages;
+        this.unpublishedImages= new ArrayList<>();
     }
 
     public int getTotalImages() {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ImageServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ImageServiceImplTest.java
@@ -24,7 +24,9 @@ public class ImageServiceImplTest {
     private static final String IMAGE1 = "i1";
     private static final String IMAGE2 = "i2";
     private static final String IMAGE3 = "i3";
+    private static final String IMAGE4 = "i4";
     private static final String STATE_CREATED = "created";
+    private static final String STATE_UPLOADED = "uploaded";
     private static final String STATE_IMPORTING = "importing";
     private static final String STATE_FAILED_IMPORT = "failed_import";
     private static final String STATE_IMPORTED = "imported";
@@ -83,27 +85,30 @@ public class ImageServiceImplTest {
     public void testPublishImagesInCollection_withImportingORFailedImportUnpublished() throws Exception {
         // Given an api that returns importing,failed_import and imported images
         when(mockImageAPI.getImages(COLLECTION_ID)).thenReturn(createTestImages(Arrays.asList(
-                createTestImage(IMAGE1,STATE_IMPORTING),
-                createTestImage(IMAGE2,STATE_FAILED_IMPORT),
-                createTestImage(IMAGE3,STATE_IMPORTED)
+                createTestImage(IMAGE1,STATE_UPLOADED),
+                createTestImage(IMAGE2,STATE_IMPORTING),
+                createTestImage(IMAGE3,STATE_FAILED_IMPORT),
+                createTestImage(IMAGE4,STATE_IMPORTED)
                 )));
         ImageService imageService = new ImageServiceImpl(mockImageAPI);
 
         // When publish is called on the collection
         ImageServicePublishingResult result = imageService.publishImagesInCollection(mockCollection);
         assertNotNull(result);
-        assertEquals(3,result.getTotalImages());
+        assertEquals(4,result.getTotalImages());
         assertNotNull(result.getUnpublishedImages());
-        assertEquals(2,result.getUnpublishedImages().size());
+        assertEquals(3,result.getUnpublishedImages().size());
         assertNotNull(result.getUnpublishedImages().get(0));
         assertEquals(IMAGE1, result.getUnpublishedImages().get(0).getId());
         assertNotNull(result.getUnpublishedImages().get(1));
         assertEquals(IMAGE2, result.getUnpublishedImages().get(1).getId());
+        assertNotNull(result.getUnpublishedImages().get(2));
+        assertEquals(IMAGE3, result.getUnpublishedImages().get(2).getId());
 
         // Then publishImage should not be called on the API for the created or deleted images.
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(mockImageAPI, times(1)).publishImage(captor.capture());
-        assertEquals(IMAGE3, captor.getAllValues().get(0));
+        assertEquals(IMAGE4, captor.getAllValues().get(0));
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ImageServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ImageServiceImplTest.java
@@ -24,11 +24,11 @@ public class ImageServiceImplTest {
     private static final String IMAGE1 = "i1";
     private static final String IMAGE2 = "i2";
     private static final String IMAGE3 = "i3";
-    public static final String STATE_CREATED = "created";
-    public static final String STATE_IMPORTING = "importing";
-    public static final String STATE_FAILED_IMPORT = "failed_import";
-    public static final String STATE_IMPORTED = "imported";
-    public static final String STATE_DELETED = "deleted";
+    private static final String STATE_CREATED = "created";
+    private static final String STATE_IMPORTING = "importing";
+    private static final String STATE_FAILED_IMPORT = "failed_import";
+    private static final String STATE_IMPORTED = "imported";
+    private static final String STATE_DELETED = "deleted";
 
     ImageAPIException apiException = new ImageAPIException("error", 123);
 


### PR DESCRIPTION
### What

When publishing a collection containing uploaded images…
- Skip publishing for any images in an `importing` or `failed-import` state
- Send a slack alert so the development team can look into why they failed

### How to review

Check the code and ensure there are appropriate tests (where possible, it is zebedee after all)
Ensure all tests pass

NB. If you want to try running it, you'll need to setup your local zebedee to send slack messages. For example, I have my own dev slack organisation and I added the following to my run-cms.sh
```
export slack_alarm_channel="#zeb-alarm"
export slack_default_channel="#zeb-system"
export slack_publish_channel="#zeb-publog"
export slack_api_token="<my slack api token>"
```

You'll then have to have a collection to publish that has at least one image in one of the states above.

### Who can review

Anyone but me