### PR TITLE
fix delete zip defect

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DataVisualisationZip.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DataVisualisationZip.java
@@ -150,7 +150,7 @@ public class DataVisualisationZip {
             throw new BadRequestException(NO_ZIP_PATH_ERROR_MSG);
         }
 
-        info().data("zipPath", zipPath).log(DELETING_ZIP_DEBUG);
+        info().data("zipPath", zipPath).log(UNZIP_DEBUG);
 
         Session session = zebedeeCmsService.getSession(request);
         com.github.onsdigital.zebedee.model.Collection collection = zebedeeCmsService.getCollection(request);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DataVisualisationZip.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/DataVisualisationZip.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -180,15 +181,18 @@ public class DataVisualisationZip {
             ZipEntry zipEntry = zipInputStream.getNextEntry();
             Path filePath;
 
+            List<String> filesWritten = new ArrayList<>();
             while (zipEntry != null) {
 
                 if (isValidDataVisContentFile.test(zipEntry)) {
                     filePath = zipDir.resolve(zipEntry.getName());
                     contentWriter.write(zipInputStream, filePath.toString());
-                    info().data("zipPath", zipPath).log(DELETING_ZIP_DEBUG);
+                    filesWritten.add(filePath.toString());
                 }
                 zipEntry = zipInputStream.getNextEntry();
             }
+
+            info().data("files", filesWritten).log(UNZIP_SUCCESS_DEBUG);
 
         } catch (IOException e) {
             error().data("zipPath", zipPath).logException(e, UNZIPPING_ERROR_MSG);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1167,7 +1167,7 @@ public class Collection {
             return false;
         }
 
-        String visualisationZipUri = resolveDataVizZipURI(contentPath);
+        String visualisationZipUri = resolveParentURI(contentPath);
         String dataJsonUri = resolveDataVizDataJsonURI(contentPath);
         boolean hasDeleted = false;
 
@@ -1208,13 +1208,8 @@ public class Collection {
     }
 
     /**
-     * Get the path of the data viz zip file to delete.
-     * Deleteing a data viz zip is a different process to deleting standard CMS content. Deleting standard CMS
-     * content means deleteing a file so the path to delete will always be a path to a data.json file. However, when
-     * deleteing a data viz zip we have to delete the page (data.json file) and the directory containig the data viz
-     * zip content. We therefore need a path to the parent directory of the data.json file.
+     * Returns the parent path of a URI if the provided URI is a data.json file, otherwise returns the input URI.
      * <p>
-     * This method will return a path to the parent dir if the uri is a data.json file.
      * Example:
      * If uri is "a/b/c/data.json" then it will return "a/b/c".
      *
@@ -1222,7 +1217,7 @@ public class Collection {
      *
      * @param uri the file path to check.
      */
-    private String resolveDataVizZipURI(Path uri) {
+    private String resolveParentURI(Path uri) {
         String zipPath = uri.toString();
         if (DATA_JSON.equals(uri.getFileName().toString()) && uri.getParent() != null && !uri.getParent().equals("/")) {
             zipPath = uri.getParent().toString();


### PR DESCRIPTION
### What

Fix defect deleting data viz pages/zips.

Deleting standard content from the CMS requires a path to the file being deleted - a `data.json` file . However, data viz content is a special case and requires a different approach.

When deleting a data viz page or zip file we need to delete a directory not just a single file so the URI need to be for the **parent directory of the content being deleted**. 

This fix updates the logic generating the filepath to delete if the path points to a data.json file we return the parent dir instead (i.e. the directory the data.json lives in).

Example: 
If URI is `/a/b/c/data.json` the path to delete is `/a/b/c`.
