### PR TITLE
Upgrade Guava to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,12 @@
                 <version>0.9.10</version>
             </dependency>
 
+            <!-- override the Guava version used by reflections and elasticsearch -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>30.1.1-jre</version>
+            </dependency>
 
             <!-- used in the Test builder project for timeseries random walk generation-->
             <dependency>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -166,12 +166,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-session-service-client-java</artifactId>
             <version>0.2.1</version>

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -56,16 +56,6 @@
             <version>2.1.1</version>
         </dependency>
 
-        <!-- Elasticsearch 2.1.1 uses guava 18 whereas reflections library uses 15.
-        This does not cause any problems on compile time but fails on runtime to init elasticsearch client.
-        That's why explicitly adding guava version 18-->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-
-
         <!-- Encryption -->
         <dependency>
             <groupId>com.github.onsdigital</groupId>


### PR DESCRIPTION
### What
Upgrade Guava to the latest version
- Maintain only one declaration of the dependency in the root POM
- Guava is used by both the reflections library and elasticsearch client.
- Fixes CVE's
   - https://nvd.nist.gov/vuln/detail/CVE-2020-8908
   - https://nvd.nist.gov/vuln/detail/CVE-2018-10237

### How to review
Sanity check changes

I have tested that the website search still builds when Zebedee starts, and that the website search works.
I have also tested that pages still load via Zebedee, as the page type is determined using the reflactions library.

### Who can review
Anyone
