### PR TITLE
fix central keyring list method to return the correct keys for viewer…

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.interfaces.JWTHandler;
 import com.github.onsdigital.slack.Profile;
 import com.github.onsdigital.slack.client.SlackClient;
 import com.github.onsdigital.slack.client.SlackClientImpl;
+import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
 import com.github.onsdigital.zebedee.data.processing.DataIndex;
 import com.github.onsdigital.zebedee.kafka.KafkaClient;
 import com.github.onsdigital.zebedee.kafka.KafkaClientImpl;
@@ -274,7 +275,7 @@ public class ZebedeeConfiguration {
             KeyringCacheImpl.init(keyStore);
             KeyringCache keyringCache = KeyringCacheImpl.getInstance();
 
-            CentralKeyringImpl.init(keyringCache, permissionsService);
+            CentralKeyringImpl.init(keyringCache, permissionsService, collections);
             centralKeyring = CentralKeyringImpl.getInstance();
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImpl.java
@@ -192,7 +192,9 @@ public class KeyringMigratorImpl implements Keyring {
     @Override
     public void unlock(User user, String password) throws KeyringException {
         try {
-            getKeyring().unlock(user, password);
+            // The central keyring does not need to be unlocked. While migrating we only need to unlock the legacy
+            // keyring.
+            legacyKeyring.unlock(user, password);
         } catch (KeyringException ex) {
             throw wrappedKeyringException(ex, UNLOCK_KEYRING_ERR);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -251,6 +252,17 @@ public class Collections {
         }
 
         return result;
+    }
+
+    /**
+     * Returns a {@link List} of {@link Collection} matching the provided {@link Predicate} filter criteria.
+     *
+     * @param f the filter to apply
+     * @return
+     * @throws IOException problem listing the collections
+     */
+    public List<Collection> filterBy(Predicate<Collection> f) throws IOException {
+        return list().stream().filter(f).collect(Collectors.toList());
     }
 
     public List<String> listOrphaned() throws IOException {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/KeyringMigratorImplTest.java
@@ -796,7 +796,7 @@ public class KeyringMigratorImplTest {
     }
 
     @Test
-    public void unlock_migrateEnabled_shouldCallCentralKeyringUnlock() throws Exception {
+    public void unlock_migrateEnabled_shouldCallLegacyKeyringOnly() throws Exception {
         // Given migrate is enabled
         keyring = new KeyringMigratorImpl(enabled, legacyKeyring, centralKeyring);
 
@@ -804,8 +804,8 @@ public class KeyringMigratorImplTest {
         keyring.unlock(user, "1234");
 
         // Then central keyring is unlocked
-        verify(centralKeyring, times(1)).unlock(user, "1234");
-        verifyZeroInteractions(legacyKeyring);
+        verify(legacyKeyring, times(1)).unlock(user, "1234");
+        verifyZeroInteractions(centralKeyring);
     }
 
     @Test
@@ -839,7 +839,7 @@ public class KeyringMigratorImplTest {
         String password = "1234";
 
         doThrow(KeyringException.class)
-                .when(centralKeyring)
+                .when(legacyKeyring)
                 .unlock(user, password);
 
         // When unlocked is called
@@ -848,8 +848,8 @@ public class KeyringMigratorImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, UNLOCK_KEYRING_ERR, enabled);
 
-        verify(centralKeyring, times(1)).unlock(user, password);
-        verifyZeroInteractions(legacyKeyring);
+        verify(legacyKeyring, times(1)).unlock(user, password);
+        verifyZeroInteractions(centralKeyring);
     }
 
 


### PR DESCRIPTION
### What

Fixed logic in new Central keyring.list method. It now uses the `permissionsService` to determining which values should be returned for a given user. Admin/Editors should list all keys whereas a Viewer should only list keys they have access to.
