### PR TITLE
Refactored legacyKeyring impl brought the keyringCache behind the new…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
@@ -14,7 +14,7 @@ public interface Keyring {
      * @param user the user that populates the keyring.
      * @throws KeyringException problem populating the keyring.
      */
-    void populateFromUser(User user) throws KeyringException;
+    void cacheUserKeyring(User user) throws KeyringException;
 
     /**
      * Get a key from the keyring for the specified collection.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringImpl.java
@@ -58,7 +58,7 @@ public class KeyringImpl implements Keyring {
     }
 
     @Override
-    public void populateFromUser(User user) throws KeyringException {
+    public void cacheUserKeyring(User user) throws KeyringException {
         validateUser(user);
 
         if (user.keyring() == null) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
@@ -54,10 +54,10 @@ public class KeyringMigratorImpl implements Keyring {
     }
 
     @Override
-    public void populateFromUser(User user) throws KeyringException {
+    public void cacheUserKeyring(User user) throws KeyringException {
         try {
-            legacyKeyring.populateFromUser(user);
-            centralKeyring.populateFromUser(user);
+            legacyKeyring.cacheUserKeyring(user);
+            centralKeyring.cacheUserKeyring(user);
         } catch (KeyringException ex) {
             throw wrappedKeyringException(ex, POPULATE_FROM_USER_ERR);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -34,8 +34,9 @@ public class LegacyKeyringImpl implements Keyring {
     static final String COLLECTION_ID_EMPTY_ERR = "collection ID required but was null/empty";
     static final String SECRET_KEY_NULL_ERR = "secret key required but was null";
     static final String CACHE_GET_ERR = "error getting entry from keyringCache";
-    static final String SAVE_USER_ERR = "error persiting user update";
-    static final String GET_USER_ERR = "error getting user";
+    static final String ADD_KEY_SAVE_ERR = "user service add key to user returned an error";
+    static final String REMOVE_KEY_SAVE_ERR = "user service remove key from user returned an error";
+    static final String GET_USER_ERR = "user service get user by email return an error";
 
     private Sessions sessions;
     private UsersService users;
@@ -193,7 +194,7 @@ public class LegacyKeyringImpl implements Keyring {
     }
 
     /**
-     * List the key held in the user's {@link com.github.onsdigital.zebedee.json.Keyring}.
+     * List the keys held in the user's {@link com.github.onsdigital.zebedee.json.Keyring}.
      * <ul>
      *     <li>Lists from a cached user keyring if it exists in the {@link KeyringCache}.</li>
      *     <li>Otherwise lists from the stored user keyring.</li>
@@ -272,7 +273,7 @@ public class LegacyKeyringImpl implements Keyring {
         try {
             users.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
         } catch (IOException ex) {
-            throw new KeyringException(SAVE_USER_ERR, ex);
+            throw new KeyringException(REMOVE_KEY_SAVE_ERR, ex);
         }
     }
 
@@ -280,7 +281,7 @@ public class LegacyKeyringImpl implements Keyring {
         try {
             users.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
         } catch (IOException ex) {
-            throw new KeyringException(SAVE_USER_ERR, ex);
+            throw new KeyringException(ADD_KEY_SAVE_ERR, ex);
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -6,15 +6,21 @@ import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.model.User;
+import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+
 /**
- * This class duplicates the existing (legacy) keyring functionality behind a newly defined Keyring interface.
- * Moving the keyring functionality behind an interface allows to swap implemetations more easily.
+ * This class duplicates the existing (legacy) {@link com.github.onsdigital.zebedee.json.Keyring} and {@link KeyringCache}
+ * functionality behind a newly defined Keyring interface. Doing so allows to start the process of migrating to
+ * the new {@link Keyring} abstraction while maintaing backwards compatability and the ability to swicth back if
+ * necessary.
  */
 public class LegacyKeyringImpl implements Keyring {
 
@@ -22,88 +28,202 @@ public class LegacyKeyringImpl implements Keyring {
     static final String EMAIL_EMPTY_ERR = "user email required but was empty";
     static final String USER_KEYRING_NULL_ERR = "user keyring expected was null";
     static final String GET_SESSION_ERR = "error getting user session";
-    static final String SESSION_NULL_ERR = "user session required but was null";
     static final String CACHE_PUT_ERR = "error added user keys to legacy keyring cache";
     static final String COLLECTION_NULL_ERR = "collection required but was null";
     static final String COLLECTION_DESC_NULL_ERR = "collection description required but was null";
     static final String COLLECTION_ID_EMPTY_ERR = "collection ID required but was null/empty";
     static final String SECRET_KEY_NULL_ERR = "secret key required but was null";
-    static final String USER_KEYRING_LOCKED_ERR = "unable to access locked user keyring";
+    static final String CACHE_GET_ERR = "error getting entry from keyringCache";
+    static final String SAVE_USER_ERR = "error persiting user update";
+    static final String GET_USER_ERR = "error getting user";
 
-    private Sessions sessionsService;
+    private Sessions sessions;
+    private UsersService users;
     private KeyringCache cache;
     private ApplicationKeys applicationKeys;
 
     /**
-     * COnstruct a new instance of the Legacy keyring.
+     * Construct a new instance of the Legacy keyring.
      *
-     * @param sessionsService the {@link Sessions} service to use.
+     * @param sessions        the {@link Sessions} service to use.
      * @param cache           the {@link KeyringCache} to use.
      * @param applicationKeys the {@link ApplicationKeys} to use.
      */
-    public LegacyKeyringImpl(final Sessions sessionsService, final KeyringCache cache, final ApplicationKeys applicationKeys) {
-        this.sessionsService = sessionsService;
+    public LegacyKeyringImpl(final Sessions sessions, final UsersService users, final KeyringCache cache,
+                             final ApplicationKeys applicationKeys) {
+        this.sessions = sessions;
+        this.users = users;
         this.cache = cache;
         this.applicationKeys = applicationKeys;
     }
 
+    /**
+     * Add the user's keyring to the {@link KeyringCache}.
+     *
+     * @param user the user that populates the keyring.
+     * @throws KeyringException thrown if the user was null, their email was null/empty or a session for the user
+     *                          could not be found.
+     */
     @Override
-    public void populateFromUser(User user) throws KeyringException {
+    public void cacheUserKeyring(User user) throws KeyringException {
         validateUser(user);
-
         Session session = getUserSession(user);
 
-        try {
-            cache.put(user, session);
-        } catch (IOException ex) {
-            throw new KeyringException(CACHE_PUT_ERR, ex);
+        if (session != null) {
+            addUserKeyringToCache(user, session);
         }
 
         applicationKeys.populateCacheFromUserKeyring(user.keyring());
     }
 
+    private Session getUserSession(User user) throws KeyringException {
+        Session session = null;
+        try {
+            session = sessions.find(user.getEmail());
+        } catch (IOException ex) {
+            throw new KeyringException(GET_SESSION_ERR, ex);
+        }
+
+        return session;
+    }
+
+    private void addUserKeyringToCache(User user, Session session) throws KeyringException {
+        try {
+            cache.put(user, session);
+        } catch (IOException ex) {
+            throw new KeyringException(CACHE_PUT_ERR, ex);
+        }
+    }
+
+    /**
+     * Get the {@link SecretKey} for the specified collection. Returns the key if
+     * <ul>
+     *     <li>The users keyring exists in the {@link KeyringCache}.</li>
+     *     <li>The cached {@link com.github.onsdigital.zebedee.json.Keyring} has been unlocked.</li>
+     *     <li>The keyring contains the a key for the collection requested.</li>
+     * </ul>
+     *
+     * @param user       the user requesting the key.
+     * @param collection the collection to get the key for.
+     * @return the {@link} if it exists (see conditions above).
+     * @throws KeyringException thrown is the user is null, their email is null/empty, the collection is null, the
+     *                          collection description is null the collection ID is null/empty, or if there is a problem getting the user
+     *                          keyring from the cache.
+     */
     @Override
     public SecretKey get(User user, Collection collection) throws KeyringException {
         validateUser(user);
         validateCollection(collection);
-        return user.keyring().get(collection.getDescription().getId());
+
+        com.github.onsdigital.zebedee.json.Keyring userKeyring = getCachedUserKeyring(user);
+        if (userKeyring == null) {
+            info().user(user.getEmail())
+                    .collectionID(collection)
+                    .log("get key unsuccessful user keyring not found in cache");
+            return null;
+        }
+
+        if (!userKeyring.isUnlocked()) {
+            info().user(user.getEmail())
+                    .collectionID(collection)
+                    .log("get key unsuccessful cached user keyring is locked");
+            return null;
+        }
+
+        return userKeyring.get(collection.getDescription().getId());
     }
 
+    /**
+     * Remove the key for the specified collection from the user's keyring.
+     * <ul>
+     *     <li>Removes the key from the users cached keyring if it exists in {@link KeyringCache}</li>
+     *     <li>Removed it from the stored user object (the user json file) and persists the change.</li>
+     * </ul>
+     *
+     * @param user       the user performing the action.
+     * @param collection the collection the the key belongs to.
+     * @throws KeyringException thrown if the user is null, their email is null/empty, the collection is null, the
+     *                          collection description is null, the collection ID is null/empty, there is a error
+     *                          getting the users cached keyring or if there is an error updating the stored user.
+     */
     @Override
     public void remove(User user, Collection collection) throws KeyringException {
         validateUser(user);
         validateCollection(collection);
-        user.keyring().remove(collection.getDescription().getId());
+
+        // Remove the key from the cached user keyring
+        com.github.onsdigital.zebedee.json.Keyring cachedKeyring = getCachedUserKeyring(user);
+        if (cachedKeyring != null) {
+            cachedKeyring.remove(collection.getDescription().getId());
+        }
+
+        // Remove the key from the user and save the changes.
+        removeKeyFromStoredUser(user, collection);
+
     }
 
+    /**
+     * Add a key to the user's {@link com.github.onsdigital.zebedee.json.Keyring}.
+     * <ul>
+     *     <li>Add key to user's cached keyring if it exists in the {@link KeyringCache}.</li>
+     *     <li>Add key to store user file and persists the change.</li>
+     * </ul>
+     *
+     * @param user       the user adding the key.
+     * @param collection the {@link Collection} the key belongs to.
+     * @param key        the {@link SecretKey} to add.
+     * @throws KeyringException thrown if the user is null, their email is null/empty, the collection is null, the
+     *                          collection description is null, the collection ID is null/empty, the key is null, there
+     *                          is a error updating the stored user file.
+     */
     @Override
     public void add(User user, Collection collection, SecretKey key) throws KeyringException {
         validateUser(user);
         validateCollection(collection);
         validateSecretKey(key);
 
-        user.keyring().put(collection.getDescription().getId(), key);
+        // Add key to users cached keyring if exists
+        com.github.onsdigital.zebedee.json.Keyring cachedKeyring = getCachedUserKeyring(user);
+        if (cachedKeyring != null) {
+            cachedKeyring.put(collection.getDescription().getId(), key);
+        }
+
+        // Add the key to the stored user value.
+        addKeyToStoredUser(user, collection, key);
     }
 
+    /**
+     * List the key held in the user's {@link com.github.onsdigital.zebedee.json.Keyring}.
+     * <ul>
+     *     <li>Lists from a cached user keyring if it exists in the {@link KeyringCache}.</li>
+     *     <li>Otherwise lists from the stored user keyring.</li>
+     *     <li>Returns an empty {@link Set} if the user's keyring is empty or null.</li>
+     * </ul>
+     *
+     * @param user the user to list the keys for.
+     * @return
+     * @throws KeyringException thrown if the user is null, their email is null/empty, there is an error getting the
+     *                          user's keyring from the cache or getting the stored user.
+     */
     @Override
     public Set<String> list(User user) throws KeyringException {
         validateUser(user);
-        return user.keyring().list();
-    }
 
-    private Session getUserSession(User user) throws KeyringException {
-        Session session = null;
-        try {
-            session = sessionsService.find(user.getEmail());
-        } catch (IOException ex) {
-            throw new KeyringException(GET_SESSION_ERR, ex);
+        com.github.onsdigital.zebedee.json.Keyring cachedKeyring = getCachedUserKeyring(user);
+        if (cachedKeyring != null) {
+            return cachedKeyring.list();
         }
 
-        if (session == null) {
-            throw new KeyringException(SESSION_NULL_ERR);
+        User storedUser = getUser(user);
+        if (storedUser == null) {
+            throw new KeyringException(USER_NULL_ERR);
         }
 
-        return session;
+        if (storedUser.keyring() == null) {
+            return new HashSet<>();
+        }
+
+        return storedUser.keyring().list();
     }
 
     private void validateUser(User user) throws KeyringException {
@@ -117,10 +237,6 @@ public class LegacyKeyringImpl implements Keyring {
 
         if (user.keyring() == null) {
             throw new KeyringException(USER_KEYRING_NULL_ERR);
-        }
-
-        if (!user.keyring().isUnlocked()) {
-            throw new KeyringException(USER_KEYRING_LOCKED_ERR);
         }
     }
 
@@ -141,6 +257,38 @@ public class LegacyKeyringImpl implements Keyring {
     private void validateSecretKey(SecretKey key) throws KeyringException {
         if (key == null) {
             throw new KeyringException(SECRET_KEY_NULL_ERR);
+        }
+    }
+
+    private com.github.onsdigital.zebedee.json.Keyring getCachedUserKeyring(User user) throws KeyringException {
+        try {
+            return cache.get(user);
+        } catch (IOException ex) {
+            throw new KeyringException(CACHE_GET_ERR, ex);
+        }
+    }
+
+    private void removeKeyFromStoredUser(User user, Collection collection) throws KeyringException {
+        try {
+            users.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
+        } catch (IOException ex) {
+            throw new KeyringException(SAVE_USER_ERR, ex);
+        }
+    }
+
+    private void addKeyToStoredUser(User user, Collection collection, SecretKey key) throws KeyringException {
+        try {
+            users.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
+        } catch (IOException ex) {
+            throw new KeyringException(SAVE_USER_ERR, ex);
+        }
+    }
+
+    private User getUser(User user) throws KeyringException {
+        try {
+            return users.getUserByEmail(user.getEmail());
+        } catch (Exception ex) {
+            throw new KeyringException(GET_USER_ERR, ex);
         }
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -387,7 +387,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(legacyKeyring, times(1)).unlock(any());
         verify(applicationKeys, times(1)).populateCacheFromUserKeyring(legacyKeyring);
         verify(legacyKeyringCache, times(1)).put(user, userSession);
-        verify(keyring, never()).populateFromUser(any());
+        verify(keyring, never()).cacheUserKeyring(any());
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringImplTest.java
@@ -83,10 +83,10 @@ public class KeyringImplTest {
     }
 
     @Test
-    public void testPopulateFromUser_userNull() throws KeyringException {
+    public void testCacheUserKeyring_userNull() throws KeyringException {
         // Given the user is null
-        // when populateFromUser is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(null));
+        // when CacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(null));
 
         // then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
@@ -94,7 +94,7 @@ public class KeyringImplTest {
     }
 
     @Test
-    public void testPopulateFromUser_userKeyringNull() throws Exception {
+    public void testCacheUserKeyring_userKeyringNull() throws Exception {
         // Given the user keyring is null
         when(user.getEmail())
                 .thenReturn(TEST_EMAIL_ID);
@@ -102,8 +102,8 @@ public class KeyringImplTest {
         when(user.keyring())
                 .thenReturn(null);
 
-        // When populateFromUser is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        // When CacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
@@ -111,7 +111,7 @@ public class KeyringImplTest {
     }
 
     @Test
-    public void testPopulateFromUser_userKeyringIsLocked() throws Exception {
+    public void testCacheUserKeyring_userKeyringIsLocked() throws Exception {
         // Given the user keyring is locked
         when(user.getEmail())
                 .thenReturn(TEST_EMAIL_ID);
@@ -122,8 +122,8 @@ public class KeyringImplTest {
         when(userKeyring.isUnlocked())
                 .thenReturn(false);
 
-        // When populateFromUser is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        // When CacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
@@ -131,7 +131,7 @@ public class KeyringImplTest {
     }
 
     @Test
-    public void testPopulateFromUser_userKeyringIsEmpty() throws Exception {
+    public void testCacheUserKeyring_userKeyringIsEmpty() throws Exception {
         // Given the user keyring is empty
         when(user.getEmail())
                 .thenReturn(TEST_EMAIL_ID);
@@ -145,15 +145,15 @@ public class KeyringImplTest {
         when(userKeyring.list())
                 .thenReturn(new HashSet<>());
 
-        // When populateFromUser is called
-        keyring.populateFromUser(user);
+        // When CacheUserKeyring is called
+        keyring.cacheUserKeyring(user);
 
         // Then the central keyring is not updated.
         verifyZeroInteractions(keyringCache);
     }
 
     @Test
-    public void testPopulateFromUser_addThrowsException() throws Exception {
+    public void testCacheUserKeyring_addThrowsException() throws Exception {
         // Given central keyring.add throws an exception
         when(user.getEmail())
                 .thenReturn(TEST_EMAIL_ID);
@@ -176,15 +176,15 @@ public class KeyringImplTest {
                 .when(keyringCache)
                 .add(any(), any());
 
-        // When populateFromUser is called
-        assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        // When CacheUserKeyring is called
+        assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then the central keyring is not updated.
         verify(keyringCache, times(1)).add(any(), any());
     }
 
     @Test
-    public void testPopulateFromUser_success() throws Exception {
+    public void testCacheUserKeyring_success() throws Exception {
         // Given a populated user keyring
         when(user.getEmail())
                 .thenReturn(TEST_EMAIL_ID);
@@ -203,8 +203,8 @@ public class KeyringImplTest {
         when(userKeyring.get(TEST_COLLECTION_ID))
                 .thenReturn(secretKey);
 
-        // When populateFromUser is called
-        keyring.populateFromUser(user);
+        // When CacheUserKeyring is called
+        keyring.cacheUserKeyring(user);
 
         // Then the central keyring is updated with each entry in the user keyring.
         verify(keyringCache, times(1)).add(TEST_COLLECTION_ID, secretKey);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
@@ -81,11 +81,11 @@ public class KeyringMigratorImplTest {
         keyring = new KeyringMigratorImpl(disabled, legacyKeyring, centralKeyring);
 
         // When populate from user is called
-        keyring.populateFromUser(user);
+        keyring.cacheUserKeyring(user);
 
         // Then both the legacy and central keyrings are updated
-        verify(legacyKeyring, times(1)).populateFromUser(user);
-        verify(centralKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
+        verify(centralKeyring, times(1)).cacheUserKeyring(user);
     }
 
     @Test
@@ -94,11 +94,11 @@ public class KeyringMigratorImplTest {
         keyring = new KeyringMigratorImpl(enabled, legacyKeyring, centralKeyring);
 
         // When populate from user is called
-        keyring.populateFromUser(user);
+        keyring.cacheUserKeyring(user);
 
         // Then both the legacy and central keyrings are updated
-        verify(legacyKeyring, times(1)).populateFromUser(user);
-        verify(centralKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
+        verify(centralKeyring, times(1)).cacheUserKeyring(user);
     }
 
     @Test
@@ -109,16 +109,16 @@ public class KeyringMigratorImplTest {
 
         doThrow(KeyringException.class)
                 .when(legacyKeyring)
-                .populateFromUser(user);
+                .cacheUserKeyring(user);
 
         // When populate from user is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then an exception is thrown
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, disabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
 
         // And the central keyring is never called
         verifyZeroInteractions(centralKeyring);
@@ -132,16 +132,16 @@ public class KeyringMigratorImplTest {
 
         doThrow(KeyringException.class)
                 .when(legacyKeyring)
-                .populateFromUser(user);
+                .cacheUserKeyring(user);
 
         // When populate from user is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then an exception is thrown
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, enabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
 
         // And the central keyring is never called
         verifyZeroInteractions(centralKeyring);
@@ -155,19 +155,19 @@ public class KeyringMigratorImplTest {
 
         doThrow(KeyringException.class)
                 .when(centralKeyring)
-                .populateFromUser(user);
+                .cacheUserKeyring(user);
 
         // When populate from user is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then an exception is thrown
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, disabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
 
         // And the central keyring is called 1 time
-        verify(centralKeyring, times(1)).populateFromUser(user);
+        verify(centralKeyring, times(1)).cacheUserKeyring(user);
     }
 
     @Test
@@ -178,19 +178,19 @@ public class KeyringMigratorImplTest {
 
         doThrow(KeyringException.class)
                 .when(centralKeyring)
-                .populateFromUser(user);
+                .cacheUserKeyring(user);
 
         // When populate from user is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> keyring.cacheUserKeyring(user));
 
         // Then an exception is thrown
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, enabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).populateFromUser(user);
+        verify(legacyKeyring, times(1)).cacheUserKeyring(user);
 
         // And the central keyring is called 1 time
-        verify(centralKeyring, times(1)).populateFromUser(user);
+        verify(centralKeyring, times(1)).cacheUserKeyring(user);
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImplTest.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.model.User;
+import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -17,15 +18,16 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.CACHE_GET_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.CACHE_PUT_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.COLLECTION_DESC_NULL_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.COLLECTION_ID_EMPTY_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.COLLECTION_NULL_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.GET_SESSION_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.GET_USER_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.SAVE_USER_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.SECRET_KEY_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.SESSION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.USER_KEYRING_LOCKED_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
 import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -33,9 +35,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class LegacyKeyringImplTest {
@@ -51,7 +56,13 @@ public class LegacyKeyringImplTest {
     private Session session;
 
     @Mock
+    private UsersService users;
+
+    @Mock
     private com.github.onsdigital.zebedee.json.Keyring userKeyring;
+
+    @Mock
+    private com.github.onsdigital.zebedee.json.Keyring cachedUserKeyring;
 
     @Mock
     private Sessions sessionsService;
@@ -60,7 +71,7 @@ public class LegacyKeyringImplTest {
     private ApplicationKeys applicationKeys;
 
     @Mock
-    private KeyringCache cache;
+    private KeyringCache keyringCache;
 
     @Mock
     private Collection collection;
@@ -71,7 +82,7 @@ public class LegacyKeyringImplTest {
     @Mock
     private SecretKey secretKey;
 
-    private Keyring keyring;
+    private Keyring legacyKeyring;
     private KeyringException expectedEx;
 
     @Before
@@ -90,6 +101,12 @@ public class LegacyKeyringImplTest {
         when(userKeyring.isUnlocked())
                 .thenReturn(true);
 
+        when(cachedUserKeyring.isUnlocked())
+                .thenReturn(true);
+
+        when(keyringCache.get(user))
+                .thenReturn(cachedUserKeyring);
+
         when(sessionsService.find(TEST_EMAIL))
                 .thenReturn(session);
 
@@ -99,135 +116,16 @@ public class LegacyKeyringImplTest {
         when(collectionDescription.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        keyring = new LegacyKeyringImpl(sessionsService, cache, applicationKeys);
+        legacyKeyring = new LegacyKeyringImpl(sessionsService, users, keyringCache, applicationKeys);
     }
 
-    @Test
-    public void testPopulateFromUser_userNull_shouldThrowException() {
-        // Given user is null
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(null));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_userEmailNull_shouldThrowException() {
-        // Given user email is null
-        when(user.getEmail())
-                .thenReturn(null);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_userEmailEmpty_shouldThrowException() {
-        // Given user email is empty
-        when(user.getEmail())
-                .thenReturn("");
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_userKeyringNull_shouldThrowException() {
-        // Given user keyring is null
-        when(user.keyring())
-                .thenReturn(null);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_userKeyringLocked_shouldThrowException() {
-        // Given user keyring has not been unlocked
-        when(userKeyring.isUnlocked())
-                .thenReturn(false);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_getSessionError_shouldThrowException() throws IOException {
-        // Given get session throws an exception
-        when(sessionsService.find(TEST_EMAIL))
-                .thenThrow(expectedEx);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(GET_SESSION_ERR));
-        assertThat(ex.getCause(), equalTo(expectedEx));
-    }
-
-    @Test
-    public void testPopulateFromUser_getSessionReturnsNull_shouldThrowException() throws IOException {
-        // Given get session returns null
-        when(sessionsService.find(TEST_EMAIL))
-                .thenReturn(null);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(SESSION_NULL_ERR));
-    }
-
-    @Test
-    public void testPopulateFromUser_cachePutError_shouldThrowException() throws IOException {
-        // Given cache put throws an exception
-        doThrow(expectedEx)
-                .when(cache)
-                .put(user, session);
-
-        // When populate from user is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.populateFromUser(user));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(CACHE_PUT_ERR));
-        assertThat(ex.getCause(), equalTo(expectedEx));
-    }
-
-    @Test
-    public void testPopulateFromUser_success_shouldPopulateCacheAndAppKeys() throws IOException {
-        // Given a valid user
-
-        // When populate from user is called
-        keyring.populateFromUser(user);
-
-        // Then the keyring cache is updated with the users keys
-        verify(sessionsService, times(1)).find(TEST_EMAIL);
-        verify(cache, times(1)).put(user, session);
-
-        // And the applicate keys are updated from the user keyring
-        verify(applicationKeys, times(1)).populateCacheFromUserKeyring(userKeyring);
-    }
 
     @Test
     public void testGet_userNull_shouldThrowException() {
         // Given user is null
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(null, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
@@ -240,7 +138,7 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -253,36 +151,10 @@ public class LegacyKeyringImplTest {
                 .thenReturn("");
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
-    }
-
-    @Test
-    public void testGet_userKeyringNull_shouldThrowException() {
-        // Given user keyring is null
-        when(user.keyring())
-                .thenReturn(null);
-
-        // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, null));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
-    }
-
-    @Test
-    public void testGet_userKeyringLocked_shouldThrowException() {
-        // Given user keyring is locked
-        when(userKeyring.isUnlocked())
-                .thenReturn(false);
-
-        // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, null));
-
-        // Then an exception is thrown.
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
     }
 
     @Test
@@ -290,7 +162,7 @@ public class LegacyKeyringImplTest {
         // Given collection is null
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
@@ -303,7 +175,7 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
@@ -316,7 +188,7 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -329,38 +201,197 @@ public class LegacyKeyringImplTest {
                 .thenReturn("");
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
     }
 
     @Test
-    public void testGet_entryNotFound_shouldReturnNull() throws Exception {
-        // Given a collection does not exist in the keyring
-        when(userKeyring.get(TEST_COLLECTION_ID))
-                .thenReturn(null);
+    public void testGet_keyringCacheError_shouldThrowException() throws Exception {
+        // Given keyring cache throws an exception
+        when(keyringCache.get(user))
+                .thenThrow(IOException.class);
 
         // When get is called
-        SecretKey actual = keyring.get(user, collection);
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.get(user, collection));
 
         // Then null is returned
-        assertThat(actual, is(nullValue()));
-        verify(userKeyring, times(1)).get(TEST_COLLECTION_ID);
+        assertThat(actual.getMessage(), equalTo(CACHE_GET_ERR));
+        verify(keyringCache, times(1)).get(user);
     }
 
     @Test
-    public void testGet_entryExists_shouldReturnKey() throws Exception {
-        // Given a key exists for the collection
-        when(userKeyring.get(TEST_COLLECTION_ID))
+    public void testGet_keyringCacheReturnsNull_shouldReturnNull() throws Exception {
+        // Given keyring cache throws an exception
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        // When get is called
+        SecretKey actual = legacyKeyring.get(user, collection);
+
+        // Then null is returned
+        assertThat(actual, is(nullValue()));
+        verify(keyringCache, times(1)).get(user);
+    }
+
+    @Test
+    public void testGet_userKeyringIsLocked_shouldReturnNull() throws Exception {
+        // Given the user keyring is locked
+        when(cachedUserKeyring.isUnlocked())
+                .thenReturn(false);
+
+        // When get is called
+        SecretKey actual = legacyKeyring.get(user, collection);
+
+        // Then null is returned
+        assertThat(actual, is(nullValue()));
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).isUnlocked();
+    }
+
+    @Test
+    public void testGet_keyNotInUserKeyring_shouldReturnNull() throws Exception {
+        // Given the user keyring does not contain the requested collection key
+        when(cachedUserKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(null);
+
+        // When get is called
+        SecretKey actual = legacyKeyring.get(user, collection);
+
+        // Then null is returned
+        assertThat(actual, is(nullValue()));
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).isUnlocked();
+        verify(cachedUserKeyring, times(1)).get(TEST_COLLECTION_ID);
+    }
+
+    @Test
+    public void testGet_success_shouldReturnKey() throws Exception {
+        // Given an unlocked user keyring exists in the cache
+        // and contains the requested key
+        when(cachedUserKeyring.get(TEST_COLLECTION_ID))
                 .thenReturn(secretKey);
 
         // When get is called
-        SecretKey actual = keyring.get(user, collection);
+        SecretKey actual = legacyKeyring.get(user, collection);
 
         // Then the expected key is returned
         assertThat(actual, equalTo(secretKey));
-        verify(userKeyring, times(1)).get(TEST_COLLECTION_ID);
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).isUnlocked();
+        verify(cachedUserKeyring, times(1)).get(TEST_COLLECTION_ID);
+    }
+
+    @Test
+    public void testCacheUserKeyring_userNull_shouldThrowException() {
+        // Given user is null
+
+        // When cache user keyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(null));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+    }
+
+    @Test
+    public void testCacheUserKeyring_userEmailNull_shouldThrowException() {
+        // Given user email is null
+        when(user.getEmail())
+                .thenReturn(null);
+
+        // When cache user keyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(user));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testCacheUserKeyring_userEmailEmpty_shouldThrowException() {
+        // Given user email is empty
+        when(user.getEmail())
+                .thenReturn("");
+
+        // When cacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(user));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testCacheUserKeyring_userKeyringNull_shouldThrowException() {
+        // Given user keyring is null
+        when(user.keyring())
+                .thenReturn(null);
+
+        // When cacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(user));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
+    }
+
+    @Test
+    public void testCacheUserKeyring_getSessionError_shouldThrowException() throws IOException {
+        // Given get session throws an exception
+        when(sessionsService.find(TEST_EMAIL))
+                .thenThrow(expectedEx);
+
+        // When cacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(user));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(GET_SESSION_ERR));
+        assertThat(ex.getCause(), equalTo(expectedEx));
+    }
+
+    @Test
+    public void testCacheUserKeyring_getSessionReturnsNull_doNothing() throws IOException {
+        // Given get session returns null
+        when(sessionsService.find(TEST_EMAIL))
+                .thenReturn(null);
+
+        // When cacheUserKeyring is called
+        legacyKeyring.cacheUserKeyring(user);
+
+        // Then no keying is added to the cache
+        verify(sessionsService, times(1)).find(TEST_EMAIL);
+        verifyZeroInteractions(keyringCache);
+
+        // And then applicationKeys is updated
+        verify(applicationKeys, times(1)).populateCacheFromUserKeyring(userKeyring);
+    }
+
+    @Test
+    public void testCacheUserKeyring_cachePutError_shouldThrowException() throws IOException {
+        // Given cache put throws an exception
+        doThrow(expectedEx)
+                .when(keyringCache)
+                .put(user, session);
+
+        // When cacheUserKeyring is called
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheUserKeyring(user));
+
+        // Then an exception is thrown.
+        assertThat(ex.getMessage(), equalTo(CACHE_PUT_ERR));
+        assertThat(ex.getCause(), equalTo(expectedEx));
+    }
+
+    @Test
+    public void testCacheUserKeyring_success_shouldPopulateCacheAndAppKeys() throws IOException {
+        // Given a valid user
+
+        // WhencacheUserKeyring is called
+        legacyKeyring.cacheUserKeyring(user);
+
+        // Then the keyring cache is updated with the users keys
+        verify(sessionsService, times(1)).find(TEST_EMAIL);
+        verify(keyringCache, times(1)).put(user, session);
+
+        // And the applicate keys are updated from the user keyring
+        verify(applicationKeys, times(1)).populateCacheFromUserKeyring(userKeyring);
     }
 
     @Test
@@ -368,10 +399,11 @@ public class LegacyKeyringImplTest {
         // Given user is null
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -381,10 +413,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -394,36 +427,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn("");
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
-    }
-
-    @Test
-    public void testRemove_userKeyringNull_shouldThrowException() {
-        // Given user keyring is null
-        when(user.keyring())
-                .thenReturn(null);
-
-        // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, null));
-
-        // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
-    }
-
-    @Test
-    public void testRemove_userKeyringLocked_shouldThrowException() {
-        // Given user keyring is locked
-        when(userKeyring.isUnlocked())
-                .thenReturn(false);
-
-        // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, null));
-
-        // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -431,10 +439,11 @@ public class LegacyKeyringImplTest {
         // Given collection is null
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -444,10 +453,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -457,10 +467,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -470,22 +481,81 @@ public class LegacyKeyringImplTest {
                 .thenReturn("");
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(user, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
-    public void testRemove_success_shouldCallKeyringRemove() throws Exception {
-        // Given a valid user and colleciton
+    public void testRemove_userKeyringNotInCache_shouldStillUpdateAndSaveUser() throws Exception {
+        // Given the keyring cache does not contain the users keyring
+        when(keyringCache.get(user))
+                .thenReturn(null);
 
         // When remove is called
-        keyring.remove(user, collection);
+        legacyKeyring.remove(user, collection);
 
-        // Then user keyring.remove is called with the expected parameters
-        verify(user, times(3)).keyring();
-        verify(userKeyring, times(1)).remove(TEST_COLLECTION_ID);
+        // Then no update is made to the user keyring
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID);
+    }
+
+    @Test
+    public void testRemove_userKeyringNotInCacheSaveUserError_shouldThrowException() throws Exception {
+        // Given the keyring cache does not contain the users keyring
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        IOException cause = new IOException("save user error");
+        when(users.removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID))
+                .thenThrow(cause);
+
+        // When remove is called
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, collection));
+
+        // Then an exception is thrown
+        assertThat(actual.getMessage(), equalTo(SAVE_USER_ERR));
+        assertThat(actual.getCause(), equalTo(cause));
+
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID);
+    }
+
+    @Test
+    public void testRemove_success_shouldRemoveKeyFromCacheKeyringAndSaveUser() throws Exception {
+        // Given the users cached keyring is unlocked
+
+        // When remove is called
+        legacyKeyring.remove(user, collection);
+
+        // Then the key is removed from cached keyring
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).remove(TEST_COLLECTION_ID);
+
+        // And the user is updated and saved
+        verify(users, times(1)).removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID);
+    }
+
+    @Test
+    public void testRemove_saveChangesToUserError_shouldThrowException() throws Exception {
+        // Given removing the key from the user and saving the change throws an exception
+        IOException cause = new IOException("save user error");
+
+        when(users.removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID))
+                .thenThrow(cause);
+
+        // When remove is called
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.remove(user, collection));
+
+        // Then an exception is thrown
+        assertThat(actual.getMessage(), equalTo(SAVE_USER_ERR));
+        assertThat(actual.getCause(), equalTo(cause));
+
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).remove(TEST_COLLECTION_ID);
+        verify(users, times(1)).removeKeyFromKeyring(TEST_EMAIL, TEST_COLLECTION_ID);
     }
 
     @Test
@@ -493,10 +563,11 @@ public class LegacyKeyringImplTest {
         // Given user is null
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(null, null, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(null, null, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
@@ -506,10 +577,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, null, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, null, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
@@ -519,36 +591,11 @@ public class LegacyKeyringImplTest {
                 .thenReturn("");
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, null, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, null, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
-    }
-
-    @Test
-    public void testAdd_userKeyringNull_shouldThrowException() {
-        // Given user keyring is null
-        when(user.keyring())
-                .thenReturn(null);
-
-        // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, null, null));
-
-        // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
-    }
-
-    @Test
-    public void testAdd_userKeyringLocked_shouldThrowException() {
-        // Given user keyring is locked
-        when(userKeyring.isUnlocked())
-                .thenReturn(false);
-
-        // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, null, null));
-
-        // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
+        assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
@@ -556,10 +603,11 @@ public class LegacyKeyringImplTest {
         // Given collection is null
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, null, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, null, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(COLLECTION_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
@@ -569,59 +617,101 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, collection, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
-    public void testAdd_collectionIDNull_shouldThrowException() {
+    public void testAdd_collectionDescriptionIDNull_shouldThrowException() {
         // Given collection ID is null
         when(collectionDescription.getId())
                 .thenReturn(null);
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, collection, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        assertThat(actual.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
-    public void testAdd_collectionIDEmpty_shouldThrowException() {
+    public void testAdd_collectionDescriptionIDEmpty_shouldThrowException() {
         // Given collection ID is empty
         when(collectionDescription.getId())
                 .thenReturn("");
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, collection, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        assertThat(actual.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
-    public void testAdd_secretKeyNull_shouldThrowException() {
-        // Given secret key is null
+    public void testAdd_keyNull_shouldThrowException() {
+        // Given key is null
 
         // When add is called
-        KeyringException ex = assertThrows(KeyringException.class, ()-> keyring.add(user, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(user, collection, null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(SECRET_KEY_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(SECRET_KEY_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users, userKeyring, cachedUserKeyring);
     }
 
     @Test
-    public void testAdd_success_shouldAddKeyToUserKeyring() throws Exception {
-        // Given a valid user, collection and secret key
+    public void testAdd_cacheKeyringNotFound_shouldUpdatedStoredUserOnly() throws Exception {
+        // Given a cached keyring does not exist for the user
+        when(keyringCache.get(user))
+                .thenReturn(null);
 
         // When add is called
-        keyring.add(user, collection, secretKey);
+        legacyKeyring.add(user, collection, secretKey);
 
-        // Then the key is added to the user keyring.
-        verify(user, times(3)).keyring();
-        verify(userKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);
+        // Then nothing happens
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).addKeyToKeyring(TEST_EMAIL, TEST_COLLECTION_ID, secretKey);
+        verifyZeroInteractions(userKeyring, cachedUserKeyring);
+    }
+
+    @Test
+    public void testAdd_cacheKeyringIsLocked_shouldUpdateStoredUserOnly() throws Exception {
+        // Given the users cached keyring is locked
+        when(cachedUserKeyring.isUnlocked())
+                .thenReturn(false);
+
+        // When add is called
+        legacyKeyring.add(user, collection, secretKey);
+
+        // Then the keyring cache is not updated
+        verify(keyringCache, times(1)).get(user);
+
+        // And the user stored is updated
+        verify(users, times(1)).addKeyToKeyring(TEST_EMAIL, TEST_COLLECTION_ID, secretKey);
+    }
+
+    @Test
+    public void testAdd_updateAndSaveUserError_shouldThrowException() throws Exception {
+        // Given users add key to keyring throws an exception
+        when(users.addKeyToKeyring(TEST_EMAIL, TEST_COLLECTION_ID, secretKey))
+                .thenThrow(IOException.class);
+
+        // When add is called
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyKeyring.add(user, collection, secretKey));
+
+        // Then an exception is thrown
+        assertThat(actual.getMessage(), equalTo(SAVE_USER_ERR));
+        assertTrue(actual.getCause() instanceof IOException);
+
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);
+        verify(users, times(1)).addKeyToKeyring(TEST_EMAIL, TEST_COLLECTION_ID, secretKey);
     }
 
     @Test
@@ -629,10 +719,11 @@ public class LegacyKeyringImplTest {
         // Given user is null
 
         // When list is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.list(null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(null));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
@@ -642,68 +733,138 @@ public class LegacyKeyringImplTest {
                 .thenReturn(null);
 
         // When list is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.list(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(user));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
     public void testList_userEmailEmpty_shouldThrowException() {
-        // Given user email is empty
+        // Given user email is null
         when(user.getEmail())
                 .thenReturn("");
 
         // When list is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.list(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(user));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+        verifyZeroInteractions(keyringCache, users);
     }
 
     @Test
-    public void testList_userKeyringNull_shouldThrowException() {
-        // Given user keyring is null
-        when(user.keyring())
+    public void testList_cacheKeyringExists_shouldListCachedKeyringEntries() throws Exception {
+        // Given the users keyring exists in the cache
+        Set<String> expected = new HashSet<String>() {{
+            add(TEST_COLLECTION_ID);
+        }};
+
+        when(cachedUserKeyring.list())
+                .thenReturn(expected);
+
+        // When list is called
+        Set<String> actual = legacyKeyring.list(user);
+
+        // Then the expected set is returned
+        assertThat(actual, equalTo(expected));
+        verify(keyringCache, times(1)).get(user);
+        verify(cachedUserKeyring, times(1)).list();
+        verifyZeroInteractions(users);
+    }
+
+    @Test
+    public void testList_cacheKeyringDoesNotExistUsersGetError_shouldThrowException() throws Exception {
+        // Given the users keyring does not exists in the cache
+        // And get user throws an exception
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        when(users.getUserByEmail(TEST_EMAIL))
+                .thenThrow(IOException.class);
+
+        // When list is called
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(user));
+
+        // Then an exception is thrown
+        assertThat(actual.getMessage(), equalTo(GET_USER_ERR));
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).getUserByEmail(TEST_EMAIL);
+        verifyZeroInteractions(cachedUserKeyring);
+    }
+
+    @Test
+    public void testList_getUserReturnsNull_shouldThrowException() throws Exception {
+        // Given the users get user returns null
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        when(users.getUserByEmail(TEST_EMAIL))
                 .thenReturn(null);
 
         // When list is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.list(user));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(user));
 
         // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
+        assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).getUserByEmail(TEST_EMAIL);
+        verifyZeroInteractions(cachedUserKeyring);
     }
 
     @Test
-    public void testList_userKeyringLocked_shouldThrowException() {
-        // Given user keyring is locked
-        when(userKeyring.isUnlocked())
-                .thenReturn(false);
+    public void testList_storedUserKeyringNull_shouldReturnEmptyResult() throws Exception {
+        // Given the stored users keyring is null
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        User storedUser = mock(User.class);
+        when(users.getUserByEmail(TEST_EMAIL))
+                .thenReturn(storedUser);
+
+        when(storedUser.keyring())
+                .thenReturn(null);
 
         // When list is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyring.list(user));
+        Set<String> actual = legacyKeyring.list(user);
 
-        // Then an exception is thrown
-        assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
+        // Then an empty set is returned
+        assertTrue(actual.isEmpty());
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).getUserByEmail(TEST_EMAIL);
+        verifyZeroInteractions(cachedUserKeyring);
     }
 
     @Test
-    public void testList_success_shouldListKeys() throws KeyringException {
-        // Given a valid user
-        Set<String> expectedKeys = new HashSet<String>() {{
-            add("1234");
-            add("5679");
+    public void testList_storedUserSuccess_shouldReturnKeys() throws Exception {
+        // Given the stored users keyring is not null
+        when(keyringCache.get(user))
+                .thenReturn(null);
+
+        User storedUser = mock(User.class);
+        when(users.getUserByEmail(TEST_EMAIL))
+                .thenReturn(storedUser);
+
+        when(storedUser.keyring())
+                .thenReturn(userKeyring);
+
+        Set<String> expected = new HashSet<String>() {{
+            add(TEST_COLLECTION_ID);
         }};
 
         when(userKeyring.list())
-                .thenReturn(expectedKeys);
+                .thenReturn(expected);
 
         // When list is called
-        Set<String> actual = keyring.list(user);
+        Set<String> actual = legacyKeyring.list(user);
 
-        // Then the expected values are returned
-        assertThat(actual, equalTo(expectedKeys));
-        verify(user, times(3)).keyring();
-        verify(userKeyring, times(1)).list();
+        // Then the expected result is returned
+        assertThat(actual, equalTo(expected));
+        verify(keyringCache, times(1)).get(user);
+        verify(users, times(1)).getUserByEmail(TEST_EMAIL);
+        verifyZeroInteractions(cachedUserKeyring);
     }
+
+
 }


### PR DESCRIPTION
### What

Updated legacy keyring impl to also use the `KeyringCache`.

The change  essentially duplicates the existing keyring logic including the `KeyringCache` behind the new kerying interface. This will enabled us to migrate to the new world keyring  impl smoothly.

### How to review

Code review.

### Who can review

ANyone.
