### PR TITLE
added unlock to keyring interface as it's required to maintain backwa…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
@@ -51,4 +51,16 @@ public interface Keyring {
      * @return An unmodifiable set of the key identifiers in the keyring.
      */
     Set<String> list(User user) throws KeyringException;
+
+    /**
+     * Unlock the user keyring.
+     *
+     * <b>Note:</b> This is to maintain backwards compatability only. This functionality is not required by the new
+     * central keyring implementation.
+     *
+     * @param user     the user the keyring belongs to.
+     * @param password the user's password.
+     * @throws KeyringException problem unlocking the keyring.
+     */
+    void unlock(User user, String password) throws KeyringException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringImpl.java
@@ -133,6 +133,22 @@ public class KeyringImpl implements Keyring {
         return cache.list();
     }
 
+    /**
+     * <b>Do nothing.</b>
+     * <p>This method is defined in order to maintain backwards compatability. This functionality is not
+     * required in the new central keyring design so when called we do nothing.</p>
+     * This method will be removed once we have fully migrated to the central keyring implementation.
+     *
+     * @param user     the user the keyring belongs to.
+     * @param password the user's password.
+     * @throws KeyringException thrown if there is a problem unlocking the keyring.
+     */
+    @Override
+    public void unlock(User user, String password) throws KeyringException {
+        // This method is defined in order to maintain backwards compatability. This functionality is not required in
+        // the new central keyring design so when called we do nothing.
+    }
+
     private void validateUser(User user) throws KeyringException {
         if (user == null) {
             throw new KeyringException(USER_NULL_ERR);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
@@ -34,6 +34,7 @@ public class KeyringMigratorImpl implements Keyring {
     static final String ADD_KEY_ERR = "error adding key to keyring";
     static final String ROLLBACK_FAILED_ERR = "rollback action was unsuccessful";
     static final String LIST_KEYS_ERR = "error listing keys on keyring";
+    static final String UNLOCK_KEYRING_ERR = "error while attempting to unlock user kerying";
 
     private boolean migrationEnabled;
     private Keyring legacyKeyring;
@@ -183,6 +184,15 @@ public class KeyringMigratorImpl implements Keyring {
             return getKeyring().list(user);
         } catch (KeyringException ex) {
             throw wrappedKeyringException(ex, LIST_KEYS_ERR);
+        }
+    }
+
+    @Override
+    public void unlock(User user, String password) throws KeyringException {
+        try {
+            getKeyring().unlock(user, password);
+        } catch (KeyringException ex) {
+            throw wrappedKeyringException(ex, UNLOCK_KEYRING_ERR);
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -37,6 +37,8 @@ public class LegacyKeyringImpl implements Keyring {
     static final String ADD_KEY_SAVE_ERR = "user service add key to user returned an error";
     static final String REMOVE_KEY_SAVE_ERR = "user service remove key from user returned an error";
     static final String GET_USER_ERR = "user service get user by email return an error";
+    static final String PASSWORD_EMPTY_ERR = "user password required but was null or empty";
+    static final String UNLOCK_KEYRING_ERR = "error unlocking user keyring";
 
     private Sessions sessions;
     private UsersService users;
@@ -227,6 +229,16 @@ public class LegacyKeyringImpl implements Keyring {
         return storedUser.keyring().list();
     }
 
+    @Override
+    public void unlock(User user, String password) throws KeyringException {
+        validateUser(user);
+        validatePassword(password);
+
+        if (!user.keyring().unlock(password)) {
+            throw new KeyringException(UNLOCK_KEYRING_ERR);
+        }
+    }
+
     private void validateUser(User user) throws KeyringException {
         if (user == null) {
             throw new KeyringException(USER_NULL_ERR);
@@ -290,6 +302,12 @@ public class LegacyKeyringImpl implements Keyring {
             return users.getUserByEmail(user.getEmail());
         } catch (Exception ex) {
             throw new KeyringException(GET_USER_ERR, ex);
+        }
+    }
+
+    private void validatePassword(String password) throws KeyringException {
+        if (StringUtils.isEmpty(password)) {
+            throw new KeyringException(PASSWORD_EMPTY_ERR);
         }
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringImplTest.java
@@ -906,6 +906,17 @@ public class KeyringImplTest {
         verify(keyringCache, times(1)).list();
     }
 
+    @Test
+    public void testUnlock_userNull_shouldDoNothing() throws Exception {
+        // Given a user
+
+        // When unlock is called
+        keyring.unlock(null, null);
+
+        // Then no action is taken
+        verifyZeroInteractions(user, keyringCache, permissionsService);
+    }
+
     private void resetInstanceToNull() throws Exception {
         // Use some evil reflection magic to set the instance back to null for this test case.
         Field field = KeyringImpl.class.getDeclaredField("INSTANCE");

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
@@ -18,8 +18,8 @@ import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.LIST_KEY
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.POPULATE_FROM_USER_ERR;
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.REMOVE_KEY_ERR;
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.ROLLBACK_FAILED_ERR;
-import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.WRAPPED_ERR_FMT;
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.UNLOCK_KEYRING_ERR;
+import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.WRAPPED_ERR_FMT;
 import static java.text.MessageFormat.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -787,7 +787,7 @@ public class KeyringMigratorImplTest {
         // When unlocked is called
         keyring.unlock(user, "1234");
 
-        // Then lecacy keyring is unlocked
+        // Then legacy keyring is unlocked
         verify(legacyKeyring, times(1)).unlock(user, "1234");
         verifyZeroInteractions(centralKeyring);
     }
@@ -800,7 +800,7 @@ public class KeyringMigratorImplTest {
         // When unlocked is called
         keyring.unlock(user, "1234");
 
-        // Then lecacy keyring is unlocked
+        // Then legacy keyring is unlocked
         verify(centralKeyring, times(1)).unlock(user, "1234");
         verifyZeroInteractions(legacyKeyring);
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
@@ -800,7 +800,7 @@ public class KeyringMigratorImplTest {
         // When unlocked is called
         keyring.unlock(user, "1234");
 
-        // Then legacy keyring is unlocked
+        // Then central keyring is unlocked
         verify(centralKeyring, times(1)).unlock(user, "1234");
         verifyZeroInteractions(legacyKeyring);
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
@@ -19,6 +19,7 @@ import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.POPULATE
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.REMOVE_KEY_ERR;
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.ROLLBACK_FAILED_ERR;
 import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.WRAPPED_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.KeyringMigratorImpl.UNLOCK_KEYRING_ERR;
 import static java.text.MessageFormat.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -759,7 +760,7 @@ public class KeyringMigratorImplTest {
 
     @Test
     public void list_migrateEnabled_success_shouldListKeys() throws Exception {
-        // Given migrate is disabled
+        // Given migrate is enabled
         keyring = new KeyringMigratorImpl(enabled, legacyKeyring, centralKeyring);
 
         Set<String> keys = new HashSet<String>() {{
@@ -775,6 +776,76 @@ public class KeyringMigratorImplTest {
         // Then the expected key list is returned
         assertThat(actual, equalTo(keys));
         verify(centralKeyring, times(1)).list(user);
+        verifyZeroInteractions(legacyKeyring);
+    }
+
+    @Test
+    public void unlock_migrateDisbaled_shouldCallLegacyKeyringUnlock() throws Exception {
+        // Given migrate is disabled
+        keyring = new KeyringMigratorImpl(disabled, legacyKeyring, centralKeyring);
+
+        // When unlocked is called
+        keyring.unlock(user, "1234");
+
+        // Then lecacy keyring is unlocked
+        verify(legacyKeyring, times(1)).unlock(user, "1234");
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void unlock_migrateEnabled_shouldCallCentralKeyringUnlock() throws Exception {
+        // Given migrate is enabled
+        keyring = new KeyringMigratorImpl(enabled, legacyKeyring, centralKeyring);
+
+        // When unlocked is called
+        keyring.unlock(user, "1234");
+
+        // Then lecacy keyring is unlocked
+        verify(centralKeyring, times(1)).unlock(user, "1234");
+        verifyZeroInteractions(legacyKeyring);
+    }
+
+    @Test
+    public void unlock_migrateDisabled_unlockErrorShouldThrowException() throws Exception {
+        // Given migrate is disabled
+        // And legacy keyring unlock throws an exception
+        keyring = new KeyringMigratorImpl(disabled, legacyKeyring, centralKeyring);
+
+        String password = "1234";
+
+        doThrow(KeyringException.class)
+                .when(legacyKeyring)
+                .unlock(user, password);
+
+        // When unlocked is called
+        KeyringException actual = assertThrows(KeyringException.class, ()->keyring.unlock(user, password));
+
+        // Then an exception is thrown
+        assertWrappedException(actual, UNLOCK_KEYRING_ERR, disabled);
+
+        verify(legacyKeyring, times(1)).unlock(user, password);
+        verifyZeroInteractions(centralKeyring);
+    }
+
+    @Test
+    public void unlock_migrateEnabled_unlockErrorShouldThrowException() throws Exception {
+        // Given migrate is enabled
+        // And legacy keyring unlock throws an exception
+        keyring = new KeyringMigratorImpl(enabled, legacyKeyring, centralKeyring);
+
+        String password = "1234";
+
+        doThrow(KeyringException.class)
+                .when(centralKeyring)
+                .unlock(user, password);
+
+        // When unlocked is called
+        KeyringException actual = assertThrows(KeyringException.class, ()->keyring.unlock(user, password));
+
+        // Then an exception is thrown
+        assertWrappedException(actual, UNLOCK_KEYRING_ERR, enabled);
+
+        verify(centralKeyring, times(1)).unlock(user, password);
         verifyZeroInteractions(legacyKeyring);
     }
 }


### PR DESCRIPTION
### What

Added `unlock` to keyring interface. This functionality is required but the legacy keyring so I've added behind the new abstraction and updated the impl and tests.

This functionality is not required by the new central keyring so the implementation is blank and the tests verify it does nothing.

This is temp code that will be removed once we have fully migrated to the new keyring.

### How to review

Code review

### Who can review

Anyone.
