### PR TITLE
Upgrade hibernate dependency version for vulnerability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,26 @@
             <version>1.5.0.0</version>
         </dependency>
 
+        <!-- Fasterxml Jackson dependencies - overrides vulnerable transitive dependencies
+       and declared explicitly to resolve conflicts in elasticsearch and dp-logging -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
@@ -223,16 +243,6 @@
                                     <groupId>org.apache.xmlgraphics</groupId>
                                     <artifactId>batik-dom</artifactId>
                                     <version>1.12</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>org.hibernate</groupId>
-                                    <artifactId>hibernate-core</artifactId>
-                                    <version>5.1.0.Final</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>com.mchange</groupId>
-                                    <artifactId>c3p0</artifactId>
-                                    <version>0.9.2.1</version>
                                 </exlude>
                                 <!-- End Trello #1717 -->
                                 <exlude>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.1.0.Final</version>
+            <version>5.4.30.Final</version>
         </dependency>
 
         <dependency>
@@ -168,27 +168,13 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-c3p0</artifactId>
-            <version>5.1.0.Final</version>
+            <version>5.4.30.Final</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>26.0-jre</version>
-        </dependency>
-
-        <!-- Fasterxml Jackson dependencies - overrides vulnerable transitive dependencies
-        and declared explicitly to resolve conflicts in elasticsearch and dp-logging -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${fasterxml.jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/persistence/dao/impl/CollectionHistoryDaoImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/persistence/dao/impl/CollectionHistoryDaoImplTest.java
@@ -3,17 +3,17 @@ package com.github.onsdigital.zebedee.persistence.dao.impl;
 import com.github.davidcarboni.cryptolite.Random;
 import com.github.onsdigital.zebedee.exceptions.CollectionEventHistoryException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.persistence.CollectionEventType;
 import com.github.onsdigital.zebedee.persistence.HibernateServiceImpl;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDao;
 import com.github.onsdigital.zebedee.persistence.model.CollectionEventMetaData;
 import com.github.onsdigital.zebedee.persistence.model.CollectionHistoryEvent;
+import com.github.onsdigital.zebedee.session.model.Session;
 import org.hibernate.HibernateException;
-import org.hibernate.SQLQuery;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.query.NativeQuery;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 
 import static com.github.onsdigital.zebedee.persistence.dao.impl.CollectionHistoryDaoImpl.COLLECTION_ID;
 import static com.github.onsdigital.zebedee.persistence.dao.impl.CollectionHistoryDaoImpl.SELECT_BY_COLLECTION_ID;
@@ -58,13 +57,10 @@ public class CollectionHistoryDaoImplTest {
     private Transaction transactionMock;
 
     @Mock
-    private SQLQuery sqlQueryMock;
+    private NativeQuery queryMock;
 
     @Mock
     private Collection collectionMock;
-
-    @Mock
-    private ExecutorService threadPoolMock;
 
     private CollectionHistoryDaoImpl dao;
     private CollectionHistoryEvent event;
@@ -103,7 +99,6 @@ public class CollectionHistoryDaoImplTest {
         dao.saveCollectionHistoryEvent(event).get();
         saveEventSuccessVerifications();
     }
-
 
 
     /**
@@ -185,12 +180,12 @@ public class CollectionHistoryDaoImplTest {
         expectedResult.add(event);
 
         when(hibernateSessionMock.createSQLQuery(SELECT_BY_COLLECTION_ID))
-                .thenReturn(sqlQueryMock);
-        when(sqlQueryMock.addEntity(CollectionHistoryEvent.class))
-                .thenReturn(sqlQueryMock);
-        when(sqlQueryMock.setString(COLLECTION_ID, TEST_COLLECTION_ID))
-                .thenReturn(sqlQueryMock);
-        when(sqlQueryMock.list())
+                .thenReturn(queryMock);
+        when(queryMock.addEntity(CollectionHistoryEvent.class))
+                .thenReturn(queryMock);
+        when(queryMock.setString(COLLECTION_ID, TEST_COLLECTION_ID))
+                .thenReturn(queryMock);
+        when(queryMock.list())
                 .thenReturn(expectedResult);
 
         // run the test.
@@ -200,9 +195,9 @@ public class CollectionHistoryDaoImplTest {
         verify(sessionFactoryMock, times(1)).getCurrentSession();
         verify(hibernateSessionMock, times(1)).beginTransaction();
         verify(hibernateSessionMock, times(1)).createSQLQuery(SELECT_BY_COLLECTION_ID);
-        verify(sqlQueryMock, times(1)).addEntity(CollectionHistoryEvent.class);
-        verify(sqlQueryMock, times(1)).setString(COLLECTION_ID, TEST_COLLECTION_ID);
-        verify(sqlQueryMock, times(1)).list();
+        verify(queryMock, times(1)).addEntity(CollectionHistoryEvent.class);
+        verify(queryMock, times(1)).setString(COLLECTION_ID, TEST_COLLECTION_ID);
+        verify(queryMock, times(1)).list();
         verify(hibernateSessionMock, times(1)).getTransaction();
         verify(transactionMock, times(1)).commit();
     }
@@ -223,9 +218,9 @@ public class CollectionHistoryDaoImplTest {
 
             verify(hibernateSessionMock, never()).beginTransaction();
             verify(hibernateSessionMock, never()).createSQLQuery(anyString());
-            verify(sqlQueryMock, never()).addEntity(CollectionHistoryEvent.class);
-            verify(sqlQueryMock, never()).setString(any(), any());
-            verify(sqlQueryMock, never()).list();
+            verify(queryMock, never()).addEntity(CollectionHistoryEvent.class);
+            verify(queryMock, never()).setString(any(), any());
+            verify(queryMock, never()).list();
             verify(hibernateSessionMock, never()).getTransaction();
             verify(transactionMock, never()).commit();
             throw ex;

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -99,20 +99,6 @@
             <version>v1.1.0</version>
         </dependency>
 
-        <!-- Fasterxml Jackson dependencies - overrides vulnerable transitive dependencies
-        and declared explicitly to resolve conflicts in elasticsearch and dp-logging -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${fasterxml.jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>


### PR DESCRIPTION
### What
- Moved duplicated Jackson dependencies to the root POM file
- Add `jackson-dataformat-smile` dependency to fix missing class bug in the /publishedCollections endpoint
- Upgrade hibernate dependency version for vulnerability fixes of the following CVE's:
[CVE-2018-1000632]  XML Injection (aka Blind XPath Injection)
https://ossindex.sonatype.org/vuln/09883ba9-5094-49df-bd4a-1eaf1d6ba07b
[CVE-2019-5427]  Resource Management Errors
https://ossindex.sonatype.org/vuln/d25f4c21-9e76-4fc2-9d73-3770aa3aec56

### How to review
Sanity check / check `make audit` result

### Who can review
Anyone
