### PR TITLE
Added noop StartUpAlerterImpl as default impl

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -64,6 +64,7 @@ import java.util.List;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 import static com.github.onsdigital.zebedee.Zebedee.APPLICATION_KEYS;
 import static com.github.onsdigital.zebedee.Zebedee.COLLECTIONS;
 import static com.github.onsdigital.zebedee.Zebedee.KEYRING;
@@ -275,6 +276,7 @@ public class ZebedeeConfiguration {
         List<String> startUpNotificationRecipients = slackChannelsToNotfiyOnStartUp();
 
         if (startUpNotificationRecipients == null || startUpNotificationRecipients.isEmpty()) {
+            warn().log("startUpNotificationRecipients was null or empty NoOpStartUpAlerter will be initialized.");
             return new NoOpStartUpAlerter();
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NoOpStartUpAlerter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NoOpStartUpAlerter.java
@@ -14,6 +14,6 @@ public class NoOpStartUpAlerter implements StartUpAlerter {
 
     @Override
     public void queueUnlocked() {
-        info().log("NoOpStartUpAlerter queueUnlocked invoked - - do nothing");
+        info().log("NoOpStartUpAlerter queueUnlocked invoked - do nothing");
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NoOpStartUpAlerter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NoOpStartUpAlerter.java
@@ -1,0 +1,19 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+
+/**
+ * No Op impl of StartUpAlerter.
+ */
+public class NoOpStartUpAlerter implements StartUpAlerter {
+
+    @Override
+    public void queueLocked() {
+        info().log("NoOpStartUpAlerter queueLocked invoked - do nothing");
+    }
+
+    @Override
+    public void queueUnlocked() {
+        info().log("NoOpStartUpAlerter queueUnlocked invoked - - do nothing");
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -60,6 +60,10 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     public void queueUnlocked() {
         synchronized (MUTEX) {
             if (queueLocked && lockedNotificationSent) {
+                if (channels == null || channels.isEmpty()) {
+                    return;
+                }
+
                 if (messages == null || messages.isEmpty()) {
                     throw new RuntimeException("failed to send publish queue unlocked notification original message " +
                             "expected but was null");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -118,6 +118,7 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     /**
      * Create a {@link Callable} task to send a Slack message advising the CMS has restarted and requires an admin
      * user to login in.
+     *
      * @param channel the channel to send the message to.
      */
     Callable<PostMessage> newQueueLockedAlertTask(String channel) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -26,16 +26,14 @@ import static java.text.MessageFormat.format;
  */
 public class StartUpAlerterImpl implements StartUpAlerter {
 
+    private static final ExecutorService executorService = Executors.newFixedThreadPool(5);
     private static final Object MUTEX = new Object();
 
     private SlackClient slack;
     private boolean queueLocked;
-    private boolean lockedNotificationSent;
-
     private List<Callable<PostMessage>> queueLockedAlerts;
     private List<Callable<Void>> queueUnlockedAlerts;
 
-    private ExecutorService executorService = Executors.newFixedThreadPool(5);
 
     /**
      * Create a new instance of the alerter.
@@ -44,14 +42,12 @@ public class StartUpAlerterImpl implements StartUpAlerter {
      * @param channels the Slack channels to send the alerts to.
      */
     public StartUpAlerterImpl(SlackClient slack, List<String> channels) {
-        this(slack, channels, true, false);
+        this(slack, channels, true);
     }
 
-    StartUpAlerterImpl(SlackClient slack, List<String> channels, boolean queueLocked,
-                       boolean lockedNotificationSent) {
+    StartUpAlerterImpl(SlackClient slack, List<String> channels, boolean queueLocked) {
         this.slack = slack;
         this.queueLocked = queueLocked;
-        this.lockedNotificationSent = lockedNotificationSent;
 
         this.queueLockedAlerts = channels.stream()
                 .map(c -> newQueueLockedAlertTask(c))
@@ -60,7 +56,7 @@ public class StartUpAlerterImpl implements StartUpAlerter {
         this.queueUnlockedAlerts = new ArrayList<>();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            info().log("shutting down slack thread executor service");
+            info().log("shutting down Slack notification thread executor service");
             executorService.shutdown();
         }));
     }
@@ -68,17 +64,15 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     @Override
     public void queueLocked() {
         synchronized (MUTEX) {
-            if (queueLocked && !lockedNotificationSent) {
-
+            if (queueLocked && !queueLockedAlerts.isEmpty() && queueUnlockedAlerts.isEmpty()) {
                 List<Future<PostMessage>> futures = null;
                 try {
                     futures = executorService.invokeAll(queueLockedAlerts);
                 } catch (Exception ex) {
-                    error().exception(ex).log("error sending publishing queue locked slack notification");
+                    error().exception(ex).log("error invoking callable tasks for start up publishing queue locked " +
+                            "notification");
                     return;
                 }
-
-                this.lockedNotificationSent = true;
 
                 for (Future<PostMessage> result : futures) {
                     try {
@@ -87,7 +81,7 @@ public class StartUpAlerterImpl implements StartUpAlerter {
                             this.queueUnlockedAlerts.add(newQueueUnlockedAlertTask(msg));
                         }
                     } catch (Exception ex) {
-                        error().exception(ex).log("error sending publishing queue locked slack notification");
+                        error().exception(ex).log("error sending start up publishing queue locked notification");
                     }
                 }
             }
@@ -97,18 +91,15 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     @Override
     public void queueUnlocked() {
         synchronized (MUTEX) {
-            if (queueLocked && lockedNotificationSent) {
+            if (queueLocked && queueUnlockedAlerts != null && !queueUnlockedAlerts.isEmpty()) {
                 this.queueLocked = false;
-
-                if (queueUnlockedAlerts == null || queueUnlockedAlerts.isEmpty()) {
-                    return;
-                }
 
                 List<Future<Void>> futures;
                 try {
                     futures = executorService.invokeAll(queueUnlockedAlerts);
                 } catch (Exception ex) {
-                    error().exception(ex).log("error sending publishing queue locked slack notification");
+                    error().exception(ex).log("error invoking callable tasks for start up publishing queue unlocked " +
+                            "notification");
                     return;
                 }
 
@@ -119,10 +110,16 @@ public class StartUpAlerterImpl implements StartUpAlerter {
                         error().exception(ex).log("error sending publishing queue unlocked slack notification");
                     }
                 }
+                queueUnlockedAlerts.clear();
             }
         }
     }
 
+    /**
+     * Create a {@link Callable} task to send a Slack message advising the CMS has restarted and requires an admin
+     * user to login in.
+     * @param channel the channel to send the message to.
+     */
     Callable<PostMessage> newQueueLockedAlertTask(String channel) {
         return () -> {
             Profile profile = slack.getProfile();
@@ -132,8 +129,7 @@ public class StartUpAlerterImpl implements StartUpAlerter {
                     .addAttachment(new PostMessageAttachment(
                             "Administrator log in required",
                             "Please log out of any existing session and log in again to unlock the publishing queue.",
-                            Colour.WARNING
-                    ));
+                            Colour.WARNING));
 
             PostMessageResponse response = slack.sendMessage(msg);
             msg.ts(response.getTs()).channel(response.getChannel());
@@ -142,7 +138,12 @@ public class StartUpAlerterImpl implements StartUpAlerter {
         };
     }
 
-
+    /**
+     * Create a {@link Callable} task for sending a Slack message update informing that the publishing queue
+     * has been unlocked
+     *
+     * @param messageToUpdate the original message to update.
+     */
     Callable<Void> newQueueUnlockedAlertTask(PostMessage messageToUpdate) {
         return () -> {
             if (messageToUpdate.getAttachments() != null && !messageToUpdate.getAttachments().isEmpty()) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImpl.java
@@ -10,7 +10,14 @@ import com.github.onsdigital.slack.messages.PostMessageAttachment;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 import static java.text.MessageFormat.format;
 
 /**
@@ -24,8 +31,11 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     private SlackClient slack;
     private boolean queueLocked;
     private boolean lockedNotificationSent;
-    private List<PostMessage> messages;
-    private List<String> channels;
+
+    private List<Callable<PostMessage>> queueLockedAlerts;
+    private List<Callable<Void>> queueUnlockedAlerts;
+
+    private ExecutorService executorService = Executors.newFixedThreadPool(5);
 
     /**
      * Create a new instance of the alerter.
@@ -40,18 +50,46 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     StartUpAlerterImpl(SlackClient slack, List<String> channels, boolean queueLocked,
                        boolean lockedNotificationSent) {
         this.slack = slack;
-        this.channels = channels;
         this.queueLocked = queueLocked;
         this.lockedNotificationSent = lockedNotificationSent;
-        this.messages = new ArrayList<>();
+
+        this.queueLockedAlerts = channels.stream()
+                .map(c -> newQueueLockedAlertTask(c))
+                .collect(Collectors.toList());
+
+        this.queueUnlockedAlerts = new ArrayList<>();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            info().log("shutting down slack thread executor service");
+            executorService.shutdown();
+        }));
     }
 
     @Override
     public void queueLocked() {
         synchronized (MUTEX) {
             if (queueLocked && !lockedNotificationSent) {
-                channels.stream().forEach(c -> messages.add(publishingQueueLocked(c)));
+
+                List<Future<PostMessage>> futures = null;
+                try {
+                    futures = executorService.invokeAll(queueLockedAlerts);
+                } catch (Exception ex) {
+                    error().exception(ex).log("error sending publishing queue locked slack notification");
+                    return;
+                }
+
                 this.lockedNotificationSent = true;
+
+                for (Future<PostMessage> result : futures) {
+                    try {
+                        PostMessage msg = result.get();
+                        if (msg != null) {
+                            this.queueUnlockedAlerts.add(newQueueUnlockedAlertTask(msg));
+                        }
+                    } catch (Exception ex) {
+                        error().exception(ex).log("error sending publishing queue locked slack notification");
+                    }
+                }
             }
         }
     }
@@ -60,45 +98,63 @@ public class StartUpAlerterImpl implements StartUpAlerter {
     public void queueUnlocked() {
         synchronized (MUTEX) {
             if (queueLocked && lockedNotificationSent) {
-                if (channels == null || channels.isEmpty()) {
+                this.queueLocked = false;
+
+                if (queueUnlockedAlerts == null || queueUnlockedAlerts.isEmpty()) {
                     return;
                 }
 
-                if (messages == null || messages.isEmpty()) {
-                    throw new RuntimeException("failed to send publish queue unlocked notification original message " +
-                            "expected but was null");
+                List<Future<Void>> futures;
+                try {
+                    futures = executorService.invokeAll(queueUnlockedAlerts);
+                } catch (Exception ex) {
+                    error().exception(ex).log("error sending publishing queue locked slack notification");
+                    return;
                 }
 
-                messages.stream()
-                        .forEach(msg -> publishingQueueUnlocked(msg));
-                this.queueLocked = false;
+                for (Future<Void> result : futures) {
+                    try {
+                        result.get();
+                    } catch (Exception ex) {
+                        error().exception(ex).log("error sending publishing queue unlocked slack notification");
+                    }
+                }
             }
         }
     }
 
-    private PostMessage publishingQueueLocked(String channel) {
-        Profile profile = slack.getProfile();
+    Callable<PostMessage> newQueueLockedAlertTask(String channel) {
+        return () -> {
+            Profile profile = slack.getProfile();
 
-        PostMessage msg = profile
-                .newPostMessage(channel, "Publishing system restart complete")
-                .addAttachment(new PostMessageAttachment(
-                        "Administrator log in required",
-                        "Please log out of any existing session and log in again to unlock the publishing queue.",
-                        Colour.WARNING
-                ));
+            PostMessage msg = profile
+                    .newPostMessage(channel, "Publishing system restart complete")
+                    .addAttachment(new PostMessageAttachment(
+                            "Administrator log in required",
+                            "Please log out of any existing session and log in again to unlock the publishing queue.",
+                            Colour.WARNING
+                    ));
 
-        PostMessageResponse response = slack.sendMessage(msg);
-        msg.ts(response.getTs()).channel(response.getChannel());
-        return msg;
+            PostMessageResponse response = slack.sendMessage(msg);
+            msg.ts(response.getTs()).channel(response.getChannel());
+
+            return msg;
+        };
     }
 
-    private void publishingQueueUnlocked(PostMessage messageToUpdate) {
-        messageToUpdate.getAttachments().get(0).setColor(Colour.GOOD.getColor());
 
-        String msg = format(("Publishing queue successfully unlocked `{0}`"), new Date().toString());
-        messageToUpdate.addAttachment(new PostMessageAttachment("Resolved", msg, Colour.GOOD));
+    Callable<Void> newQueueUnlockedAlertTask(PostMessage messageToUpdate) {
+        return () -> {
+            if (messageToUpdate.getAttachments() != null && !messageToUpdate.getAttachments().isEmpty()) {
+                messageToUpdate.getAttachments().get(0).setColor(Colour.GOOD.getColor());
+            }
 
-        slack.updateMessage(messageToUpdate);
+            String msg = format(("Publishing queue successfully unlocked `{0}`"), new Date().toString());
+            messageToUpdate.addAttachment(new PostMessageAttachment("Resolved", msg, Colour.GOOD));
+
+            slack.updateMessage(messageToUpdate);
+            return null;
+        };
     }
 
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/slack/StartUpAlerterImplTest.java
@@ -149,8 +149,8 @@ public class StartUpAlerterImplTest {
     }
 
     @Test
-    public void testNotifylocked_originalMessageNull_shouldThrowEx() throws Exception {
-        alerter = new StartUpAlerterImpl(slackClient, null, true, true);
+    public void testNotifylocked_originalMessageNull_shouldDoNothing() throws Exception {
+        alerter = new StartUpAlerterImpl(slackClient, channels, true, true);
 
         RuntimeException ex = assertThrows(RuntimeException.class, () -> alerter.queueUnlocked());
 


### PR DESCRIPTION
### What

- Added a No Op StartUpAlerterImpl to use as default if no config is provided. 
- Refactor StartUpAlerter to log exceptions instead of throwing them. If the alert fails the CMS will now continue to function.
- Refactored StartUpAlerter to be more resilient to error scenarios. Logs errors instead of throwing exceptions to offer degraded functionality over total loss of functionality.