### PR TITLE
Upgrade Batik dependencies to v1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
-            <version>1.12</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-codec</artifactId>
-            <version>1.12</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
@@ -206,11 +206,6 @@
                                     <version>3.10.5.Final</version>
                                 </exlude>
                                 <exlude>
-                                    <groupId>org.apache.xmlgraphics</groupId>
-                                    <artifactId>batik-transcoder</artifactId>
-                                    <version>1.12</version>
-                                </exlude>
-                                <exlude>
                                     <groupId>org.elasticsearch</groupId>
                                     <artifactId>elasticsearch</artifactId>
                                     <version>2.1.1</version>
@@ -229,11 +224,6 @@
                                     <groupId>org.apache.poi</groupId>
                                     <artifactId>poi</artifactId>
                                     <version>3.13</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>org.apache.xmlgraphics</groupId>
-                                    <artifactId>batik-dom</artifactId>
-                                    <version>1.12</version>
                                 </exlude>
                                 <!-- End Trello #1717 -->
                                 <exlude>


### PR DESCRIPTION
### What

- Upgrade Batik dependencies to v1.14 (to fix vulnerability CVE-2019-17566)
- remove associated exclusions

### How to review
Sanity check / check `make audit` passes

The batik library is used when rendering equations. I have tested locally by adding an equation to a bulletin and seeing that it renders correctly in the preview.

### Who can review
Anyone
