### PR TITLE
Upgrade Apache POI to 3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,17 +23,16 @@
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
         <fasterxml.jackson.version>2.11.0</fasterxml.jackson.version>
+        <apache.poi.version>3.17</apache.poi.version>
     </properties>
 
     <repositories>
-
         <repository>
             <id>splunk-artifactory</id>
             <name>Splunk Releases</name>
             <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
         </repository>
     </repositories>
-
 
     <dependencies>
 
@@ -219,11 +218,6 @@
                                     <groupId>org.yaml</groupId>
                                     <artifactId>snakeyaml</artifactId>
                                     <version>1.13</version>
-                                </exlude>
-                                <exlude>
-                                    <groupId>org.apache.poi</groupId>
-                                    <artifactId>poi</artifactId>
-                                    <version>3.13</version>
                                 </exlude>
                                 <!-- End Trello #1717 -->
                                 <exlude>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -86,14 +86,14 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
-            <version>3.13</version>
+            <version>${apache.poi.version}</version>
         </dependency>
 
         <!-- Spreadsheet handling -->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.13</version>
+            <version>${apache.poi.version}</version>
         </dependency>
 
         <!-- CSV generator (currently in Zebedee but should end up in Brian) -->

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.13</version>
+            <version>${apache.poi.version}</version>
         </dependency>
 
         <!-- CSV generator -->


### PR DESCRIPTION
### What

- upgrade Apache POI to 3.17
- deprecated functions on the POI classes has been removed in v3.17. The XlsToHtmlConverter class has been updated to reflect this.
- remove unused / commented code.
- remove Apache POI from the audit exclusions list
- CVE's addressed:
[CVE-2017-5644]  Resource Management Errors https://ossindex.sonatype.org/vuln/a4140f16-ce27-4a28-b594-ff74d959265a
[CVE-2019-12415] XML External Entity (XXE): https://ossindex.sonatype.org/vuln/6ea187cf-1c19-49cf-b052-c66a49d6a037 (CVSS 5.5)
[CVE-2017-12626]  Resource Management Errors: https://ossindex.sonatype.org/vuln/de9b3e14-c521-423f-be68-6aa3f5ecd48b (CVSS 7.5)
[CVE-2016-5000]  Improper Restriction of XML External Entity Reference ("XXE"): https://ossindex.sonatype.org/vuln/451d1563-c2af-4bfa-8974-be961c95487a (CVSS 5.5)
[CVE-2017-5644]  Resource Management Errors: https://ossindex.sonatype.org/vuln/a4140f16-ce27-4a28-b594-ff74d959265a (CVSS 5.5)

### How to review
- Review code changes
- Check `make test` succeeds
- Check `make audit` succeeds

I have locally integration tested the usages that I can identify:
- XLSX file download on a timeseries page: http://localhost:8081/businessindustryandtrade/changestobusiness/bankruptcyinsolvency/timeseries/abed/pusf (you may not have this locally)
- TeamsReport endpoint: http://localhost:8081/zebedee/TeamsReport
- When a timeseries dataset page is approved, the associated xlsx file is generated. I have tested locally to see that the XLSX file is generated and looks the same as an existing file
  - took csdb from https://develop.onsdigital.co.uk/file?uri=/businessindustryandtrade/retailindustry/datasets/retailsales/current/drsi.csdb

### Who can review
Anyone
