### PR TITLE
Feature/refactor legacy keyring remove

### DIFF
--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/BaseLegacyKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/BaseLegacyKeyringTest.java
@@ -220,6 +220,14 @@ public abstract class BaseLegacyKeyringTest {
         verify(users, never()).removeKeyFromKeyring(user.getEmail(), TEST_COLLECTION_ID);
     }
 
+    protected void verifyUserKeyringNotRetrievedFromCache(User user) throws Exception {
+        verify(keyringCache, never()).get(user);
+    }
+
+    protected void verifyUserKeyringRetrievedFromCache(User user) throws Exception {
+        verify(keyringCache, times(1)).get(user);
+    }
+
     public abstract void setUpTests() throws Exception;
 
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl_RemoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl_RemoveTest.java
@@ -107,7 +107,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
     }
 
     @Test
-    public void testRemove_listUsersRetunrsNull_shouldNotRemoveKeyFromAnyUser() throws Exception {
+    public void testRemove_listUsersReturnsNull_shouldNotRemoveKeyFromAnyUser() throws Exception {
         // Given list users rertuns null
         when(users.list())
                 .thenReturn(null);
@@ -125,7 +125,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
     }
 
     @Test
-    public void testRemove_listUsersRetunrsEmpty_shouldNotRemoveKeyFromAnyUser() throws Exception {
+    public void testRemove_listUsersReturnsEmpty_shouldNotRemoveKeyFromAnyUser() throws Exception {
         // Given list users rertuns an empty userlist
         when(users.list())
                 .thenReturn(new UserList());


### PR DESCRIPTION
### What

Refactor legacy keyring.remove - method now removes key from all users instead of 1 specific user. This is the second step if moving the "distribute key" logic behind the new keyring interface.

### How to review

Unit tests + code review

### Who can review

Anyone.
