### PR TITLE
added populate method to new keyting interface

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CentralKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CentralKeyringImpl.java
@@ -149,6 +149,11 @@ public class CentralKeyringImpl implements Keyring {
         // the new central keyring design so when called we do nothing.
     }
 
+    @Override
+    public void populate(User source, User target, Set<String> collectionIDs) throws KeyringException {
+
+    }
+
     private void validateUser(User user) throws KeyringException {
         if (user == null) {
             throw new KeyringException(USER_NULL_ERR);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/Keyring.java
@@ -63,4 +63,20 @@ public interface Keyring {
      * @throws KeyringException problem unlocking the keyring.
      */
     void unlock(User user, String password) throws KeyringException;
+
+    /**
+     * Support for legacy keyring functionality.
+     * <p>
+     * When a new user is created their keyring needs to be populated with the appropriate keys. This method replaces
+     * this functionality which is currently handled by
+     * {@link com.github.onsdigital.zebedee.permissions.service.PermissionsServiceImpl#addEditor}. This will be
+     * removed when we move to the new keyring.
+     *
+     * @param source        the {@link User} admin user who created and is assigning permissions to the new user. This
+     *                      keyring is used as the source to populate the new keyring.
+     * @param target        the new user who's keyring needs to be populated.
+     * @param collectionIDs a set of collection IDs for which the user should be given access to.
+     * @throws KeyringException problem doing the above.
+     */
+    void populate(User source, User target, Set<String> collectionIDs) throws KeyringException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
@@ -196,6 +196,11 @@ public class KeyringMigratorImpl implements Keyring {
         }
     }
 
+    @Override
+    public void populate(User source, User target, Set<String> collectionIDs) throws KeyringException {
+
+    }
+
     private Keyring getKeyring() {
         if (migrationEnabled) {
             return centralKeyring;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -51,7 +51,7 @@ public class LegacyKeyringImpl implements Keyring {
     static final String SAVE_USER_KEYRING_ERR = "error saving changes to user keyring";
 
     private Sessions sessions;
-    private UsersService users;
+    private UsersService usersService;
     private PermissionsService permissions;
     private KeyringCache cache;
     private ApplicationKeys applicationKeys;
@@ -63,11 +63,11 @@ public class LegacyKeyringImpl implements Keyring {
      * @param cache           the {@link KeyringCache} to use.
      * @param applicationKeys the {@link ApplicationKeys} to use.
      */
-    public LegacyKeyringImpl(final Sessions sessions, final UsersService users, PermissionsService permissions,
+    public LegacyKeyringImpl(final Sessions sessions, final UsersService usersService, PermissionsService permissions,
                              final KeyringCache cache,
                              final ApplicationKeys applicationKeys) {
         this.sessions = sessions;
-        this.users = users;
+        this.usersService = usersService;
         this.permissions = permissions;
         this.cache = cache;
         this.applicationKeys = applicationKeys;
@@ -233,7 +233,7 @@ public class LegacyKeyringImpl implements Keyring {
 
     private UserList listUsers() throws KeyringException {
         try {
-            return users.list();
+            return usersService.list();
         } catch (IOException ex) {
             throw new KeyringException(LIST_USERS_ERR, ex);
         }
@@ -246,7 +246,7 @@ public class LegacyKeyringImpl implements Keyring {
         }
 
         try {
-            users.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
+            usersService.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
         } catch (IOException ex) {
             throw new KeyringException(ADD_KEY_SAVE_ERR, ex);
         }
@@ -259,7 +259,7 @@ public class LegacyKeyringImpl implements Keyring {
         }
 
         try {
-            users.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
+            usersService.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
         } catch (IOException ex) {
             throw new KeyringException(REMOVE_KEY_SAVE_ERR, ex);
         }
@@ -335,7 +335,7 @@ public class LegacyKeyringImpl implements Keyring {
             }
         }
 
-        saveKeyring(target);
+        saveKeyringChanges(target);
     }
 
     private void validateUser(User user) throws KeyringException {
@@ -382,7 +382,7 @@ public class LegacyKeyringImpl implements Keyring {
 
     private User getUser(User user) throws KeyringException {
         try {
-            return users.getUserByEmail(user.getEmail());
+            return usersService.getUserByEmail(user.getEmail());
         } catch (Exception ex) {
             throw new KeyringException(GET_USER_ERR, ex);
         }
@@ -394,9 +394,9 @@ public class LegacyKeyringImpl implements Keyring {
         }
     }
 
-    private void saveKeyring(User user) throws KeyringException {
+    private void saveKeyringChanges(User user) throws KeyringException {
         try {
-            users.updateKeyring(user);
+            usersService.updateKeyring(user);
         } catch (IOException ex) {
             throw new KeyringException(SAVE_USER_KEYRING_ERR, ex);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -47,7 +47,7 @@ public class LegacyKeyringImpl implements Keyring {
     static final String GET_KEY_RECIPIENTS_ERR = "error getting recipients for collection key";
     static final String LIST_USERS_ERR = "error listing all users";
     static final String CACHE_KEYRING_NULL_ERR = "expected cached keyring but was not found";
-    static final String KEYRING_LOCKED_ERR = "cached has not been unlocked";
+    static final String KEYRING_LOCKED_ERR = "cached keyring has not been unlocked";
     static final String SAVE_USER_KEYRING_ERR = "error saving changes to user keyring";
 
     private Sessions sessions;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/NoOpCentralKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/NoOpCentralKeyring.java
@@ -45,4 +45,9 @@ public class NoOpCentralKeyring implements Keyring {
     public void unlock(User user, String password) throws KeyringException {
         info().user(user.getEmail()).log("no-op keyring unlock");
     }
+
+    @Override
+    public void populate(User source, User target, Set<String> collectionIDs) throws KeyringException {
+
+    }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl_PopulateTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl_PopulateTest.java
@@ -1,0 +1,209 @@
+package com.github.onsdigital.zebedee.keyring;
+
+import com.github.onsdigital.zebedee.json.Keyring;
+import com.github.onsdigital.zebedee.user.model.User;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.CACHE_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.KEYRING_LOCKED_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.SAVE_USER_KEYRING_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl.USER_NULL_ERR;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class LegacyKeyringImpl_PopulateTest extends BaseLegacyKeyringTest {
+
+    @Mock
+    private User srcUser, targeUser;
+
+    @Mock
+    private Keyring srcKeyring, targetKeyring, srcCachedKeyring;
+
+    private Set<String> collectionIDs;
+
+    @Override
+    public void setUpTests() throws Exception {
+        when(srcUser.getEmail())
+                .thenReturn("src@test.com");
+
+        when(srcUser.keyring())
+                .thenReturn(srcKeyring);
+
+        when(keyringCache.get(srcUser))
+                .thenReturn(srcCachedKeyring);
+
+        when(srcCachedKeyring.isUnlocked())
+                .thenReturn(true);
+
+        when(srcCachedKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
+        when(targeUser.getEmail())
+                .thenReturn("target@test.com");
+
+        when(targeUser.keyring())
+                .thenReturn(targetKeyring);
+
+        collectionIDs = new HashSet<String>() {{
+            add(TEST_COLLECTION_ID);
+        }};
+    }
+
+    @Test
+    public void testPopulate_srcUserNull_ShouldThrowException() {
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(null, null, null));
+
+        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+    }
+
+    @Test
+    public void testPopulate_srcUserEmailNull_ShouldThrowException() {
+        when(srcUser.getEmail())
+                .thenReturn(null);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testPopulate_srcUserEmailEmpty_ShouldThrowException() {
+        when(srcUser.getEmail())
+                .thenReturn("");
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testPopulate_srcUserKeyringNull_ShouldThrowException() {
+        when(srcUser.keyring())
+                .thenReturn(null);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
+    }
+
+    @Test
+    public void testPopulate_srcUserKeyringNotInCache_ShouldThrowException() throws Exception {
+        when(keyringCache.get(srcUser))
+                .thenReturn(null);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(CACHE_KEYRING_NULL_ERR));
+        verify(keyringCache, times(1)).get(srcUser);
+    }
+
+    @Test
+    public void testPopulate_srcKeyringLocked_ShouldThrowException() throws Exception {
+        when(srcCachedKeyring.isUnlocked())
+                .thenReturn(false);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(KEYRING_LOCKED_ERR));
+        verify(keyringCache, times(1)).get(srcUser);
+    }
+
+    @Test
+    public void testPopulate_targetUserNull_ShouldThrowException() {
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, null, null));
+
+        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
+    }
+
+    @Test
+    public void testPopulate_targetUserEmailNull_ShouldThrowException() {
+        when(targeUser.getEmail())
+                .thenReturn(null);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, targeUser, null));
+
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testPopulate_targetUserEmailEmpty_ShouldThrowException() {
+        when(targeUser.getEmail())
+                .thenReturn("");
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, targeUser, null));
+
+        assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
+    }
+
+    @Test
+    public void testPopulate_targetUserKeyringNull_ShouldThrowException() {
+        when(targeUser.keyring())
+                .thenReturn(null);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, targeUser, null));
+
+        assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
+    }
+
+    @Test
+    public void testPopulate_collectionIdsNull_shouldDoNothing() throws Exception {
+        legacyKeyring.populate(srcUser, targeUser, null);
+
+        verifyZeroInteractions(srcKeyring, targetKeyring);
+    }
+
+    @Test
+    public void testPopulate_collectionIdsEmpty_shouldDoNothing() throws Exception {
+        legacyKeyring.populate(srcUser, targeUser, new HashSet<>());
+
+        verifyZeroInteractions(srcKeyring, targetKeyring);
+    }
+
+    @Test
+    public void testPopulate_updateUserKeyringError_shouldThrowException() throws Exception {
+        when(users.updateKeyring(targeUser))
+                .thenThrow(IOException.class);
+
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyKeyring.populate(srcUser, targeUser, collectionIDs));
+
+        assertThat(ex.getMessage(), equalTo(SAVE_USER_KEYRING_ERR));
+        verify(keyringCache, times(1)).get(srcUser);
+        verify(srcCachedKeyring, times(1)).get(TEST_COLLECTION_ID);
+        verify(targetKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);
+        verify(users, times(1)).updateKeyring(targeUser);
+    }
+
+    @Test
+    public void testPopulate_success_shouldAssignExpectedKeys() throws Exception {
+        legacyKeyring.populate(srcUser, targeUser, collectionIDs);
+
+        verify(keyringCache, times(1)).get(srcUser);
+        verify(srcCachedKeyring, times(1)).get(TEST_COLLECTION_ID);
+        verify(targetKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);
+        verify(users, times(1)).updateKeyring(targeUser);
+    }
+
+}


### PR DESCRIPTION
### What

Support for legacy keyring. When a new user is created their keyring has to be populate for the collections they have access to. The keys to assign as copied from the admin user's (who is creating the new user) keyring.

This functionality existing in  the permissions service currently - moving it behind new interface to allow migration. It will be deleted once we have migrated to the new keyring as its not a problem that exists in that world.

### How to review

CoDe rEvIEw.

### Who can review

Anyone.
