### PR TITLE
bugfix - Allows deleting visualisations

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1175,7 +1175,7 @@ public class Collection {
 
         String visualisationZipUri = contentPath.getParent().toString();
         if (visualisationZipUri == null || StringUtils.isEmpty(visualisationZipUri)){
-            info().data("zip", visualisationZipUri).log("unable to delete visualisation")
+            info().data("zip", visualisationZipUri).log("unable to delete visualisation");
             return false;
         }
         String dataJsonUri = resolveDataVizDataJsonURI(contentPath);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1169,13 +1169,13 @@ public class Collection {
     }
 
     public boolean deleteDataVisContent(Session session, Path contentPath) throws IOException {
-        if (contentPath == null || StringUtils.isEmpty(contentPath.toString())) {
+        if (StringUtils.isEmpty(contentPath.toString())) {
             return false;
         }
 
         String visualisationZipUri = contentPath.getParent().toString();
-        if (visualisationZipUri == null || StringUtils.isEmpty(visualisationZipUri)){
-            info().data("zip", visualisationZipUri).log("unable to delete visualisation");
+        if (StringUtils.isEmpty(visualisationZipUri)){
+            info().data("zip", visualisationZipUri).log("unable to delete visualisation. Path provided was null/empty");
             return false;
         }
         String dataJsonUri = resolveDataVizDataJsonURI(contentPath);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1174,6 +1174,10 @@ public class Collection {
         }
 
         String visualisationZipUri = contentPath.getParent().toString();
+        if (visualisationZipUri == null || StringUtils.isEmpty(visualisationZipUri)){
+            info().data("zip", visualisationZipUri).log("unable to delete visualisation")
+            return false;
+        }
         String dataJsonUri = resolveDataVizDataJsonURI(contentPath);
         boolean hasDeleted = false;
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1173,7 +1173,7 @@ public class Collection {
             return false;
         }
 
-        String visualisationZipUri = contentPath.toString();
+        String visualisationZipUri = contentPath.getParent().toString();
         String dataJsonUri = resolveDataVizDataJsonURI(contentPath);
         boolean hasDeleted = false;
 


### PR DESCRIPTION
### What

Currently there is a bug that does not allow you to delete visualisations. It tries to delete the directory for the visualisation, but the path tha is passed in is for a file (/data.json). 

This PR ensures that the visualisation folder is removed.

### How to review
Check that the code change makes sense

- run the publishing stack
- create collection --> create/edit content --> Old workspace --> visualisations (in Browse) --> click upload visualisation --> enter a unique id and page name, then create page --> Click Visualistion (file upload - it must be a zip file) then save and submit for review.
- click on the visualisation that is now awaiting for review --> Delete --> OK
If no errors appear, it's worked. 
You can double check that the folder has been deleted from `dp-zebedee-content`

### Who can review

anyone
