### PR TITLE
refactor scheduler cache to work for new world

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -8,6 +8,7 @@ import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.keyring.Keyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
+import com.github.onsdigital.zebedee.keyring.cache.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.model.Content;
@@ -74,6 +75,7 @@ public class Zebedee {
     private final Collections collections;
     private final Content published;
     private final KeyringCache legacyKeyringCache;
+    private final SchedulerKeyCache schedulerKeyCache;
     private final Path publishedContentPath;
     private final Path path;
     private final PermissionsService permissionsService;
@@ -91,38 +93,39 @@ public class Zebedee {
     /**
      * Create a new instance of Zebedee setting.
      *
-     * @param configuration {@link ZebedeeConfiguration} contains the set up to use for this instance.
+     * @param cfg {@link ZebedeeConfiguration} contains the set up to use for this instance.
      */
-    public Zebedee(ZebedeeConfiguration configuration) {
-        this.path = configuration.getZebedeePath();
-        this.publishedContentPath = configuration.getPublishedContentPath();
-        this.sessions = configuration.getSessions();
-        this.legacyKeyringCache = configuration.getKeyringCache();
-        this.permissionsService = configuration.getPermissionsService();
-        this.published = configuration.getPublished();
-        this.dataIndex = configuration.getDataIndex();
-        this.collections = configuration.getCollections();
-        this.publishedCollections = configuration.getPublishCollections();
-        this.applicationKeys = configuration.getApplicationKeys();
-        this.teamsService = configuration.getTeamsService();
-        this.usersService = configuration.getUsersService();
-        this.verificationAgent = configuration.getVerificationAgent(isVerificationEnabled(), this);
-        this.datasetService = configuration.getDatasetService();
-        this.imageService = configuration.getImageService();
-        this.serviceStoreImpl = configuration.getServiceStore();
-        this.collectionKeyring = configuration.getCollectionKeyring();
-        this.encryptionKeyFactory = configuration.getEncryptionKeyFactory();
+    public Zebedee(ZebedeeConfiguration cfg) {
+        this.path = cfg.getZebedeePath();
+        this.publishedContentPath = cfg.getPublishedContentPath();
+        this.sessions = cfg.getSessions();
+        this.legacyKeyringCache = cfg.getKeyringCache();
+        this.schedulerKeyCache = cfg.getSchedulerKeyringCache();
+        this.permissionsService = cfg.getPermissionsService();
+        this.published = cfg.getPublished();
+        this.dataIndex = cfg.getDataIndex();
+        this.collections = cfg.getCollections();
+        this.publishedCollections = cfg.getPublishCollections();
+        this.applicationKeys = cfg.getApplicationKeys();
+        this.teamsService = cfg.getTeamsService();
+        this.usersService = cfg.getUsersService();
+        this.verificationAgent = cfg.getVerificationAgent(isVerificationEnabled(), this);
+        this.datasetService = cfg.getDatasetService();
+        this.imageService = cfg.getImageService();
+        this.serviceStoreImpl = cfg.getServiceStore();
+        this.collectionKeyring = cfg.getCollectionKeyring();
+        this.encryptionKeyFactory = cfg.getEncryptionKeyFactory();
 
-        this.collectionsPath = configuration.getCollectionsPath();
-        this.publishedCollectionsPath = configuration.getPublishedCollectionsPath();
-        this.usersPath = configuration.getUsersPath();
-        this.sessionsPath = configuration.getSessionsPath();
-        this.permissionsPath = configuration.getPermissionsPath();
-        this.teamsPath = configuration.getTeamsPath();
-        this.applicationKeysPath = configuration.getApplicationKeysPath();
-        this.redirectPath = configuration.getRedirectPath();
-        this.servicePath = configuration.getServicePath();
-        this.keyRingPath = configuration.getKeyRingPath();
+        this.collectionsPath = cfg.getCollectionsPath();
+        this.publishedCollectionsPath = cfg.getPublishedCollectionsPath();
+        this.usersPath = cfg.getUsersPath();
+        this.sessionsPath = cfg.getSessionsPath();
+        this.permissionsPath = cfg.getPermissionsPath();
+        this.teamsPath = cfg.getTeamsPath();
+        this.applicationKeysPath = cfg.getApplicationKeysPath();
+        this.redirectPath = cfg.getRedirectPath();
+        this.servicePath = cfg.getServicePath();
+        this.keyRingPath = cfg.getKeyRingPath();
     }
 
     /**
@@ -360,6 +363,10 @@ public class Zebedee {
     @Deprecated
     public KeyringCache getLegacyKeyringCache() {
         return this.legacyKeyringCache;
+    }
+
+    public SchedulerKeyCache getSchedulerKeyCache() {
+        return this.schedulerKeyCache;
     }
 
     public ApplicationKeys getApplicationKeys() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -14,6 +14,8 @@ import com.github.onsdigital.zebedee.keyring.LegacyKeyringImpl;
 import com.github.onsdigital.zebedee.keyring.NoOpCentralKeyring;
 import com.github.onsdigital.zebedee.keyring.cache.KeyringCache;
 import com.github.onsdigital.zebedee.keyring.cache.KeyringCacheImpl;
+import com.github.onsdigital.zebedee.keyring.cache.LegacySchedulerKeyCache;
+import com.github.onsdigital.zebedee.keyring.cache.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.keyring.store.KeyringStore;
 import com.github.onsdigital.zebedee.keyring.store.KeyringStoreImpl;
 import com.github.onsdigital.zebedee.model.Collections;
@@ -111,6 +113,7 @@ public class ZebedeeConfiguration {
     private ImageService imageService;
     private SessionClient sessionClient;
     private Keyring collectionKeyring;
+    private SchedulerKeyCache schedulerKeyCache;
     private EncryptionKeyFactory encryptionKeyFactory;
 
 
@@ -163,8 +166,10 @@ public class ZebedeeConfiguration {
             this.sessions = new SessionsServiceImpl(sessionsPath);
         }
 
+        this.schedulerKeyCache = new LegacySchedulerKeyCache();
+
         // Initialise legacy keyring regardless - they will dual run until we cut over to new impl.
-        this.legacyKeyringCache = new com.github.onsdigital.zebedee.model.KeyringCache(sessions);
+        this.legacyKeyringCache = new com.github.onsdigital.zebedee.model.KeyringCache(sessions, schedulerKeyCache);
 
         this.teamsService = new TeamsServiceImpl(
                 new TeamsStoreFileSystemImpl(teamsPath), this::getPermissionsService);
@@ -189,7 +194,7 @@ public class ZebedeeConfiguration {
 
         // The legacy keyring logic but behind the new keyring interface.
         Keyring legacyKeyring = new LegacyKeyringImpl(
-                sessions, usersService, permissionsService, legacyKeyringCache, applicationKeys);
+                sessions, usersService, permissionsService, legacyKeyringCache, schedulerKeyCache, applicationKeys);
 
         // The new world keyring impl - could be no op or real impl depending on config.
         Keyring centralKeyring = initCentralKeyring();
@@ -386,6 +391,10 @@ public class ZebedeeConfiguration {
 
     public EncryptionKeyFactory getEncryptionKeyFactory() {
         return this.encryptionKeyFactory;
+    }
+
+    public SchedulerKeyCache getSchedulerKeyringCache() {
+        return this.schedulerKeyCache;
     }
 
     private Path createDir(Path root, String dirName) throws IOException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CsdbNotify.java
@@ -44,7 +44,7 @@ public class CsdbNotify {
                 csdbId,
                 dylanClient,
                 Root.zebedee.getCollections(),
-                Root.zebedee.getLegacyKeyringCache().getSchedulerCache());
+                Root.zebedee.getSchedulerKeyCache());
 
         Audit.Event.CSDB_NEW_FILE_NOTIFICATION
                 .parameters()

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.keyring;
 
+import com.github.onsdigital.zebedee.keyring.cache.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
@@ -54,6 +55,7 @@ public class LegacyKeyringImpl implements Keyring {
     private UsersService usersService;
     private PermissionsService permissions;
     private KeyringCache cache;
+    private SchedulerKeyCache schedulerKeyCache;
     private ApplicationKeys applicationKeys;
 
     /**
@@ -64,12 +66,13 @@ public class LegacyKeyringImpl implements Keyring {
      * @param applicationKeys the {@link ApplicationKeys} to use.
      */
     public LegacyKeyringImpl(final Sessions sessions, final UsersService usersService, PermissionsService permissions,
-                             final KeyringCache cache,
+                             final KeyringCache cache, final SchedulerKeyCache schedulerKeyCache,
                              final ApplicationKeys applicationKeys) {
         this.sessions = sessions;
         this.usersService = usersService;
         this.permissions = permissions;
         this.cache = cache;
+        this.schedulerKeyCache = schedulerKeyCache;
         this.applicationKeys = applicationKeys;
     }
 
@@ -190,7 +193,7 @@ public class LegacyKeyringImpl implements Keyring {
         validateCollection(collection);
         validateSecretKey(key);
 
-        cache.getSchedulerCache().put(collection.getDescription().getId(), key);
+        schedulerKeyCache.add(collection.getDescription().getId(), key);
 
         List<User> assignments = getKeyRecipients(collection);
         List<User> removals = getKeyToRemoveFrom(collection, assignments);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -51,7 +51,7 @@ public class LegacyKeyringImpl implements Keyring {
     static final String SAVE_USER_KEYRING_ERR = "error saving changes to user keyring";
 
     private Sessions sessions;
-    private UsersService users;
+    private UsersService usersService;
     private PermissionsService permissions;
     private KeyringCache cache;
     private ApplicationKeys applicationKeys;
@@ -63,11 +63,11 @@ public class LegacyKeyringImpl implements Keyring {
      * @param cache           the {@link KeyringCache} to use.
      * @param applicationKeys the {@link ApplicationKeys} to use.
      */
-    public LegacyKeyringImpl(final Sessions sessions, final UsersService users, PermissionsService permissions,
+    public LegacyKeyringImpl(final Sessions sessions, final UsersService usersService, PermissionsService permissions,
                              final KeyringCache cache,
                              final ApplicationKeys applicationKeys) {
         this.sessions = sessions;
-        this.users = users;
+        this.usersService = usersService;
         this.permissions = permissions;
         this.cache = cache;
         this.applicationKeys = applicationKeys;
@@ -233,7 +233,7 @@ public class LegacyKeyringImpl implements Keyring {
 
     private UserList listUsers() throws KeyringException {
         try {
-            return users.list();
+            return usersService.list();
         } catch (IOException ex) {
             throw new KeyringException(LIST_USERS_ERR, ex);
         }
@@ -246,7 +246,7 @@ public class LegacyKeyringImpl implements Keyring {
         }
 
         try {
-            users.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
+            usersService.addKeyToKeyring(user.getEmail(), collection.getDescription().getId(), key);
         } catch (IOException ex) {
             throw new KeyringException(ADD_KEY_SAVE_ERR, ex);
         }
@@ -259,7 +259,7 @@ public class LegacyKeyringImpl implements Keyring {
         }
 
         try {
-            users.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
+            usersService.removeKeyFromKeyring(user.getEmail(), collection.getDescription().getId());
         } catch (IOException ex) {
             throw new KeyringException(REMOVE_KEY_SAVE_ERR, ex);
         }
@@ -335,7 +335,7 @@ public class LegacyKeyringImpl implements Keyring {
             }
         }
 
-        saveKeyring(target);
+        saveKeyringChanges(target);
     }
 
     private void validateUser(User user) throws KeyringException {
@@ -382,7 +382,7 @@ public class LegacyKeyringImpl implements Keyring {
 
     private User getUser(User user) throws KeyringException {
         try {
-            return users.getUserByEmail(user.getEmail());
+            return usersService.getUserByEmail(user.getEmail());
         } catch (Exception ex) {
             throw new KeyringException(GET_USER_ERR, ex);
         }
@@ -394,9 +394,9 @@ public class LegacyKeyringImpl implements Keyring {
         }
     }
 
-    private void saveKeyring(User user) throws KeyringException {
+    private void saveKeyringChanges(User user) throws KeyringException {
         try {
-            users.updateKeyring(user);
+            usersService.updateKeyring(user);
         } catch (IOException ex) {
             throw new KeyringException(SAVE_USER_KEYRING_ERR, ex);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/LegacyKeyringImpl.java
@@ -47,7 +47,7 @@ public class LegacyKeyringImpl implements Keyring {
     static final String GET_KEY_RECIPIENTS_ERR = "error getting recipients for collection key";
     static final String LIST_USERS_ERR = "error listing all users";
     static final String CACHE_KEYRING_NULL_ERR = "expected cached keyring but was not found";
-    static final String KEYRING_LOCKED_ERR = "cached has not been unlocked";
+    static final String KEYRING_LOCKED_ERR = "cached keyring has not been unlocked";
     static final String SAVE_USER_KEYRING_ERR = "error saving changes to user keyring";
 
     private Sessions sessions;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/KeyringCacheImpl.java
@@ -6,7 +6,6 @@ import liquibase.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,7 +26,7 @@ import java.util.Set;
  * However if this does become an issue consider replacing the Hashmap with some type time based cache object to
  * automatically evicted after a duration of inactivity.
  */
-public class KeyringCacheImpl implements KeyringCache {
+public class KeyringCacheImpl implements KeyringCache, SchedulerKeyCache {
 
     static final String INVALID_COLLECTION_ID_ERR = "expected collection ID but was null or empty";
     static final String INVALID_SECRET_KEY_ERR = "expected secret key but was null";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/LegacySchedulerKeyCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/LegacySchedulerKeyCache.java
@@ -1,0 +1,56 @@
+package com.github.onsdigital.zebedee.keyring.cache;
+
+import com.github.onsdigital.zebedee.keyring.KeyringException;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Encapsulate legacy scheduler cache implementation behind interface.
+ */
+public class LegacySchedulerKeyCache implements SchedulerKeyCache {
+
+    static final String COLLECTION_ID_EMPTY = "collection ID required but was null/empty";
+    static final String SECRET_KEY_EMPTY = "secret key required but was null";
+
+    private final ConcurrentHashMap<String, SecretKey> cache;
+
+    /**
+     * Construct a new SchedulerKeyringCache.
+     *
+     * @param cache the {@link ConcurrentHashMap} to use for the internal cache.
+     */
+    LegacySchedulerKeyCache(final ConcurrentHashMap<String, SecretKey> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Construct a new LegacySchedulerKeyringCache with the default configuration.
+     */
+    public LegacySchedulerKeyCache() {
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public SecretKey get(String collectionID) {
+        if (cache == null) {
+            return null;
+        }
+
+        return cache.get(collectionID);
+    }
+
+    @Override
+    public void add(String collectionID, SecretKey key) throws KeyringException {
+        if (StringUtils.isEmpty(collectionID)) {
+            throw new KeyringException(COLLECTION_ID_EMPTY);
+        }
+
+        if (key == null) {
+            throw new KeyringException(SECRET_KEY_EMPTY);
+        }
+
+        cache.put(collectionID, key);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/SchedulerKeyCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/cache/SchedulerKeyCache.java
@@ -1,0 +1,30 @@
+package com.github.onsdigital.zebedee.keyring.cache;
+
+import com.github.onsdigital.zebedee.keyring.KeyringException;
+
+import javax.crypto.SecretKey;
+
+/**
+ * Defines a {@link com.github.onsdigital.zebedee.keyring.Keyring} cache used for scheduled publishing tasks (i.e.
+ * non user driven actions).
+ */
+public interface SchedulerKeyCache {
+
+    /**
+     * Get a {@link SecretKey} from the cache.
+     *
+     * @param collectionID the collection ID the key belongs to.
+     * @return the key if it exists.
+     * @throws KeyringException problem getting the key.
+     */
+    SecretKey get(String collectionID) throws KeyringException;
+
+    /**
+     * Add a {@link SecretKey} to the scheduler cache.
+     *
+     * @param collectionID the ID of the collection the key belongs to.
+     * @param key          the key to add.
+     * @throws KeyringException problem adding the key.
+     */
+    void add(String collectionID, SecretKey key) throws KeyringException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyManager.java
@@ -75,9 +75,7 @@ public class KeyManager {
             assignKeyToUser(zebedee, recipient, collection.getDescription().getId(), key);
         }
 
-        zebedee.getLegacyKeyringCache()
-                .getSchedulerCache()
-                .put(collection.getDescription().getId(), key);
+        zebedee.getSchedulerKeyCache().add(collection.getDescription().getId(), key);
     }
 
     private static <T> List<T> nullSafeList(List<T> list) {
@@ -90,7 +88,7 @@ public class KeyManager {
     /**
      * Creates a {@link List} of {@link Callable} tasks to distribute/remove the collection key. For each user creates
      * either a key assignment task if they should have access to the collection, a key removal task if not and a single
-     * task to add the new key to {@link Zebedee#keyringCache}
+     * task to add the new key to {@link Zebedee#schedulerKeyCache}
      *
      * @param zebedee         the {@link Zebedee} instance to use.
      * @param collection      the {@link Collection} the key belongs too.
@@ -123,7 +121,7 @@ public class KeyManager {
 
         // Put the Key in the schedule cache.
         collectionKeyTasks.add(() -> {
-            zebedee.getLegacyKeyringCache().getSchedulerCache().put(collection.getDescription().getId(), secretKey);
+            zebedee.getSchedulerKeyCache().add(collection.getDescription().getId(), secretKey);
             return true;
         });
         return collectionKeyTasks;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/KeyringCache.java
@@ -101,9 +101,4 @@ public class KeyringCache {
             keyringMap.remove(session);
         }
     }
-
-    @Deprecated
-    private SchedulerKeyCache getSchedulerCache() {
-        return this.schedulerCache;
-    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -151,7 +151,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         // send versioned files manifest ahead of time. allowing files to be copied from the website into the transaction.
                         Publisher.sendManifest(collection);
 
-                        SecretKey key = zebedee.getLegacyKeyringCache().getSchedulerCache().get(collection.getDescription().getId());
+                        SecretKey key = zebedee.getSchedulerKeyCache().get(collection.getDescription().getId());
                         ZebedeeCollectionReader collectionReader = new ZebedeeCollectionReader(collection, key);
                         PublishCollectionTask publishCollectionTask = new PublishCollectionTask(collection, collectionReader, hostToTransactionIdMap);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.cache.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
@@ -70,6 +71,9 @@ public abstract class ZebedeeTestBaseFixture {
     protected KeyringCache legacyKeyringCache;
 
     @Mock
+    protected SchedulerKeyCache schedulerKeyCache;
+
+    @Mock
     protected Keyring collectionKeyring;
 
     @Mock
@@ -113,7 +117,7 @@ public abstract class ZebedeeTestBaseFixture {
         ReflectionTestUtils.setField(zebedee.getPermissionsService(), "usersServiceSupplier", usersServiceServiceSupplier);
 
         ReflectionTestUtils.setField(zebedee, "sessions", sessionsService);
-        ReflectionTestUtils.setField(zebedee, "legacyKeyringCache", new KeyringCache(sessionsService));
+        ReflectionTestUtils.setField(zebedee, "legacyKeyringCache", new KeyringCache(sessionsService, schedulerKeyCache));
         ReflectionTestUtils.setField(zebedee, "collectionKeyring", collectionKeyring);
         ReflectionTestUtils.setField(zebedee, "encryptionKeyFactory", encryptionKeyFactory);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/BaseLegacyKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/BaseLegacyKeyringTest.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.keyring;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.keyring.cache.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.model.encryption.ApplicationKeys;
@@ -17,7 +18,6 @@ import org.mockito.MockitoAnnotations;
 import javax.crypto.SecretKey;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -79,7 +79,7 @@ public abstract class BaseLegacyKeyringTest {
     protected SecretKey secretKey;
 
     @Mock
-    protected Map<String, SecretKey> schedulerCache;
+    protected SchedulerKeyCache schedulerCache;
 
     protected Keyring legacyKeyring;
     protected KeyringException expectedEx;
@@ -110,7 +110,8 @@ public abstract class BaseLegacyKeyringTest {
 
         setUpTests();
 
-        legacyKeyring = new LegacyKeyringImpl(sessionsService, users, permissions, keyringCache, applicationKeys);
+        legacyKeyring = new LegacyKeyringImpl(
+                sessionsService, users, permissions, keyringCache, schedulerCache, applicationKeys);
 
     }
 
@@ -133,9 +134,6 @@ public abstract class BaseLegacyKeyringTest {
 
         when(users.list())
                 .thenReturn(allUsers);
-
-        when(keyringCache.getSchedulerCache())
-                .thenReturn(schedulerCache);
     }
 
     private void setUpMockUserBert() throws Exception {
@@ -236,9 +234,8 @@ public abstract class BaseLegacyKeyringTest {
         verify(keyringCache, times(1)).get(user);
     }
 
-    protected void verifyKeyAddedToSchedulerCache() {
-        verify(keyringCache, times(1)).getSchedulerCache();
-        verify(schedulerCache, times(1)).put(TEST_COLLECTION_ID, secretKey);
+    protected void verifyKeyAddedToSchedulerCache() throws Exception {
+        verify(schedulerCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
         verifyNoMoreInteractions(schedulerCache);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/cache/LegacySchedulerKeyCacheTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/cache/LegacySchedulerKeyCacheTest.java
@@ -1,0 +1,128 @@
+package com.github.onsdigital.zebedee.keyring.cache;
+
+import com.github.onsdigital.zebedee.keyring.KeyringException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.crypto.SecretKey;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.github.onsdigital.zebedee.keyring.cache.LegacySchedulerKeyCache.COLLECTION_ID_EMPTY;
+import static com.github.onsdigital.zebedee.keyring.cache.LegacySchedulerKeyCache.SECRET_KEY_EMPTY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class LegacySchedulerKeyCacheTest {
+
+    static final String COLLECTION_ID = "666";
+
+    @Mock
+    private SecretKey secretKey;
+
+    private LegacySchedulerKeyCache schedulerCache;
+    private ConcurrentHashMap<String, SecretKey> cache;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        cache = new ConcurrentHashMap<String, SecretKey>() {{
+            put(COLLECTION_ID, secretKey);
+        }};
+
+        schedulerCache = new LegacySchedulerKeyCache(cache);
+    }
+
+    @Test
+    public void testGet_cacheNull_shouldReturnNull() throws Exception {
+        schedulerCache = new LegacySchedulerKeyCache(null);
+        SecretKey actual = schedulerCache.get(COLLECTION_ID);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testGet_cacheEmpty_shouldReturnNull() throws Exception {
+        schedulerCache = new LegacySchedulerKeyCache(new ConcurrentHashMap<>());
+
+        SecretKey actual = schedulerCache.get(COLLECTION_ID);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testGet_entryNotInCache_shouldReturnNull() throws Exception {
+        schedulerCache = new LegacySchedulerKeyCache(new ConcurrentHashMap<String, SecretKey>() {{
+            put("1234", secretKey);
+        }});
+
+        SecretKey actual = schedulerCache.get(COLLECTION_ID);
+
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testGet_entryExists_shouldReturnKey() throws Exception {
+        SecretKey actual = schedulerCache.get(COLLECTION_ID);
+
+        assertThat(actual, equalTo(secretKey));
+    }
+
+    @Test
+    public void testPut_collectionIDNull_shouldThrowException() {
+        KeyringException ex = assertThrows(KeyringException.class, () -> schedulerCache.add(null, null));
+
+        assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY));
+    }
+
+    @Test
+    public void testAdd_collectionIDEmpty_shouldThrowException() {
+        ConcurrentHashMap<String, SecretKey> cache = new ConcurrentHashMap<>();
+        schedulerCache = new LegacySchedulerKeyCache(cache);
+
+        KeyringException ex = assertThrows(KeyringException.class, () -> schedulerCache.add("", null));
+
+        assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY));
+        assertTrue(cache.isEmpty());
+    }
+
+    @Test
+    public void testAdd_secretKeyNull_shouldThrowException() {
+        ConcurrentHashMap<String, SecretKey> cache = new ConcurrentHashMap<>();
+        schedulerCache = new LegacySchedulerKeyCache(cache);
+
+        KeyringException ex = assertThrows(KeyringException.class, () -> schedulerCache.add(COLLECTION_ID, null));
+
+        assertThat(ex.getMessage(), equalTo(SECRET_KEY_EMPTY));
+        assertTrue(cache.isEmpty());
+    }
+
+    @Test
+    public void testAdd_entryAlreadyExists_shouldReplace() throws Exception {
+        assertThat(secretKey, equalTo(cache.get(COLLECTION_ID)));
+
+        SecretKey newkey = mock(SecretKey.class);
+        schedulerCache.add(COLLECTION_ID, newkey);
+
+        assertThat(newkey, equalTo(cache.get(COLLECTION_ID)));
+        assertThat(cache.size(), equalTo(1));
+    }
+
+    @Test
+    public void testAdd_entryDoesNotAlreadyExists_shouldAddKey() throws Exception {
+        cache = new ConcurrentHashMap<>();
+        schedulerCache = new LegacySchedulerKeyCache(cache);
+
+        schedulerCache.add(COLLECTION_ID, secretKey);
+
+        assertThat(secretKey, equalTo(cache.get(COLLECTION_ID)));
+        assertThat(cache.size(), equalTo(1));
+    }
+}


### PR DESCRIPTION
### What

Refactor the existing scheduler cache. I've decoupled it from the legacy Keyring and implemented it behind a new interface and updated all existing uses of it to use the new interface. 

When we migrate to the new keyring we can swap the implementations without breaking any code.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
