### PR TITLE
Upgrade Restolino to v0.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     </properties>
 
     <repositories>
+
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
@@ -121,7 +122,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>restolino</artifactId>
-                <version>v0.2.1</version>
+                <version>v0.2.2</version>
             </dependency>
 
             <!-- Cryptography -->
@@ -223,16 +224,6 @@
                                     <groupId>org.yaml</groupId>
                                     <artifactId>snakeyaml</artifactId>
                                     <version>1.13</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>org.eclipse.jetty</groupId>
-                                    <artifactId>jetty-http</artifactId>
-                                    <version>9.4.28.v20200408</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>org.eclipse.jetty</groupId>
-                                    <artifactId>jetty-server</artifactId>
-                                    <version>9.4.28.v20200408</version>
                                 </exlude>
                                 <exlude>
                                     <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
### What

A new version of Restolino has been create to fix vulnerabilities with it's own dependencies. This PR upgrades the version of Restolino to fix the vulnerable dependencies in Zebedee. The associated exclusions have also been removed. 

### How to review
Sanity check change / check tests

### Who can review
Anyone
