### PR TITLE
added unit tests for alerter

### DIFF
--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -177,6 +177,12 @@
             <version>0.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-slack-client-java</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -273,10 +273,6 @@ public class Zebedee {
         Files.delete(path);
     }
 
-    public void notifyQueueUnlocked(Session session) throws IOException {
-
-    }
-
     /**
      * Open a user session
      * <p>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -27,7 +27,6 @@ import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.service.UsersService;
-import com.github.onsdigital.zebedee.util.slack.PostMessage;
 import com.github.onsdigital.zebedee.util.slack.StartUpAlerter;
 import com.github.onsdigital.zebedee.verification.VerificationAgent;
 
@@ -37,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.github.onsdigital.zebedee.configuration.Configuration.isVerificationEnabled;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.beingEditedByAnotherCollectionError;
@@ -47,10 +45,6 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 
 public class Zebedee {
-
-    private static final AtomicBoolean QUEUE_LOCKED = new AtomicBoolean(true);
-    private static PostMessage startupMessage = null;
-
     public static final String PUBLISHED = "master";
     public static final String COLLECTIONS = "collections";
     public static final String PUBLISHED_COLLECTIONS = "publish-log";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -5,6 +5,9 @@ import com.github.onsdigital.dp.image.api.client.ImageClient;
 import com.github.onsdigital.session.service.client.Http;
 import com.github.onsdigital.session.service.client.SessionClient;
 import com.github.onsdigital.session.service.client.SessionClientImpl;
+import com.github.onsdigital.slack.Profile;
+import com.github.onsdigital.slack.client.SlackClient;
+import com.github.onsdigital.slack.client.SlackClientImpl;
 import com.github.onsdigital.zebedee.data.processing.DataIndex;
 import com.github.onsdigital.zebedee.keyring.CentralKeyringImpl;
 import com.github.onsdigital.zebedee.keyring.Keyring;
@@ -44,6 +47,8 @@ import com.github.onsdigital.zebedee.teams.store.TeamsStoreFileSystemImpl;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import com.github.onsdigital.zebedee.user.service.UsersServiceImpl;
 import com.github.onsdigital.zebedee.user.store.UserStoreFileSystemImpl;
+import com.github.onsdigital.zebedee.util.slack.StartUpAlerter;
+import com.github.onsdigital.zebedee.util.slack.StartUpAlerterImpl;
 import com.github.onsdigital.zebedee.util.versioning.VersionsService;
 import com.github.onsdigital.zebedee.util.versioning.VersionsServiceImpl;
 import com.github.onsdigital.zebedee.verification.VerificationAgent;
@@ -76,6 +81,7 @@ import static com.github.onsdigital.zebedee.configuration.Configuration.getKeyri
 import static com.github.onsdigital.zebedee.configuration.Configuration.getKeyringSecretKey;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getServiceAuthToken;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getSessionsApiUrl;
+import static com.github.onsdigital.zebedee.configuration.Configuration.slackChannelsToNotfiyOnStartUp;
 import static com.github.onsdigital.zebedee.permissions.store.PermissionsStoreFileSystemImpl.initialisePermissions;
 
 /**
@@ -115,6 +121,7 @@ public class ZebedeeConfiguration {
     private Keyring collectionKeyring;
     private SchedulerKeyCache schedulerKeyCache;
     private EncryptionKeyFactory encryptionKeyFactory;
+    private StartUpAlerter startUpAlerter;
 
 
     /**
@@ -221,6 +228,14 @@ public class ZebedeeConfiguration {
         }
 
         imageService = new ImageServiceImpl(imageClient);
+
+        SlackClient slackClient = new SlackClientImpl(new Profile.Builder()
+                .emoji(":flo:")
+                .username("Florence")
+                .authToken(System.getenv("slack_api_token"))
+                .create());
+
+        startUpAlerter = new StartUpAlerterImpl(slackClient, slackChannelsToNotfiyOnStartUp());
 
         info().data("root_path", rootPath.toString())
                 .data("zebedee_path", zebedeePath.toString())
@@ -404,5 +419,9 @@ public class ZebedeeConfiguration {
             Files.createDirectory(dir);
         }
         return dir;
+    }
+
+    public StartUpAlerter getStartUpAlerter() {
+        return this.startUpAlerter;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -122,7 +122,7 @@ public class Root {
         System.setProperty(ZEBEDEE_ROOT, root.toString());
 
         final SlackNotifier notifier = new SlackNotifier();
-        notifier.alarm("Zebedee has just started. Ensure an administrator has logged in.");
+        zebedee.getStartUpAlerter().queueLocked();
 
         try {
             Collections.CollectionList collections = zebedee.getCollections().list();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -92,6 +92,15 @@ public class Configuration {
         return StringUtils.defaultIfBlank(getValue("SLACK_USERNAME"), DEFAULT_SLACK_USERNAME);
     }
 
+    public static List<String> slackChannelsToNotfiyOnStartUp() {
+        String val = getValue("START_UP_NOTIFY_LIST");
+        if (StringUtils.isEmpty(val)) {
+            return new ArrayList<>();
+        }
+
+        return Arrays.asList(val.split(","));
+    }
+
     public static String getMathjaxServiceUrl() {
         return StringUtils.defaultIfBlank(getValue("MATHJAX_SERVICE_URL"), MATHJAX_SERVICE_URL);
     }
@@ -175,7 +184,9 @@ public class Configuration {
         return StringUtils.defaultIfBlank(getValue("db_audit_password"), "");
     }
 
-    public static String getSessionsApiUrl() { return StringUtils.defaultIfBlank(getValue("SESSIONS_API_URL"), SESSIONS_API_URL); }
+    public static String getSessionsApiUrl() {
+        return StringUtils.defaultIfBlank(getValue("SESSIONS_API_URL"), SESSIONS_API_URL);
+    }
 
     /**
      * Get collection keyring encryption key

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerter.java
@@ -1,0 +1,18 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+/**
+ * Defines a CMS start up alerter.
+ */
+public interface StartUpAlerter {
+
+    /**
+     * Send an alert to inform users the CMS as started up and requires and Admin user to login to unlock the
+     * publoshing queue.
+     */
+    void queueLocked();
+
+    /**
+     * Update the pervious alert setting the status to resolved.
+     */
+    void queueUnlocked();
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -1,0 +1,100 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.slack.Profile;
+import com.github.onsdigital.slack.client.PostMessageResponse;
+import com.github.onsdigital.slack.client.SlackClient;
+import com.github.onsdigital.slack.messages.Colour;
+import com.github.onsdigital.slack.messages.PostMessage;
+import com.github.onsdigital.slack.messages.PostMessageAttachment;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static java.text.MessageFormat.format;
+
+/**
+ * Called on CMS start up/first admin login after start up. Sends Slack alerts to the configured channels to notify the
+ * dev/publishing teams the CMS has started up and requires an admin user to log in/and to resolve this warning.
+ */
+public class StartUpAlerterImpl implements StartUpAlerter {
+
+    private static final Object MUTEX = new Object();
+
+    private SlackClient slack;
+    private boolean queueLocked;
+    private boolean lockedNotificationSent;
+    private List<PostMessage> messages;
+    private List<String> channels;
+
+    /**
+     * Create a new instabce of the alerter.
+     *
+     * @param slack    the {@link SlackClient} to use.
+     * @param channels the Slack channels to send the alerts to.
+     */
+    public StartUpAlerterImpl(SlackClient slack, List<String> channels) {
+        this(slack, channels, true, false);
+    }
+
+    StartUpAlerterImpl(SlackClient slack, List<String> channels, boolean queueLocked,
+                       boolean lockedNotificationSent) {
+        this.slack = slack;
+        this.channels = channels;
+        this.queueLocked = queueLocked;
+        this.lockedNotificationSent = lockedNotificationSent;
+        this.messages = new ArrayList<>();
+    }
+
+    @Override
+    public void queueLocked() {
+        synchronized (MUTEX) {
+            if (queueLocked && !lockedNotificationSent) {
+                channels.stream().forEach(c -> messages.add(publishingQueueLocked(c)));
+                this.lockedNotificationSent = true;
+            }
+        }
+    }
+
+    @Override
+    public void queueUnlocked() {
+        synchronized (MUTEX) {
+            if (queueLocked && lockedNotificationSent) {
+                if (messages == null || messages.isEmpty()) {
+                    throw new RuntimeException("failed to send publish queue unlocked notification original message " +
+                            "expected but was null");
+                }
+
+                messages.stream()
+                        .forEach(msg -> publishingQueueUnlocked(msg));
+                this.queueLocked = false;
+            }
+        }
+    }
+
+    private PostMessage publishingQueueLocked(String channel) {
+        Profile profile = slack.getProfile();
+
+        PostMessage msg = profile
+                .newPostMessage(channel, "Publishing system restart complete")
+                .addAttachment(new PostMessageAttachment(
+                        "Administrator log in required",
+                        "Please log out of any existing session and log in again to unlock the publishing queue.",
+                        Colour.WARNING
+                ));
+
+        PostMessageResponse response = slack.sendMessage(msg);
+        msg.ts(response.getTs()).channel(response.getChannel());
+        return msg;
+    }
+
+    private void publishingQueueUnlocked(PostMessage messageToUpdate) {
+        messageToUpdate.getAttachments().get(0).setColor(Colour.GOOD.getColor());
+
+        String msg = format(("Publishing queue successfully unlocked `{0}`"), new Date().toString());
+        messageToUpdate.addAttachment(new PostMessageAttachment("Resolved", msg, Colour.GOOD));
+
+        slack.updateMessage(messageToUpdate);
+    }
+
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -28,7 +28,7 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     private List<String> channels;
 
     /**
-     * Create a new instabce of the alerter.
+     * Create a new instance of the alerter.
      *
      * @param slack    the {@link SlackClient} to use.
      * @param channels the Slack channels to send the alerts to.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -417,6 +417,9 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         when(user.keyring())
                 .thenReturn(usersKeyring);
 
+        when(permissionsService.isAdministrator(any(Session.class)))
+                .thenReturn(true);
+
         Zebedee zebedee = new Zebedee(zebCfg);
 
         // When openSession is called
@@ -431,5 +434,7 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         // And the keyring is unlocked and cached
         verify(collectionKeyring, times(1)).unlock(user, PASSWORD);
         verify(collectionKeyring, times(1)).cacheKeyring(user);
+
+        verify(startUpAlerter, times(1)).queueUnlocked();
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -17,6 +17,7 @@ import com.github.onsdigital.zebedee.session.service.SessionsAPIServiceImpl;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import com.github.onsdigital.zebedee.user.service.UsersService;
+import com.github.onsdigital.zebedee.util.slack.StartUpAlerter;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -93,6 +94,9 @@ public abstract class ZebedeeTestBaseFixture {
 
     @Mock
     protected EncryptionKeyFactory encryptionKeyFactory;
+
+    @Mock
+    protected StartUpAlerter startUpAlerter;
 
     protected Zebedee zebedee;
     protected Builder builder;
@@ -185,6 +189,12 @@ public abstract class ZebedeeTestBaseFixture {
 
         when(zebCfg.getCollectionKeyring())
                 .thenReturn(collectionKeyring);
+
+        when(zebCfg.getStartUpAlerter())
+                .thenReturn(startUpAlerter);
+
+        when(zebCfg.getPermissionsService())
+                .thenReturn(permissionsService);
     }
 
     protected void verifyKeyAddedToCollectionKeyring() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
@@ -57,7 +57,7 @@ public class StartUpAlerterImplTest {
     }
 
     @Test
-    public void testNotifyLocked_success() throws Exception {
+    public void testNotifyLocked_success_shouldSendAlerts() throws Exception {
         when(slackClient.getProfile())
                 .thenReturn(profile);
 
@@ -100,7 +100,7 @@ public class StartUpAlerterImplTest {
     }
 
     @Test
-    public void testNotifyLocked_notifyError() throws Exception {
+    public void testNotifyLocked_notifyError_shouldThrowEx() throws Exception {
         when(slackClient.getProfile())
                 .thenReturn(profile);
 
@@ -225,7 +225,7 @@ public class StartUpAlerterImplTest {
     }
 
     @Test
-    public void testNotifyUnlocked_success_shouldSendMessages() throws Exception {
+    public void testNotifyUnlocked_success_shouldSendAlerts() throws Exception {
         channels = new ArrayList<>();
         channels.add("chan-A");
         alerter = new StartUpAlerterImpl(slackClient, channels, true, true);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
@@ -1,0 +1,261 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.slack.Profile;
+import com.github.onsdigital.slack.client.PostMessageResponse;
+import com.github.onsdigital.slack.client.SlackClient;
+import com.github.onsdigital.slack.messages.Colour;
+import com.github.onsdigital.slack.messages.PostMessage;
+import com.github.onsdigital.slack.messages.PostMessageAttachment;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class StartUpAlerterImplTest {
+
+    @Mock
+    private SlackClient slackClient;
+
+    @Mock
+    private Profile profile;
+
+    @Mock
+    private PostMessage postMessage;
+
+    @Mock
+    private PostMessageResponse messageResponse;
+
+    private StartUpAlerter alerter;
+    private List<String> channels;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        channels = new ArrayList<>();
+        channels.add("chan-A");
+        channels.add("chan-B");
+
+        alerter = new StartUpAlerterImpl(slackClient, channels);
+    }
+
+    @Test
+    public void testNotifyLocked_success() throws Exception {
+        when(slackClient.getProfile())
+                .thenReturn(profile);
+
+        when(profile.newPostMessage(any(), any()))
+                .thenReturn(postMessage);
+
+        when(postMessage.addAttachment(any()))
+                .thenReturn(postMessage);
+
+        when(slackClient.sendMessage(any(PostMessage.class)))
+                .thenReturn(messageResponse);
+
+        when(slackClient.sendMessage(postMessage))
+                .thenReturn(messageResponse);
+
+        when(messageResponse.getTs())
+                .thenReturn("time.now");
+
+        when(postMessage.ts(any()))
+                .thenReturn(postMessage);
+
+        when(postMessage.channel(any()))
+                .thenReturn(postMessage);
+
+        ArgumentCaptor<PostMessageAttachment> captor = ArgumentCaptor.forClass(PostMessageAttachment.class);
+
+        alerter.queueLocked();
+
+        verify(profile, times(1)).newPostMessage("chan-A", "Publishing system restart complete");
+        verify(profile, times(1)).newPostMessage("chan-B", "Publishing system restart complete");
+        verify(postMessage, times(2)).addAttachment(captor.capture());
+
+        assertThat(captor.getAllValues().size(), equalTo(2));
+
+        captor.getAllValues().stream().forEach(attch -> {
+            assertThat(attch.getTitle(), equalTo("Administrator log in required"));
+            assertThat(attch.getText(), equalTo("Please log out of any existing session and log in again to unlock the publishing queue."));
+            assertThat(attch.getColor(), equalTo(Colour.WARNING.getColor()));
+        });
+    }
+
+    @Test
+    public void testNotifyLocked_notifyError() throws Exception {
+        when(slackClient.getProfile())
+                .thenReturn(profile);
+
+        when(profile.newPostMessage(any(), any()))
+                .thenReturn(postMessage);
+
+        when(postMessage.addAttachment(any()))
+                .thenReturn(postMessage);
+
+        when(slackClient.sendMessage(any(PostMessage.class)))
+                .thenReturn(messageResponse);
+
+        when(slackClient.sendMessage(any()))
+                .thenThrow(RuntimeException.class);
+
+        assertThrows(RuntimeException.class, () -> alerter.queueLocked());
+
+        verify(slackClient, times(1)).sendMessage(any());
+    }
+
+    @Test
+    public void testNotifyLocked_alreadySent_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, true);
+
+        alerter.queueLocked();
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifyLocked_queueNotLocked_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, false, true);
+
+        alerter.queueLocked();
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifyLocked_noChannelsConfigured_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, new ArrayList<>(), true, false);
+
+        alerter.queueLocked();
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifylocked_originalMessageNull_shouldThrowEx() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, null, true, true);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> alerter.queueUnlocked());
+
+        assertThat(ex.getMessage(), equalTo("failed to send publish queue unlocked notification original message " +
+                "expected but was null"));
+
+        verifyZeroInteractions(slackClient);
+    }
+
+
+    @Test
+    public void testNotifyUnlocked_queueNotLocked_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, false, true);
+
+        alerter.queueUnlocked();
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifyUnlocked_lockedNotificationHasNotBeenSent_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, false);
+
+        alerter.queueUnlocked();
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifyUnlocked_originalMessagesNull_shouldThrowEx() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, true);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> alerter.queueUnlocked());
+        assertThat(ex.getMessage(), equalTo("failed to send publish queue unlocked notification original message " +
+                "expected but was null"));
+
+        verifyZeroInteractions(slackClient);
+    }
+
+    @Test
+    public void testNotifyUnlocked_sendMessageError_shouldThrowEx() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, true);
+
+        List<PostMessage> messages = new ArrayList<PostMessage>() {{
+            add(postMessage);
+            add(postMessage);
+        }};
+        ReflectionTestUtils.setField(alerter, "messages", messages);
+
+        when(slackClient.getProfile())
+                .thenReturn(profile);
+
+        when(postMessage.getAttachments())
+                .thenReturn(new ArrayList<PostMessageAttachment>() {{
+                    add(mock(PostMessageAttachment.class));
+                }});
+
+        when(slackClient.updateMessage(postMessage))
+                .thenThrow(RuntimeException.class);
+
+        assertThrows(RuntimeException.class, () -> alerter.queueUnlocked());
+
+        verify(slackClient, times(1)).updateMessage(any(PostMessage.class));
+
+        ArgumentCaptor<PostMessageAttachment> captor = ArgumentCaptor.forClass(PostMessageAttachment.class);
+        verify(postMessage, times(1)).addAttachment(captor.capture());
+
+        PostMessageAttachment attachment = captor.getValue();
+        assertThat(attachment.getTitle(), equalTo("Resolved"));
+        assertThat(attachment.getColor(), equalTo(Colour.GOOD.getColor()));
+        assertTrue(StringUtils.startsWith(attachment.getText(), "Publishing queue successfully unlocked `"));
+    }
+
+    @Test
+    public void testNotifyUnlocked_success_shouldSendMessages() throws Exception {
+        channels = new ArrayList<>();
+        channels.add("chan-A");
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, true);
+
+        PostMessage originalMessage = new PostMessage();
+        List<PostMessage> messages = new ArrayList<PostMessage>() {{
+            add(originalMessage);
+        }};
+        ReflectionTestUtils.setField(alerter, "messages", messages);
+
+        when(slackClient.getProfile())
+                .thenReturn(profile);
+
+        PostMessageAttachment originalAttachment = new PostMessageAttachment("", "", Colour.WARNING);
+        originalMessage.addAttachment(originalAttachment);
+
+        alerter.queueUnlocked();
+
+        ArgumentCaptor<PostMessage> captor = ArgumentCaptor.forClass(PostMessage.class);
+        verify(slackClient, times(1)).updateMessage(captor.capture());
+
+        List<PostMessage> updatedMessages = captor.getAllValues();
+        assertThat(updatedMessages.size(), equalTo(1));
+
+        updatedMessages.stream().forEach(msg -> {
+            assertThat(msg.getAttachments().size(), equalTo(2));
+            PostMessageAttachment attachment = msg.getAttachments().get(1);
+            assertThat(attachment.getColor(), equalTo(Colour.GOOD.getColor()));
+            assertThat(attachment.getTitle(), equalTo("Resolved"));
+            assertTrue(StringUtils.startsWith(attachment.getText(), "Publishing queue successfully unlocked `"));
+        });
+    }
+}


### PR DESCRIPTION
### What
Updated the Slack alerts on start up.

- When the CMS starts up it will send a notification to slack requesting an admin user login to unlock the publishing queue. 
- The first time an admin user logs in this alert will be updated and marked resolved.

I've also made the channels configurable so we can send messages to PST and the Dev team. I think it makes sense for PST to see this as they will have to respond to it.

### On start up
<img width="522" alt="Screenshot 2021-05-07 at 11 09 12" src="https://user-images.githubusercontent.com/14196957/117435410-be857480-af25-11eb-8e22-0ae92a6db69a.png">

### After admin login
<img width="527" alt="Screenshot 2021-05-07 at 11 09 30" src="https://user-images.githubusercontent.com/14196957/117435423-c0e7ce80-af25-11eb-8aec-aa20d055021f.png">
