### PR TITLE
renamed Keyring interface and updated uses of it

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -7,7 +7,7 @@ import com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedExcept
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.Credentials;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
@@ -80,7 +80,7 @@ public class Zebedee {
     private final Path publishedContentPath;
     private final Path path;
     private final PermissionsService permissionsService;
-    private final Keyring collectionKeyring;
+    private final CollectionKeyring collectionKeyring;
     private final EncryptionKeyFactory encryptionKeyFactory;
 
     private final UsersService usersService;
@@ -418,7 +418,7 @@ public class Zebedee {
         return keyRingPath;
     }
 
-    public Keyring getCollectionKeyring() {
+    public CollectionKeyring getCollectionKeyring() {
         return this.collectionKeyring;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -12,7 +12,7 @@ import com.github.onsdigital.zebedee.data.processing.DataIndex;
 import com.github.onsdigital.zebedee.kafka.KafkaClient;
 import com.github.onsdigital.zebedee.kafka.KafkaClientImpl;
 import com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl;
 import com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl;
@@ -125,7 +125,7 @@ public class ZebedeeConfiguration {
     private DatasetService datasetService;
     private ImageService imageService;
     private KafkaService kafkaService;
-    private Keyring collectionKeyring;
+    private CollectionKeyring collectionKeyring;
     private SchedulerKeyCache schedulerKeyCache;
     private EncryptionKeyFactory encryptionKeyFactory;
     private StartUpAlerter startUpAlerter;
@@ -196,17 +196,17 @@ public class ZebedeeConfiguration {
         this.collections = new Collections(collectionsPath, permissionsService, versionsService, published);
 
 
-        Supplier<Keyring> keyringSupplier = () -> collectionKeyring;
+        Supplier<CollectionKeyring> keyringSupplier = () -> collectionKeyring;
 
         this.usersService = UsersServiceImpl.getInstance(
                 new UserStoreFileSystemImpl(this.usersPath), collections, permissionsService, keyringSupplier);
 
         // The legacy keyring logic but behind the new keyring interface.
-        Keyring legacyKeyring = new LegacyKeyringImpl(
+        CollectionKeyring legacyKeyring = new LegacyKeyringImpl(
                 sessions, usersService, permissionsService, legacyKeyringCache, schedulerKeyCache);
 
         // The new world keyring impl - could be no op or real impl depending on config.
-        Keyring centralKeyring = initCentralKeyring();
+        CollectionKeyring centralKeyring = initCentralKeyring();
 
         // Keyring migrator encapuslates the keyring migration logic behind the new keyring interface.
         this.collectionKeyring = new MigrationKeyringImpl(CMSFeatureFlags.cmsFeatureFlags().isCentralisedKeyringEnabled(), legacyKeyring, centralKeyring);
@@ -263,9 +263,9 @@ public class ZebedeeConfiguration {
 
     }
 
-    private Keyring initCentralKeyring() throws KeyringException {
+    private CollectionKeyring initCentralKeyring() throws KeyringException {
         // Default to the NoOp impl
-        Keyring centralKeyring = new NoOpCentralKeyring();
+        CollectionKeyring centralKeyring = new NoOpCentralKeyring();
 
         // If centralised keying is enabled initialize
         if (cmsFeatureFlags().isCentralisedKeyringEnabled()) {
@@ -413,7 +413,7 @@ public class ZebedeeConfiguration {
         return new ServiceStoreImpl(servicePath);
     }
 
-    public Keyring getCollectionKeyring() {
+    public CollectionKeyring getCollectionKeyring() {
         return this.collectionKeyring;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -10,7 +10,7 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.KeyringUtil;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -45,7 +45,7 @@ public class Collection {
     private PermissionsService permissionsService;
     private com.github.onsdigital.zebedee.model.Collections collections;
     private UsersService usersService;
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
     private ScheduleCanceller scheduleCanceller;
 
     /**
@@ -56,7 +56,7 @@ public class Collection {
         this.permissionsService = Root.zebedee.getPermissionsService();
         this.collections = Root.zebedee.getCollections();
         this.usersService = Root.zebedee.getUsersService();
-        this.keyring = Root.zebedee.getCollectionKeyring();
+        this.collectionKeyring = Root.zebedee.getCollectionKeyring();
         this.scheduleCanceller = (c) -> Root.cancelPublish(c);
     }
 
@@ -65,13 +65,13 @@ public class Collection {
      */
     Collection(final Sessions sessionsService, final PermissionsService permissionsService,
                final com.github.onsdigital.zebedee.model.Collections collections,
-               final UsersService usersService, final Keyring keyring,
+               final UsersService usersService, final CollectionKeyring collectionKeyring,
                final ScheduleCanceller scheduleCanceller) {
         this.sessionsService = sessionsService;
         this.permissionsService = permissionsService;
         this.collections = collections;
         this.usersService = usersService;
-        this.keyring = keyring;
+        this.collectionKeyring = collectionKeyring;
         this.scheduleCanceller = scheduleCanceller;
     }
 
@@ -324,7 +324,7 @@ public class Collection {
         }
 
         try {
-            keyring.remove(user, c);
+            collectionKeyring.remove(user, c);
         } catch (KeyringException ex) {
             String message = format("error attempting to remove collection key from keyring: {0}", c.getId());
             throw new InternalServerError(message, ex);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
@@ -5,7 +5,7 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -30,7 +30,7 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 @Api
 public class ListKeyring {
 
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
     private Sessions sessions;
     private PermissionsService permissionsService;
     private UsersService usersService;
@@ -48,9 +48,9 @@ public class ListKeyring {
     /**
      * Construct a new instance using the provided configuration.
      */
-    public ListKeyring(final Keyring keyring, final Sessions sessions,
+    public ListKeyring(final CollectionKeyring collectionKeyring, final Sessions sessions,
                        final PermissionsService permissionsService, final UsersService usersService) {
-        this.keyring = keyring;
+        this.collectionKeyring = collectionKeyring;
         this.sessions = sessions;
         this.permissionsService = permissionsService;
         this.usersService = usersService;
@@ -109,7 +109,7 @@ public class ListKeyring {
 
     Set<String> listKeyring(User user) throws InternalServerError {
         try {
-            return keyring.list(user);
+            return collectionKeyring.list(user);
         } catch (KeyringException ex) {
             error().user(user.getEmail()).exception(ex).log("error listing user keyring");
             throw new InternalServerError("internal server error");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
@@ -9,7 +9,7 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -37,24 +37,24 @@ public class Permission {
     private Sessions sessionsService;
     private PermissionsService permissionsService;
     private UsersService usersService;
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
     private Collections collections;
 
     public Permission() {
         this.sessionsService = Root.zebedee.getSessions();
         this.permissionsService = Root.zebedee.getPermissionsService();
         this.usersService = Root.zebedee.getUsersService();
-        this.keyring = Root.zebedee.getCollectionKeyring();
+        this.collectionKeyring = Root.zebedee.getCollectionKeyring();
         this.collections = Root.zebedee.getCollections();
     }
 
     Permission(final Sessions sessionsService, PermissionsService permissionsService, UsersService usersService,
-               Collections collections, Keyring keyring) {
+               Collections collections, CollectionKeyring collectionKeyring) {
         this.sessionsService = sessionsService;
         this.permissionsService = permissionsService;
         this.usersService = usersService;
         this.collections = collections;
-        this.keyring = keyring;
+        this.collectionKeyring = collectionKeyring;
     }
 
     /**
@@ -73,8 +73,8 @@ public class Permission {
      * @throws BadRequestException   If the user specified in the {@link PermissionDefinition} is not found.
      */
     @POST
-    public String grantPermission(HttpServletRequest request, HttpServletResponse response, PermissionDefinition permissionDefinition)
-            throws IOException, ZebedeeException {
+    public String grantPermission(HttpServletRequest request, HttpServletResponse response,
+                                  PermissionDefinition permissionDefinition) throws IOException, ZebedeeException {
 
         Session session = getSession(request);
 
@@ -201,8 +201,8 @@ public class Permission {
             }
         }
 
-        keyring.revokeFrom(targetUser, removals);
-        keyring.assignTo(srcUser, targetUser, assignments);
+        collectionKeyring.revokeFrom(targetUser, removals);
+        collectionKeyring.assignTo(srcUser, targetUser, assignments);
     }
 
     private Collections.CollectionList listCollections() throws InternalServerError {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
@@ -10,7 +10,7 @@ import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -54,7 +54,7 @@ public class Teams {
     private TeamsService teamsService;
     private PermissionsService permissionsService;
     private Collections collectionsService;
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
     private UsersService usersService;
 
     /**
@@ -65,7 +65,7 @@ public class Teams {
         this.teamsService = Root.zebedee.getTeamsService();
         this.permissionsService = Root.zebedee.getPermissionsService();
         this.collectionsService = Root.zebedee.getCollections();
-        this.keyring = Root.zebedee.getCollectionKeyring();
+        this.collectionKeyring = Root.zebedee.getCollectionKeyring();
         this.usersService = Root.zebedee.getUsersService();
     }
 
@@ -76,12 +76,12 @@ public class Teams {
      */
     public Teams(final Sessions sessionsService, final TeamsService teamsService,
                  final PermissionsService permissionsService, final Collections collectionsService,
-                 final Keyring keyring, final UsersService usersService) {
+                 final CollectionKeyring collectionKeyring, final UsersService usersService) {
         this.sessionsService = sessionsService;
         this.teamsService = teamsService;
         this.permissionsService = permissionsService;
         this.collectionsService = collectionsService;
-        this.keyring = keyring;
+        this.collectionKeyring = collectionKeyring;
         this.usersService = usersService;
     }
 
@@ -140,7 +140,7 @@ public class Teams {
 
         User src = getUser(usersService, session.getEmail());
         User target = getUser(usersService, email);
-        keyring.assignTo(src, target, getCollectionsAccessibleByTeam(team));
+        collectionKeyring.assignTo(src, target, getCollectionsAccessibleByTeam(team));
 
         Audit.Event.TEAM_MEMBER_ADDED
                 .parameters()
@@ -185,7 +185,7 @@ public class Teams {
 
         List<CollectionDescription> removals = getCollectionsAccessibleByTeam(team);
         for (String member : team.getMembers()) {
-            keyring.revokeFrom(getUser(usersService, member), removals);
+            collectionKeyring.revokeFrom(getUser(usersService, member), removals);
         }
 
         teamsService.deleteTeam(team, session);
@@ -213,7 +213,7 @@ public class Teams {
         if (!permissionsService.isAdministrator(email) && !permissionsService.isPublisher(email)) {
             List<CollectionDescription> accessToRemove = getCollectionsAccessibleByTeam(team);
             User user = getUser(usersService, email);
-            keyring.revokeFrom(user, accessToRemove);
+            collectionKeyring.revokeFrom(user, accessToRemove);
         }
 
         Audit.Event.TEAM_MEMBER_REMOVED

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyring.java
@@ -8,7 +8,7 @@ import javax.crypto.SecretKey;
 import java.util.List;
 import java.util.Set;
 
-public interface Keyring {
+public interface CollectionKeyring {
 
     /**
      * Populate the Keyring from an unlocked {@link User#keyring()}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SchedulerKeyCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/SchedulerKeyCache.java
@@ -1,11 +1,9 @@
 package com.github.onsdigital.zebedee.keyring;
 
-import com.github.onsdigital.zebedee.keyring.KeyringException;
-
 import javax.crypto.SecretKey;
 
 /**
- * Defines a {@link com.github.onsdigital.zebedee.keyring.Keyring} cache used for scheduled publishing tasks (i.e.
+ * Defines a {@link CollectionKeyring} cache used for scheduled publishing tasks (i.e.
  * non user driven actions).
  */
 public interface SchedulerKeyCache {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CentralKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CentralKeyringImpl.java
@@ -1,7 +1,7 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collection;
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  * CentralKeyringImpl adds a permissions check wrapper around a {@link KeyringCache} instance to ensure only
  * authorised users can access collection encryption keys
  */
-public class CentralKeyringImpl implements Keyring {
+public class CentralKeyringImpl implements CollectionKeyring {
 
     static final String USER_NULL_ERR = "user required but was null";
     static final String USER_EMAIL_ERR = "user email required but was null or empty";
@@ -40,7 +40,7 @@ public class CentralKeyringImpl implements Keyring {
     /**
      * Singleton instance.
      */
-    private static Keyring INSTANCE = null;
+    private static CollectionKeyring INSTANCE = null;
 
     private final KeyringCache cache;
     private final PermissionsService permissionsService;
@@ -274,7 +274,7 @@ public class CentralKeyringImpl implements Keyring {
      * @return a singleton instance of the CollectionKeyring
      * @throws KeyringException CollectionKeyring has not been initalised before being accessed.
      */
-    public static Keyring getInstance() throws KeyringException {
+    public static CollectionKeyring getInstance() throws KeyringException {
         if (INSTANCE == null) {
             throw new KeyringException(NOT_INITIALISED_ERR);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NoOpCentralKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NoOpCentralKeyring.java
@@ -1,7 +1,7 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.user.model.User;
@@ -16,7 +16,7 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
  * No-op implementation of the keyring interface - empty keyring stubbed placeholder for the new cenral keyring. DO
  * NOTHING JUST LOOK PRETTY.
  */
-public class NoOpCentralKeyring implements Keyring {
+public class NoOpCentralKeyring implements CollectionKeyring {
 
     @Override
     public void cacheKeyring(User user) throws KeyringException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl.java
@@ -1,7 +1,7 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
@@ -29,10 +29,10 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 /**
  * This class duplicates the existing (legacy) {@link com.github.onsdigital.zebedee.json.Keyring} and {@link KeyringCache}
  * functionality behind a newly defined Keyring interface. Doing so allows to start the process of migrating to
- * the new {@link Keyring} abstraction while maintaing backwards compatability and the ability to swicth back if
+ * the new {@link CollectionKeyring} abstraction while maintaing backwards compatability and the ability to swicth back if
  * necessary.
  */
-public class LegacyKeyringImpl implements Keyring {
+public class LegacyKeyringImpl implements CollectionKeyring {
 
     static final String USER_NULL_ERR = "user required but was null";
     static final String EMAIL_EMPTY_ERR = "user email required but was empty";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/MigrationKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/MigrationKeyringImpl.java
@@ -1,9 +1,8 @@
 package com.github.onsdigital.zebedee.keyring.migration;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.migration.Rollback;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.user.model.User;
 
@@ -18,13 +17,13 @@ import static java.text.MessageFormat.format;
 /**
  * KeyringMigrator serves 2 purposes:
  * <ul>
- *     <li>It uses a feature flag to determine which {@link Keyring} implementation to use (legacy or new central).</li>
+ *     <li>It uses a feature flag to determine which {@link CollectionKeyring} implementation to use (legacy or new central).</li>
  *     <li>If the central keyring feature is disabled keys are read from the legacy keyring but adds/removes are
  *     applied to both legacy and central keyrings. This enables us to migrate smoothly from the old keyring
  *     without losing any keys.</li>
  * </ul>
  */
-public class MigrationKeyringImpl implements Keyring {
+public class MigrationKeyringImpl implements CollectionKeyring {
 
     static final String WRAPPED_ERR_FMT = "{0}: Migration enabled: {1}";
     static final String MIGRATE_ENABLED = "migration_enabled";
@@ -42,28 +41,29 @@ public class MigrationKeyringImpl implements Keyring {
     static final String UNLOCK_KEYRING_ERR = "error while attempting to unlock user kerying";
 
     private boolean migrationEnabled;
-    private Keyring legacyKeyring;
-    private Keyring centralKeyring;
+    private CollectionKeyring legacyCollectionKeyring;
+    private CollectionKeyring collectionKeyring;
 
     /**
      * Construct a new instance of the Keyring.
      *
      * @param migrationEnabled if true uses the new central keyring implementation. Otherwise uses legacy keyring
      *                         implemenation for reads. (Writes/Deletes will be applied to both).
-     * @param legacyKeyring    the legacy keyring implementation to use.
-     * @param centralKeyring   the new central keyring implementation to use.
+     * @param legacyCollectionKeyring    the legacy keyring implementation to use.
+     * @param collectionKeyring   the new central keyring implementation to use.
      */
-    public MigrationKeyringImpl(final boolean migrationEnabled, final Keyring legacyKeyring, final Keyring centralKeyring) {
+    public MigrationKeyringImpl(final boolean migrationEnabled, final CollectionKeyring legacyCollectionKeyring,
+                                final CollectionKeyring collectionKeyring) {
         this.migrationEnabled = migrationEnabled;
-        this.legacyKeyring = legacyKeyring;
-        this.centralKeyring = centralKeyring;
+        this.legacyCollectionKeyring = legacyCollectionKeyring;
+        this.collectionKeyring = collectionKeyring;
     }
 
     @Override
     public void cacheKeyring(User user) throws KeyringException {
         try {
-            legacyKeyring.cacheKeyring(user);
-            centralKeyring.cacheKeyring(user);
+            legacyCollectionKeyring.cacheKeyring(user);
+            collectionKeyring.cacheKeyring(user);
         } catch (KeyringException ex) {
             throw wrappedKeyringException(ex, POPULATE_FROM_USER_ERR);
         }
@@ -103,23 +103,24 @@ public class MigrationKeyringImpl implements Keyring {
         }
 
         // try removing from the new keyring implementation first.
-        removeFromKeyring(centralKeyring, user, collection);
+        removeFromKeyring(collectionKeyring, user, collection);
 
         // Remove from the legacy keyring.
         try {
-            removeFromKeyring(legacyKeyring, user, collection);
+            removeFromKeyring(legacyCollectionKeyring, user, collection);
         } catch (KeyringException ex) {
 
             // Remove failed so attempt rollback. If successful throw original exception otherwise throw the
             // failed rollback exception.
-            Rollback rb = () -> centralKeyring.add(user, collection, backUp);
+            Rollback rb = () -> collectionKeyring.add(user, collection, backUp);
             attemptRollback(rb, user, collection, REMOVE_KEY);
 
             throw ex;
         }
     }
 
-    private void removeFromKeyring(Keyring instance, User user, Collection collection) throws KeyringException {
+    private void removeFromKeyring(CollectionKeyring instance, User user, Collection collection)
+            throws KeyringException {
         try {
             instance.remove(user, collection);
         } catch (KeyringException ex) {
@@ -153,23 +154,23 @@ public class MigrationKeyringImpl implements Keyring {
     @Override
     public void add(User user, Collection collection, SecretKey key) throws KeyringException {
         // try adding the key to the legacy keyring
-        addToKeyring(legacyKeyring, user, collection, key);
+        addToKeyring(legacyCollectionKeyring, user, collection, key);
 
         // Try adding the key to the central keyring
         try {
-            addToKeyring(centralKeyring, user, collection, key);
+            addToKeyring(collectionKeyring, user, collection, key);
         } catch (KeyringException ex) {
 
             // Add failed so attemp to rollback. If rollback fails throw rollback failed exception otherwise throw
             // the original exception
-            Rollback rb = () -> legacyKeyring.remove(user, collection);
+            Rollback rb = () -> legacyCollectionKeyring.remove(user, collection);
             attemptRollback(rb, user, collection, ADD_KEY);
 
             throw ex;
         }
     }
 
-    private void addToKeyring(Keyring instance, User user, Collection collection, SecretKey key)
+    private void addToKeyring(CollectionKeyring instance, User user, Collection collection, SecretKey key)
             throws KeyringException {
         try {
             instance.add(user, collection, key);
@@ -197,7 +198,7 @@ public class MigrationKeyringImpl implements Keyring {
         try {
             // The central keyring does not need to be unlocked. While migrating we only need to unlock the legacy
             // keyring.
-            legacyKeyring.unlock(user, password);
+            legacyCollectionKeyring.unlock(user, password);
         } catch (KeyringException ex) {
             throw wrappedKeyringException(ex, UNLOCK_KEYRING_ERR);
         }
@@ -205,30 +206,30 @@ public class MigrationKeyringImpl implements Keyring {
 
     @Override
     public void assignTo(User src, User target, List<CollectionDescription> assignments) throws KeyringException {
-        legacyKeyring.assignTo(src, target, assignments);
+        legacyCollectionKeyring.assignTo(src, target, assignments);
     }
 
     @Override
     public void assignTo(User src, User target, CollectionDescription... assignments) throws KeyringException {
-        legacyKeyring.assignTo(src, target, assignments);
+        legacyCollectionKeyring.assignTo(src, target, assignments);
     }
 
     @Override
     public void revokeFrom(User target, List<CollectionDescription> removals) throws KeyringException {
-        legacyKeyring.revokeFrom(target, removals);
+        legacyCollectionKeyring.revokeFrom(target, removals);
     }
 
     @Override
     public void revokeFrom(User target, CollectionDescription... removals) throws KeyringException {
-        legacyKeyring.revokeFrom(target, removals);
+        legacyCollectionKeyring.revokeFrom(target, removals);
     }
 
-    private Keyring getKeyring() {
+    private CollectionKeyring getKeyring() {
         if (migrationEnabled) {
-            return centralKeyring;
+            return collectionKeyring;
         }
 
-        return legacyKeyring;
+        return legacyCollectionKeyring;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -22,7 +22,7 @@ import com.github.onsdigital.zebedee.json.ContentStatus;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Events;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl;
 import com.github.onsdigital.zebedee.model.approval.tasks.ReleasePopulator;
 import com.github.onsdigital.zebedee.model.content.item.ContentItemVersion;
@@ -494,14 +494,14 @@ public class Collection {
             UsersService users = zebedee.getUsersService();
             PermissionsService permissions = zebedee.getPermissionsService();
             TeamsService teams = zebedee.getTeamsService();
-            Keyring keyring = zebedee.getCollectionKeyring();
+            CollectionKeyring collectionKeyring = zebedee.getCollectionKeyring();
 
 
             // Remove any teams that should no longer have access.
-            removeTeamsFromCollection(teams, users, permissions, keyring, desc, session);
+            removeTeamsFromCollection(teams, users, permissions, collectionKeyring, desc, session);
 
             // Add any new teams that have been granted access.
-            teamsUpdated.addAll(addTeamsToCollection(teams, users, permissions, keyring, desc, session));
+            teamsUpdated.addAll(addTeamsToCollection(teams, users, permissions, collectionKeyring, desc, session));
         }
 
         return teamsUpdated;
@@ -512,7 +512,7 @@ public class Collection {
      * key is revoked from each member of the team.
      */
     private static void removeTeamsFromCollection(TeamsService teams,
-                                                  UsersService users, PermissionsService permissions, Keyring keyring,
+                                                  UsersService users, PermissionsService permissions, CollectionKeyring collectionKeyring,
                                                   CollectionDescription desc, Session session)
             throws IOException, ZebedeeException {
         Set<Integer> teamIDs = permissions.listViewerTeams(desc, session);
@@ -528,7 +528,7 @@ public class Collection {
 
                 for (String member : t.getMembers()) {
                     User target = getUser(users, member);
-                    keyring.revokeFrom(target, desc);
+                    collectionKeyring.revokeFrom(target, desc);
                 }
 
                 permissions.removeViewerTeam(desc, t, session);
@@ -541,7 +541,7 @@ public class Collection {
      * collection to assign the collection encryption key to them.
      */
     private static Set<String> addTeamsToCollection(TeamsService teams, UsersService users,
-                                                    PermissionsService permissions, Keyring keyring,
+                                                    PermissionsService permissions, CollectionKeyring collectionKeyring,
                                                     CollectionDescription desc, Session session)
             throws IOException, ZebedeeException {
 
@@ -558,7 +558,7 @@ public class Collection {
 
             for (String email : team.getMembers()) {
                 User targetUser = getUser(users, email);
-                keyring.assignTo(srcUser, targetUser, desc);
+                collectionKeyring.assignTo(srcUser, targetUser, desc);
             }
 
             teamsUpdated.add(teamName);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -4,6 +4,7 @@ import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
@@ -49,7 +50,7 @@ public class ZebedeeCollectionReader extends CollectionReader {
      * @param zebedee    a {@link Zebedee} to provide non-null
      *                   {@link com.github.onsdigital.zebedee.permissions.service.PermissionsService},
      *                   {@link com.github.onsdigital.zebedee.user.service.UsersService} &
-     *                   {@link com.github.onsdigital.zebedee.keyring.Keyring}.
+     *                   {@link CollectionKeyring}.
      * @param collection the {@link Collection} the reader will read the content from
      * @param session    the {@link Session} of the {@link User} who will use the reader.
      * @throws IOException           problem creating the read.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
@@ -7,7 +7,7 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.AdminOptions;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -63,13 +63,13 @@ public class UsersServiceImpl implements UsersService {
      * - This is Zebedee.
      * - This was a quick & reasonably clean way to solve this issue.
      */
-    private Supplier<Keyring> keyringSupplier;
+    private Supplier<CollectionKeyring> keyringSupplier;
 
     /**
      * Get a singleton instance of {@link UsersServiceImpl}.
      */
     public static UsersService getInstance(UserStore userStore, Collections collections,
-                                           PermissionsService permissionsService, Supplier<Keyring> keyringSupplier) {
+                                           PermissionsService permissionsService, Supplier<CollectionKeyring> keyringSupplier) {
         if (INSTANCE == null) {
             synchronized (MUTEX) {
                 if (INSTANCE == null) {
@@ -85,7 +85,7 @@ public class UsersServiceImpl implements UsersService {
      * singleton instance.
      */
     UsersServiceImpl(UserStore userStore, Collections collections, PermissionsService permissionsService,
-                     Supplier<Keyring> keyringSupplier) {
+                     Supplier<CollectionKeyring> keyringSupplier) {
         this.permissionsService = permissionsService;
         this.collections = collections;
         this.keyringSupplier = keyringSupplier;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/Builder.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/Builder.java
@@ -12,14 +12,13 @@ import com.github.onsdigital.zebedee.exceptions.CollectionNotFoundException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.json.serialiser.IsoDateSerializer;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.PathUtils;
 import com.github.onsdigital.zebedee.permissions.model.AccessMapping;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.user.model.User;
-import com.github.onsdigital.zebedee.util.slack.SlackNotifier;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.mockito.Mock;
@@ -51,7 +50,7 @@ public class Builder {
     public static final String COLLECTION_TWO_NAME = "labourmarketq22015";
 
     @Mock
-    private Keyring collectionKeyringMock;
+    private CollectionKeyring collectionKeyringMock;
 
     @Mock
     private SlackClient slackClient;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -4,7 +4,7 @@ import com.github.onsdigital.slack.Profile;
 import com.github.onsdigital.slack.client.SlackClient;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.SchedulerKeyCache;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
@@ -70,7 +70,7 @@ public abstract class ZebedeeTestBaseFixture {
     protected SchedulerKeyCache schedulerKeyCache;
 
     @Mock
-    protected Keyring collectionKeyring;
+    protected CollectionKeyring collectionKeyring;
 
     @Mock
     protected Credentials credentials;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
@@ -5,7 +5,7 @@ import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -53,7 +53,7 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
     private CollectionDescription description;
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
 
     @Mock
     private Collection.ScheduleCanceller scheduleCanceller;
@@ -89,7 +89,7 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         when(description.getName())
                 .thenReturn("test");
 
-        this.endpoint = new Collection(sessions, permissionsService, collections, usersService, keyring,
+        this.endpoint = new Collection(sessions, permissionsService, collections, usersService, collectionKeyring,
                 scheduleCanceller);
     }
 
@@ -429,7 +429,7 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
                 .thenReturn(user);
 
         doThrow(KeyringException.class)
-                .when(keyring)
+                .when(collectionKeyring)
                 .remove(user, collection);
 
         InternalServerError ex = assertThrows(InternalServerError.class,
@@ -440,7 +440,7 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         verify(collections, times(1)).getCollection(COLLECTION_ID);
         verify(collections, times(1)).delete(collection, session);
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
-        verify(keyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
     }
 
     @Test
@@ -462,6 +462,6 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         assertTrue(result);
         verify(collections, times(1)).delete(collection, session);
         verify(scheduleCanceller, times(1)).cancel(collection);
-        verify(keyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
@@ -4,7 +4,7 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.service.Sessions;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
 
     @Mock
     private Sessions sessions;
@@ -48,7 +48,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Override
     protected void customSetUp() throws Exception {
-        endpoint = new ListKeyring(keyring, sessions, permissionsService, usersService);
+        endpoint = new ListKeyring(collectionKeyring, sessions, permissionsService, usersService);
         email = "123@test.com";
 
         when(sessions.get(mockRequest))
@@ -136,7 +136,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Test
     public void testGet_keyringListError_shouldThrowInternalServerErrorException() throws Exception {
-        when(keyring.list(user))
+        when(collectionKeyring.list(user))
                 .thenThrow(KeyringException.class);
 
         InternalServerError ex = assertThrows(InternalServerError.class,
@@ -150,7 +150,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
         Set<String> userKeys = new HashSet<>();
         userKeys.add("666");
 
-        when(keyring.list(user))
+        when(collectionKeyring.list(user))
                 .thenReturn(userKeys);
 
         Set<String> actual = endpoint.listUserKeys(mockRequest, mockResponse);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PermissionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PermissionTest.java
@@ -5,7 +5,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
@@ -59,7 +59,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
     private CollectionDescription collectionDescription;
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
 
     @Mock
     private User srcUser, targetUser;
@@ -94,7 +94,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         when(collections.list())
                 .thenReturn(collectionList);
 
-        when(keyring.get(any(), any()))
+        when(collectionKeyring.get(any(), any()))
                 .thenReturn(key);
 
         when(collectionMock.getDescription())
@@ -103,7 +103,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         permission = new PermissionDefinition();
         permission.setEmail(USER_EMAIL);
 
-        endpoint = new Permission(sessionsService, permissionsService, usersService, collections, keyring);
+        endpoint = new Permission(sessionsService, permissionsService, usersService, collections, collectionKeyring);
     }
 
     @Override
@@ -179,7 +179,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(sessionsService, times(1)).get(mockRequest);
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
-        verifyZeroInteractions(keyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
         verify(usersService, times(1)).getUserByEmail(USER_EMAIL);
-        verifyZeroInteractions(keyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(sessionsService, times(1)).get(mockRequest);
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(collections, times(1)).list();
-        verifyZeroInteractions(keyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
@@ -231,13 +231,13 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(sessionsService, times(1)).get(mockRequest);
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(permissionsService, times(1)).canView(eq(targetUser), any());
-        verifyZeroInteractions(keyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void testGrant_addAdminRevokeFromToError_shouldThrowException() throws Exception {
         doThrow(KeyringException.class)
-                .when(keyring)
+                .when(collectionKeyring)
                 .revokeFrom(any(), any(List.class));
 
         permission.isAdmin(true);
@@ -248,7 +248,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(permissionsService, times(1)).canView(eq(targetUser), any());
 
-        verify(keyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
+        verify(collectionKeyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
         List<CollectionDescription> removals = removalsCaptor.getValue();
         assertThat(removals, is(notNullValue()));
         assertThat(removals.size(), equalTo(1));
@@ -258,7 +258,7 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
     @Test
     public void testGrant_addAdminAssignToError_shouldThrowException() throws Exception {
         doThrow(KeyringException.class)
-                .when(keyring)
+                .when(collectionKeyring)
                 .assignTo(any(User.class), any(User.class), any(List.class));
 
         when(permissionsService.canView(targetUser, collectionDescription))
@@ -272,12 +272,12 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(permissionsService, times(1)).canView(eq(targetUser), any());
 
-        verify(keyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
+        verify(collectionKeyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
         List<CollectionDescription> removals = removalsCaptor.getValue();
         assertThat(removals, is(notNullValue()));
         assertTrue(removals.isEmpty());
 
-        verify(keyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
+        verify(collectionKeyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
         List<CollectionDescription> asssignments = assignmentsCaptor.getValue();
         assertThat(asssignments, is(notNullValue()));
         assertThat(asssignments.size(), equalTo(1));
@@ -297,12 +297,12 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(permissionsService, times(1)).addAdministrator(USER_EMAIL, session);
         verify(permissionsService, times(1)).canView(eq(targetUser), any());
 
-        verify(keyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
+        verify(collectionKeyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
         List<CollectionDescription> removals = removalsCaptor.getValue();
         assertThat(removals, is(notNullValue()));
         assertTrue(removals.isEmpty());
 
-        verify(keyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
+        verify(collectionKeyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
         List<CollectionDescription> assignments = assignmentsCaptor.getValue();
         assertThat(assignments, is(notNullValue()));
         assertThat(assignments.size(), equalTo(1));
@@ -371,13 +371,13 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         verify(permissionsService, times(1)).removeEditor(USER_EMAIL, session);
         verify(permissionsService, times(1)).removeAdministrator(USER_EMAIL, session);
 
-        verify(keyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
+        verify(collectionKeyring, times(1)).revokeFrom(eq(targetUser), removalsCaptor.capture());
         List<CollectionDescription> removals = removalsCaptor.getValue();
         assertThat(removals, is(notNullValue()));
         assertThat(removals.size(), equalTo(1));
         assertThat(removals.get(0), equalTo(collectionDescription));
 
-        verify(keyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
+        verify(collectionKeyring, times(1)).assignTo(eq(srcUser), eq(targetUser), assignmentsCaptor.capture());
         List<CollectionDescription> asssignments = assignmentsCaptor.getValue();
         assertThat(asssignments, is(notNullValue()));
         assertThat(asssignments.size(), equalTo(0));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CentralKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CentralKeyringImplTest.java
@@ -1,10 +1,9 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -55,7 +54,7 @@ public class CentralKeyringImplTest {
     static final String TEST_COLLECTION_ID = "44";
     static final String SECRET_KEY = "441";
     static final String TEST_EMAIL_ID = "testid@ons.gov.uk";
-    private Keyring keyring;
+    private CollectionKeyring keyring;
 
     @Mock
     private KeyringCache keyringCache;
@@ -238,7 +237,7 @@ public class CentralKeyringImplTest {
         // Given CollectionKeyring has been initialised
 
         // When GetInstance is called
-        Keyring keyring = CentralKeyringImpl.getInstance();
+        CollectionKeyring keyring = CentralKeyringImpl.getInstance();
 
         // Then a non null instance is returned
         assertThat(keyring, is(notNullValue()));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
@@ -1,10 +1,9 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.SchedulerKeyCache;
-import com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -80,7 +79,7 @@ public abstract class BaseLegacyKeyringTest {
     @Mock
     protected SchedulerKeyCache schedulerCache;
 
-    protected Keyring legacyKeyring;
+    protected CollectionKeyring legacyCollectionKeyring;
     protected KeyringException expectedEx;
     protected List<User> usersWithCollectionAccess;
     protected UserList allUsers;
@@ -109,7 +108,7 @@ public abstract class BaseLegacyKeyringTest {
 
         setUpTests();
 
-        legacyKeyring = new LegacyKeyringImpl(sessionsService, users, permissions, keyringCache, schedulerCache);
+        legacyCollectionKeyring = new LegacyKeyringImpl(sessionsService, users, permissions, keyringCache, schedulerCache);
 
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_AddTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_AddTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import org.junit.Test;
@@ -47,7 +46,8 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
         // Given collection is null
 
         // When add is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(null, null, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.add(null, null, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(COLLECTION_NULL_ERR));
@@ -66,7 +66,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
         // When add is called
         KeyringException actual = assertThrows(KeyringException.class,
-                () -> legacyKeyring.add(null, collection, null));
+                () -> legacyCollectionKeyring.add(null, collection, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
@@ -84,7 +84,8 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When add is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(null, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.add(null, collection, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -102,7 +103,8 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When add is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(null, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.add(null, collection, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -118,7 +120,8 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
         // Given key is null
 
         // When add is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.add(null, collection, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.add(null, collection, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(SECRET_KEY_NULL_ERR));
@@ -137,7 +140,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
         // When add is called
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.add(null, collection, secretKey));
+                () -> legacyCollectionKeyring.add(null, collection, secretKey));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(GET_KEY_RECIPIENTS_ERR));
@@ -159,7 +162,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When add is called
-        legacyKeyring.add(null, collection, secretKey);
+        legacyCollectionKeyring.add(null, collection, secretKey);
 
         // Then the key is not assigned to any users
         verify(permissions, times(1)).getCollectionAccessMapping(collection);
@@ -179,7 +182,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn(new ArrayList<>());
 
         // When add is called
-        legacyKeyring.add(null, collection, secretKey);
+        legacyCollectionKeyring.add(null, collection, secretKey);
 
         // Then the key is not assigned to any users
         verify(permissions, times(1)).getCollectionAccessMapping(collection);
@@ -200,7 +203,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
         // When add is called
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.add(null, collection, secretKey));
+                () -> legacyCollectionKeyring.add(null, collection, secretKey));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(LIST_USERS_ERR));
@@ -224,7 +227,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When add is called
-        legacyKeyring.add(null, collection, secretKey);
+        legacyCollectionKeyring.add(null, collection, secretKey);
 
         // Then the key is assigned to the expected users
         verifyKeyAddedToUser(bert, bertKeyring);
@@ -248,7 +251,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
                 .thenReturn(new UserList());
 
         // When add is called
-        legacyKeyring.add(null, collection, secretKey);
+        legacyCollectionKeyring.add(null, collection, secretKey);
 
         // Then the key is assigned to the expected users
         verifyKeyAddedToUser(bert, bertKeyring);
@@ -273,7 +276,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
         // When add is called
         KeyringException actual = assertThrows(KeyringException.class,
-                () -> legacyKeyring.add(null, collection, secretKey));
+                () -> legacyCollectionKeyring.add(null, collection, secretKey));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(ADD_KEY_SAVE_ERR));
@@ -295,7 +298,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
         // When add is called
         KeyringException actual = assertThrows(KeyringException.class,
-                () -> legacyKeyring.add(null, collection, secretKey));
+                () -> legacyCollectionKeyring.add(null, collection, secretKey));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(REMOVE_KEY_SAVE_ERR));
@@ -318,7 +321,7 @@ public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
         // Given add is successfull
 
         // When add key is called
-        legacyKeyring.add(null, collection, secretKey);
+        legacyCollectionKeyring.add(null, collection, secretKey);
 
         // Then the key is assigned to the expected users only
         verifyKeyAddedToUser(bert, bertKeyring);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_AssignToTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_AssignToTest.java
@@ -3,7 +3,6 @@ package com.github.onsdigital.zebedee.keyring.legacy;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Keyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import org.junit.Test;
 import org.mockito.Mock;
 
@@ -62,14 +61,14 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
     @Test
     public void testAssignTo_assignmentsNull_shouldDoNothing() throws Exception {
         List<CollectionDescription> assignments = null;
-        legacyKeyring.assignTo(bert, ernie, assignments);
+        legacyCollectionKeyring.assignTo(bert, ernie, assignments);
 
         verifyZeroInteractions(bert, ernie, bertKeyring, ernieKeyring, keyringCache, users);
     }
 
     @Test
     public void testAssignTo_assignmentsEmpty_shouldDoNothing() throws Exception {
-        legacyKeyring.assignTo(bert, ernie, new ArrayList<>());
+        legacyCollectionKeyring.assignTo(bert, ernie, new ArrayList<>());
 
         verifyZeroInteractions(bert, ernie, bertKeyring, ernieKeyring, keyringCache, users);
     }
@@ -77,7 +76,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
     @Test
     public void testAssignTo_srcUserNull_shouldThrowEx() throws Exception {
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(null, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(null, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
         verifyZeroInteractions(ernie, bertKeyring, ernieKeyring, keyringCache, users);
@@ -89,7 +88,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(ernie, bertKeyring, ernieKeyring, keyringCache, users);
@@ -101,7 +100,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(ernie, bertKeyring, ernieKeyring, keyringCache, users);
@@ -113,7 +112,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
         verifyZeroInteractions(ernie, bertKeyring, ernieKeyring, keyringCache, users);
@@ -122,7 +121,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
     @Test
     public void testAssignTo_targetUserNull_shouldThrowEx() throws Exception {
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, null, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, null, assignments));
 
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
         verifyZeroInteractions(ernie, bertKeyring, ernieKeyring, keyringCache, users);
@@ -134,7 +133,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(bertKeyring, ernieKeyring, keyringCache, users);
@@ -146,7 +145,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(bertKeyring, ernieKeyring, keyringCache, users);
@@ -158,7 +157,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
         verifyZeroInteractions(bertKeyring, ernieKeyring, keyringCache, users);
@@ -170,7 +169,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenThrow(KeyringException.class);
 
         assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         verify(keyringCache, times(1)).get(bert);
     }
@@ -181,7 +180,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(CACHE_KEYRING_NULL_ERR));
         verify(keyringCache, times(1)).get(bert);
@@ -193,7 +192,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
                 .thenReturn(false);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.assignTo(bert, ernie, assignments));
+                () -> legacyCollectionKeyring.assignTo(bert, ernie, assignments));
 
         assertThat(ex.getMessage(), equalTo(KEYRING_LOCKED_ERR));
         verify(keyringCache, times(1)).get(bert);
@@ -204,7 +203,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
         when(bertCachedKeyring.keySet())
                 .thenReturn(new HashSet<>());
 
-        legacyKeyring.assignTo(bert, ernie, assignments);
+        legacyCollectionKeyring.assignTo(bert, ernie, assignments);
 
         verify(ernieCachedKeyring, never()).put(TEST_COLLECTION_ID, secretKey);
         verify(ernieKeyring, never()).put(TEST_COLLECTION_ID, secretKey);
@@ -213,7 +212,7 @@ public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
 
     @Test
     public void testAssignTo_success_shouldAddKeysToCachedKeyAndUserKeyring() throws Exception {
-        legacyKeyring.assignTo(bert, ernie, assignments);
+        legacyCollectionKeyring.assignTo(bert, ernie, assignments);
 
         verify(ernieCachedKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);
         verify(ernieKeyring, times(1)).put(TEST_COLLECTION_ID, secretKey);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_CacheKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_CacheKeyringTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +30,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
         // Given user is null
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
@@ -44,7 +43,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(bert));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(bert));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -57,7 +56,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(bert));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(bert));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -70,7 +69,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(bert));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(bert));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
@@ -83,7 +82,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .thenThrow(expectedEx);
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(bert));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(bert));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(GET_SESSION_ERR));
@@ -97,7 +96,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When cacheKeyring is called
-        legacyKeyring.cacheKeyring(bert);
+        legacyCollectionKeyring.cacheKeyring(bert);
 
         // Then no keying is added to the cache
         verify(sessionsService, times(1)).find(EMAIL_BERT);
@@ -112,7 +111,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
                 .put(bert, session);
 
         // When cacheKeyring is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.cacheKeyring(bert));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.cacheKeyring(bert));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(CACHE_PUT_ERR));
@@ -124,7 +123,7 @@ public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
         // Given a valid user
 
         // When cacheKeyring is called
-        legacyKeyring.cacheKeyring(bert);
+        legacyCollectionKeyring.cacheKeyring(bert);
 
         // Then the keyring cache is updated with the users keys
         verify(sessionsService, times(1)).find(EMAIL_BERT);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_GetTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_GetTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import org.junit.Test;
 
 import javax.crypto.SecretKey;
@@ -33,7 +32,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
         // Given user is null
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(null, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
@@ -46,7 +45,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -59,7 +58,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -70,7 +69,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
         // Given collection is null
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, null));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
@@ -83,7 +82,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
@@ -96,7 +95,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -109,7 +108,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When get is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.get(bert, collection));
 
         // Then an exception is thrown.
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -122,7 +121,8 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenThrow(IOException.class);
 
         // When get is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.get(bert, collection));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.get(bert, collection));
 
         // Then null is returned
         assertThat(actual.getMessage(), equalTo(CACHE_GET_ERR));
@@ -136,7 +136,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When get is called
-        SecretKey actual = legacyKeyring.get(bert, collection);
+        SecretKey actual = legacyCollectionKeyring.get(bert, collection);
 
         // Then null is returned
         assertThat(actual, is(nullValue()));
@@ -150,7 +150,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(false);
 
         // When get is called
-        SecretKey actual = legacyKeyring.get(bert, collection);
+        SecretKey actual = legacyCollectionKeyring.get(bert, collection);
 
         // Then null is returned
         assertThat(actual, is(nullValue()));
@@ -165,7 +165,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When get is called
-        SecretKey actual = legacyKeyring.get(ernie, collection);
+        SecretKey actual = legacyCollectionKeyring.get(ernie, collection);
 
         // Then null is returned
         assertThat(actual, is(nullValue()));
@@ -182,7 +182,7 @@ public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
                 .thenReturn(secretKey);
 
         // When get is called
-        SecretKey actual = legacyKeyring.get(bert, collection);
+        SecretKey actual = legacyCollectionKeyring.get(bert, collection);
 
         // Then the expected key is returned
         assertThat(actual, equalTo(secretKey));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_ListTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_ListTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import com.github.onsdigital.zebedee.user.model.User;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
         // Given user is null
 
         // When list is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(null));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.list(null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
@@ -48,7 +47,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When list is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(bert));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.list(bert));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -62,7 +61,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When list is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(bert));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.list(bert));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -80,7 +79,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn(expected);
 
         // When list is called
-        Set<String> actual = legacyKeyring.list(bert);
+        Set<String> actual = legacyCollectionKeyring.list(bert);
 
         // Then the expected set is returned
         assertThat(actual, equalTo(expected));
@@ -100,7 +99,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenThrow(IOException.class);
 
         // When list is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(bert));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.list(bert));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(GET_USER_ERR));
@@ -119,7 +118,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When list is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.list(bert));
+        KeyringException actual = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.list(bert));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
@@ -142,7 +141,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When list is called
-        Set<String> actual = legacyKeyring.list(bert);
+        Set<String> actual = legacyCollectionKeyring.list(bert);
 
         // Then an empty set is returned
         assertTrue(actual.isEmpty());
@@ -172,7 +171,7 @@ public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
                 .thenReturn(expected);
 
         // When list is called
-        Set<String> actual = legacyKeyring.list(bert);
+        Set<String> actual = legacyCollectionKeyring.list(bert);
 
         // Then the expected result is returned
         assertThat(actual, equalTo(expected));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_RemoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_RemoveTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import org.junit.Test;
@@ -37,7 +36,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
         // Given collection is null
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.remove(null, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
@@ -51,7 +50,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_DESC_NULL_ERR));
@@ -65,7 +64,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -79,7 +78,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTION_ID_EMPTY_ERR));
@@ -93,7 +92,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenThrow(IOException.class);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class, () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(LIST_USERS_ERR));
@@ -115,7 +114,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When remove is called
-        legacyKeyring.remove(null, collection);
+        legacyCollectionKeyring.remove(null, collection);
 
         // Then the key is not removed from any user
         verifyKeyNotRemovedFromUser(bert, bertKeyring);
@@ -133,7 +132,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(new UserList());
 
         // When remove is called
-        legacyKeyring.remove(null, collection);
+        legacyCollectionKeyring.remove(null, collection);
 
         // Then the key is not removed from any user
         verifyKeyNotRemovedFromUser(bert, bertKeyring);
@@ -153,7 +152,8 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .removeKeyFromKeyring(EMAIL_BERT, TEST_COLLECTION_ID);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(REMOVE_KEY_SAVE_ERR));
@@ -184,7 +184,8 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When remove is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.remove(null, collection));
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.remove(null, collection));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(REMOVE_KEY_SAVE_ERR));
@@ -211,7 +212,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When remove is called
-        legacyKeyring.remove(null, collection);
+        legacyCollectionKeyring.remove(null, collection);
 
         // Then the key is successfully removed from the stored user
         verifyUserKeyringRetrievedFromCache(bert);
@@ -236,7 +237,7 @@ public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
         // And the user's keyring is in the cache
 
         // When remove is called
-        legacyKeyring.remove(null, collection);
+        legacyCollectionKeyring.remove(null, collection);
 
         // Then the key is successfully removed from all cached user keyrings
         // And the key is removed from all stored users.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_RevokeFromTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_RevokeFromTest.java
@@ -3,7 +3,6 @@ package com.github.onsdigital.zebedee.keyring.legacy;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Keyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import org.junit.Test;
 import org.mockito.Mock;
 
@@ -38,21 +37,22 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
     @Test
     public void testRemoveFrom_removalsNull_shouldDoNothing() throws Exception {
         List<CollectionDescription> descriptions = null;
-        legacyKeyring.revokeFrom(bert, descriptions);
+        legacyCollectionKeyring.revokeFrom(bert, descriptions);
 
         verifyZeroInteractions(bertKeyring, keyringCache);
     }
 
     @Test
     public void testRemoveFrom_removalsEmpty_shouldDoNothing() throws Exception {
-        legacyKeyring.revokeFrom(bert, new ArrayList<>());
+        legacyCollectionKeyring.revokeFrom(bert, new ArrayList<>());
 
         verifyZeroInteractions(bertKeyring, keyringCache);
     }
 
     @Test
     public void testRemoveFrom_userNull_shouldThrowEx() throws Exception {
-        KeyringException ex = assertThrows(KeyringException.class, () -> legacyKeyring.revokeFrom(null, removals));
+        KeyringException ex = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.revokeFrom(null, removals));
 
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
         verifyZeroInteractions(bertKeyring, keyringCache);
@@ -64,7 +64,7 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.revokeFrom(bert, removals));
+                () -> legacyCollectionKeyring.revokeFrom(bert, removals));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(bertKeyring, keyringCache);
@@ -76,7 +76,7 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.revokeFrom(bert, removals));
+                () -> legacyCollectionKeyring.revokeFrom(bert, removals));
 
         assertThat(ex.getMessage(), equalTo(EMAIL_EMPTY_ERR));
         verifyZeroInteractions(bertKeyring, keyringCache);
@@ -88,7 +88,7 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.revokeFrom(bert, removals));
+                () -> legacyCollectionKeyring.revokeFrom(bert, removals));
 
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
         verifyZeroInteractions(bertKeyring, keyringCache);
@@ -100,7 +100,7 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
                 .thenThrow(KeyringException.class);
 
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> legacyKeyring.revokeFrom(bert, removals));
+                () -> legacyCollectionKeyring.revokeFrom(bert, removals));
 
         assertThat(ex.getMessage(), equalTo(CACHE_GET_ERR));
         verify(keyringCache, times(1)).get(bert);
@@ -112,7 +112,7 @@ public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
         when(keyringCache.get(bert))
                 .thenReturn(bertCachedKeyring);
 
-        legacyKeyring.revokeFrom(bert, removals);
+        legacyCollectionKeyring.revokeFrom(bert, removals);
 
         verify(keyringCache, times(1)).get(bert);
         verify(bertCachedKeyring, times(1)).remove(TEST_COLLECTION_ID);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_UnlockTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_UnlockTest.java
@@ -1,7 +1,6 @@
 package com.github.onsdigital.zebedee.keyring.legacy;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.legacy.BaseLegacyKeyringTest;
 import org.junit.Test;
 
 import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
@@ -28,7 +27,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
         // Given user is null
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(null, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(null, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(USER_NULL_ERR));
@@ -41,7 +41,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(bert, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(bert, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -54,7 +55,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
                 .thenReturn("");
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(bert, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(bert, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(EMAIL_EMPTY_ERR));
@@ -67,7 +69,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
                 .thenReturn(null);
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(bert, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(bert, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
@@ -78,7 +81,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
         // Given password is null
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(bert, null));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(bert, null));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(PASSWORD_EMPTY_ERR));
@@ -92,7 +96,8 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
                 .thenReturn(false);
 
         // When unlock is called
-        KeyringException actual = assertThrows(KeyringException.class, () -> legacyKeyring.unlock(bert, TEST_PASSWORD));
+        KeyringException actual = assertThrows(KeyringException.class,
+                () -> legacyCollectionKeyring.unlock(bert, TEST_PASSWORD));
 
         // Then an exception is thrown
         assertThat(actual.getMessage(), equalTo(UNLOCK_KEYRING_ERR));
@@ -104,7 +109,7 @@ public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
         // Given unlocking the keyring is successful
 
         // When unlock is called
-        legacyKeyring.unlock(bert, TEST_PASSWORD);
+        legacyCollectionKeyring.unlock(bert, TEST_PASSWORD);
 
         // Then no error is returned
         // And the user keyring is unlocked

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/migration/MigrationKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/migration/MigrationKeyringImplTest.java
@@ -1,9 +1,8 @@
 package com.github.onsdigital.zebedee.keyring.migration;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.user.model.User;
 import org.junit.Before;
@@ -52,12 +51,12 @@ public class MigrationKeyringImplTest {
     private SecretKey secretKey;
 
     @Mock
-    private Keyring legacyKeyring;
+    private CollectionKeyring legacyCollectionKeyring;
 
     @Mock
-    private Keyring centralKeyring;
+    private CollectionKeyring collectionKeyring;
 
-    private Keyring keyring;
+    private CollectionKeyring keyring;
 
     private KeyringException keyringException;
 
@@ -85,37 +84,37 @@ public class MigrationKeyringImplTest {
     @Test
     public void cacheKeyring_migrateDisabled_success_shouldUpdateBothKeyrings() throws Exception {
         // Given keyring migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When cacheKeyring is called
         keyring.cacheKeyring(user);
 
         // Then both the legacy and central keyrings are updated
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
-        verify(centralKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
+        verify(collectionKeyring, times(1)).cacheKeyring(user);
     }
 
     @Test
     public void cacheKeyring_migrateEnabled_success_shouldUpdateBothKeyrings() throws Exception {
         // Given keyring migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When cacheKeyring is called
         keyring.cacheKeyring(user);
 
         // Then both the legacy and central keyrings are updated
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
-        verify(centralKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
+        verify(collectionKeyring, times(1)).cacheKeyring(user);
     }
 
     @Test
     public void cacheKeyring_migrateDisabled_legacyKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And legacy keyring errors when called.
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .cacheKeyring(user);
 
         // When cacheKeyring is called
@@ -125,20 +124,20 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, disabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
 
         // And the central keyring is never called
-        verifyZeroInteractions(centralKeyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void cacheKeyring_migrateEnabled_legacyKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And legacy keyring errors when called.
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .cacheKeyring(user);
 
         // When cacheKeyring is called
@@ -148,20 +147,20 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, enabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
 
         // And the central keyring is never called
-        verifyZeroInteractions(centralKeyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void cacheKeyring_migrateDisabled_centralKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And central keyring errors when called.
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .cacheKeyring(user);
 
         // When cacheKeyring is called
@@ -171,20 +170,20 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, disabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
 
         // And the central keyring is called 1 time
-        verify(centralKeyring, times(1)).cacheKeyring(user);
+        verify(collectionKeyring, times(1)).cacheKeyring(user);
     }
 
     @Test
     public void cacheKeyring_migrateEnabled_centralKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And central keyring errors when called.
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .cacheKeyring(user);
 
         // When cacheKeyring is called
@@ -194,18 +193,18 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, POPULATE_FROM_USER_ERR, enabled);
 
         // And the legacy keyring is called 1 time
-        verify(legacyKeyring, times(1)).cacheKeyring(user);
+        verify(legacyCollectionKeyring, times(1)).cacheKeyring(user);
 
         // And the central keyring is called 1 time
-        verify(centralKeyring, times(1)).cacheKeyring(user);
+        verify(collectionKeyring, times(1)).cacheKeyring(user);
     }
 
     @Test
     public void get_migrateDisabled_success_shouldReadFromLegacyKeyring() throws Exception {
         // Given keyring migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         // When Get is called
@@ -213,17 +212,17 @@ public class MigrationKeyringImplTest {
 
         // Then the expected key is returned
         assertThat(actual, equalTo(secretKey));
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void get_migrateDisabled_keyringError_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenThrow(KeyringException.class);
 
         // When Get is called
@@ -233,18 +232,18 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, GET_KEY_ERR, disabled);
 
         // And the legacy keyring is called 1 times
-        verify(legacyKeyring, times(1)).get(user, collection);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
 
         // And the central keyring is never called
-        verifyZeroInteractions(centralKeyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void get_migrateEnabled_success_shouldReadFromCentralKeyring() throws Exception {
         // Given keyring migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         // When Get is called
@@ -252,17 +251,17 @@ public class MigrationKeyringImplTest {
 
         // Then the expected key is returned
         assertThat(actual, equalTo(secretKey));
-        verify(centralKeyring, times(1)).get(user, collection);
-        verifyZeroInteractions(legacyKeyring);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verifyZeroInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void get_migrateEnabled_keyringError_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenThrow(KeyringException.class);
 
         // When Get is called
@@ -272,19 +271,19 @@ public class MigrationKeyringImplTest {
         assertWrappedException(actual, GET_KEY_ERR, enabled);
 
         // And the central keyring is called 1 times
-        verify(centralKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).get(user, collection);
 
         // And the legacy keyring is never called
-        verifyZeroInteractions(legacyKeyring);
+        verifyZeroInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void remove_migrateDisabled_getKeyError_shouldThrownException() throws Exception {
         // Given migration is disabled
         // And get key returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenThrow(keyringException);
 
         // When remove is called
@@ -292,18 +291,18 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(ex, GET_KEY_ERR, disabled);
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(legacyKeyring, never()).remove(user, collection);
-        verify(centralKeyring, never()).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(legacyCollectionKeyring, never()).remove(user, collection);
+        verify(collectionKeyring, never()).remove(user, collection);
     }
 
     @Test
     public void remove_migrateEnabled_getKeyError_shouldThrownException() throws Exception {
         // Given migration is enabled
         // And get key returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenThrow(keyringException);
 
         // When remove is called
@@ -311,18 +310,18 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(ex, GET_KEY_ERR, enabled);
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(legacyKeyring, never()).remove(user, collection);
-        verify(legacyKeyring, never()).remove(user, collection);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(legacyCollectionKeyring, never()).remove(user, collection);
+        verify(legacyCollectionKeyring, never()).remove(user, collection);
     }
 
     @Test
     public void remove_migrateDisabled_keyNull_shouldThrowException() throws Exception {
         // Given migration is disabled
         // And get key returns null
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(null);
 
         // When remove is called
@@ -330,18 +329,18 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertException(actual, KEY_NULL_ERR, disabled);
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, never()).remove(user, collection);
-        verify(centralKeyring, never()).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, never()).remove(user, collection);
+        verify(collectionKeyring, never()).remove(user, collection);
     }
 
     @Test
     public void remove_migrateEnabled_keyNull_shouldThrowException() throws Exception {
         // Given migration is enabled
         // And get key returns null
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(null);
 
         // When remove is called
@@ -349,22 +348,22 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertException(actual, KEY_NULL_ERR, enabled);
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(legacyKeyring, never()).remove(user, collection);
-        verify(legacyKeyring, never()).remove(user, collection);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(legacyCollectionKeyring, never()).remove(user, collection);
+        verify(legacyCollectionKeyring, never()).remove(user, collection);
     }
 
     @Test
     public void remove_migrateDisabled_centralKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is disabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(KeyringException.class)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .remove(user, collection);
 
         // When remove is called
@@ -372,22 +371,22 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, REMOVE_KEY_ERR, disabled);
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verifyNoMoreInteractions(legacyKeyring);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verifyNoMoreInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void remove_migrateEnabled_centralKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is enabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(KeyringException.class)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .remove(user, collection);
 
         // When remove is called
@@ -395,22 +394,22 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, REMOVE_KEY_ERR, enabled);
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verifyZeroInteractions(legacyKeyring);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verifyZeroInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void remove_migrateDisabled_legacyKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is disabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(KeyringException.class)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         // When remove is called
@@ -418,22 +417,22 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, REMOVE_KEY_ERR, disabled);
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
     }
 
     @Test
     public void remove_migrateEnabled_legacyKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is enabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(keyringException)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         // When remove is called
@@ -441,10 +440,10 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, REMOVE_KEY_ERR, enabled);
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
     }
 
     @Test
@@ -452,17 +451,17 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And legacy keyring returns an error
         // And remove rollback fails
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(keyringException)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         doThrow(keyringException)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         // When remove is called
@@ -470,10 +469,10 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, ROLLBACK_FAILED_ERR, disabled);
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
     }
 
     @Test
@@ -481,17 +480,17 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And legacy keyring returns an error
         // And remove rollback fails
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         doThrow(keyringException)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         doThrow(keyringException)
-                .when(centralKeyring)
+                .when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         // When remove is called
@@ -499,58 +498,58 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, ROLLBACK_FAILED_ERR, enabled);
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
     }
 
     @Test
     public void remove_migrateDisabled_success_shouldRemoveKeyFromBothKeyrings() throws Exception {
         // Given migration is disabled
         // And remove is successful
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.get(user, collection))
+        when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         // When remove is called
         keyring.remove(user, collection);
 
         // Then both the legacy and central keyrings are updated
-        verify(legacyKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, never()).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, never()).add(user, collection, secretKey);
     }
 
     @Test
     public void remove_migrateEnabled_success_shouldRemoveKeyFromBothKeyrings() throws Exception {
         // Given migration is enabled
         // And remove is successful
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
 
         // When remove is called
         keyring.remove(user, collection);
 
         // Then both the legacy and central keyrings are updated
-        verify(centralKeyring, times(1)).get(user, collection);
-        verify(centralKeyring, times(1)).remove(user, collection);
-        verify(legacyKeyring, times(1)).remove(user, collection);
-        verify(centralKeyring, never()).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
+        verify(collectionKeyring, never()).add(user, collection, secretKey);
     }
 
     @Test
     public void add_migrateDisabled_legacyKeyringError_shouldThrowException() throws Exception {
         // Given migration is disabled
         // And legacy keyring.add is unsuccessful
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(legacyKeyring)
+                when(legacyCollectionKeyring)
                 .add(user, collection, secretKey);
 
         // When add is called
@@ -559,18 +558,18 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ADD_KEY_ERR, disabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void add_migrateEnabled_legacyKeyringError_shouldThrowException() throws Exception {
         // Given migration is enabled
         // And legacy keyring.add is unsuccessful
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(legacyKeyring)
+                when(legacyCollectionKeyring)
                 .add(user, collection, secretKey);
 
         // When add is called
@@ -579,8 +578,8 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ADD_KEY_ERR, enabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
@@ -588,14 +587,14 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And central keyring.add is unsuccessful
         // And rollback is unsuccessful
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(centralKeyring)
+                when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         doThrow(keyringException).
-                when(legacyKeyring)
+                when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         // When add is called
@@ -604,9 +603,9 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ROLLBACK_FAILED_ERR, disabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verify(legacyKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
     }
 
     @Test
@@ -614,14 +613,14 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And central keyring.add is unsuccessful
         // And rollback is unsuccessful
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(centralKeyring)
+                when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         doThrow(keyringException).
-                when(legacyKeyring)
+                when(legacyCollectionKeyring)
                 .remove(user, collection);
 
         // When add is called
@@ -630,9 +629,9 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ROLLBACK_FAILED_ERR, enabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verify(legacyKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
     }
 
     @Test
@@ -640,10 +639,10 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And central keyring.add is unsuccessful
         // And rollback is successful
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(centralKeyring)
+                when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         // When add is called
@@ -652,9 +651,9 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ADD_KEY_ERR, disabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verify(legacyKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
     }
 
     @Test
@@ -662,10 +661,10 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And central keyring.add is unsuccessful
         // And rollback is successful
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
-                when(centralKeyring)
+                when(collectionKeyring)
                 .add(user, collection, secretKey);
 
         // When add is called
@@ -674,46 +673,46 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, ADD_KEY_ERR, enabled);
 
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verify(legacyKeyring, times(1)).remove(user, collection);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(legacyCollectionKeyring, times(1)).remove(user, collection);
     }
 
     @Test
     public void add_migrateDisabled_success_shouldAddKeyToBothKeyrings() throws Exception {
         // Given migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When add is called
         keyring.add(user, collection, secretKey);
 
         // Then the key is added to both keyrings
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verifyNoMoreInteractions(legacyKeyring, centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verifyNoMoreInteractions(legacyCollectionKeyring, collectionKeyring);
     }
 
     @Test
     public void add_migrateEnabled_success_shouldAddKeyToBothKeyrings() throws Exception {
         // Given migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When add is called
         keyring.add(user, collection, secretKey);
 
         // Then the key is added to both keyrings
-        verify(legacyKeyring, times(1)).add(user, collection, secretKey);
-        verify(centralKeyring, times(1)).add(user, collection, secretKey);
-        verifyNoMoreInteractions(legacyKeyring, centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).add(user, collection, secretKey);
+        verify(collectionKeyring, times(1)).add(user, collection, secretKey);
+        verifyNoMoreInteractions(legacyCollectionKeyring, collectionKeyring);
     }
 
     @Test
     public void list_migrateDisabled_listError_shouldThrowException() throws Exception {
         // Given migrate is disabled
         // And legacy keyring.list throws an exception
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(legacyKeyring.list(user))
+        when(legacyCollectionKeyring.list(user))
                 .thenThrow(keyringException);
 
         // When list is called
@@ -721,17 +720,17 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, LIST_KEYS_ERR, disabled);
-        verify(legacyKeyring, times(1)).list(user);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).list(user);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void list_migrateEnabled_listError_shouldThrowException() throws Exception {
         // Given migrate is enabled
         // And legacy keyring.list throws an exception
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
-        when(centralKeyring.list(user))
+        when(collectionKeyring.list(user))
                 .thenThrow(keyringException);
 
         // When list is called
@@ -739,20 +738,20 @@ public class MigrationKeyringImplTest {
 
         // Then an exception is thrown
         assertWrappedException(actual, LIST_KEYS_ERR, enabled);
-        verify(centralKeyring, times(1)).list(user);
-        verifyZeroInteractions(legacyKeyring);
+        verify(collectionKeyring, times(1)).list(user);
+        verifyZeroInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void list_migrateDisabled_success_shouldListKeys() throws Exception {
         // Given migrate is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         Set<String> keys = new HashSet<String>() {{
             add("1234567890");
         }};
 
-        when(legacyKeyring.list(user))
+        when(legacyCollectionKeyring.list(user))
                 .thenReturn(keys);
 
         // When list is called
@@ -760,20 +759,20 @@ public class MigrationKeyringImplTest {
 
         // Then the expected key list is returned
         assertThat(actual, equalTo(keys));
-        verify(legacyKeyring, times(1)).list(user);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).list(user);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void list_migrateEnabled_success_shouldListKeys() throws Exception {
         // Given migrate is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         Set<String> keys = new HashSet<String>() {{
             add("1234567890");
         }};
 
-        when(centralKeyring.list(user))
+        when(collectionKeyring.list(user))
                 .thenReturn(keys);
 
         // When list is called
@@ -781,46 +780,46 @@ public class MigrationKeyringImplTest {
 
         // Then the expected key list is returned
         assertThat(actual, equalTo(keys));
-        verify(centralKeyring, times(1)).list(user);
-        verifyZeroInteractions(legacyKeyring);
+        verify(collectionKeyring, times(1)).list(user);
+        verifyZeroInteractions(legacyCollectionKeyring);
     }
 
     @Test
     public void unlock_migrateDisbaled_shouldCallLegacyKeyringUnlock() throws Exception {
         // Given migrate is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When unlocked is called
         keyring.unlock(user, "1234");
 
         // Then legacy keyring is unlocked
-        verify(legacyKeyring, times(1)).unlock(user, "1234");
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).unlock(user, "1234");
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void unlock_migrateEnabled_shouldCallLegacyKeyringOnly() throws Exception {
         // Given migrate is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When unlocked is called
         keyring.unlock(user, "1234");
 
         // Then central keyring is unlocked
-        verify(legacyKeyring, times(1)).unlock(user, "1234");
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).unlock(user, "1234");
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void unlock_migrateDisabled_unlockErrorShouldThrowException() throws Exception {
         // Given migrate is disabled
         // And legacy keyring unlock throws an exception
-        keyring = new MigrationKeyringImpl(disabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         String password = "1234";
 
         doThrow(KeyringException.class)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .unlock(user, password);
 
         // When unlocked is called
@@ -829,20 +828,20 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, UNLOCK_KEYRING_ERR, disabled);
 
-        verify(legacyKeyring, times(1)).unlock(user, password);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).unlock(user, password);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void unlock_migrateEnabled_unlockErrorShouldThrowException() throws Exception {
         // Given migrate is enabled
         // And legacy keyring unlock throws an exception
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         String password = "1234";
 
         doThrow(KeyringException.class)
-                .when(legacyKeyring)
+                .when(legacyCollectionKeyring)
                 .unlock(user, password);
 
         // When unlocked is called
@@ -851,14 +850,14 @@ public class MigrationKeyringImplTest {
         // Then an exception is thrown
         assertWrappedException(actual, UNLOCK_KEYRING_ERR, enabled);
 
-        verify(legacyKeyring, times(1)).unlock(user, password);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).unlock(user, password);
+        verifyZeroInteractions(collectionKeyring);
     }
 
 
     @Test
     public void testAssignTo_shouldCallLegacyKeyring() throws Exception {
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         User src = mock(User.class);
         User target = mock(User.class);
@@ -866,20 +865,20 @@ public class MigrationKeyringImplTest {
 
         keyring.assignTo(src, target, assignments);
 
-        verify(legacyKeyring, times(1)).assignTo(src, target, assignments);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).assignTo(src, target, assignments);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test
     public void testRemoveFrom_shouldCallLegacyKeyring() throws Exception {
-        keyring = new MigrationKeyringImpl(enabled, legacyKeyring, centralKeyring);
+        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         User target = mock(User.class);
         List<CollectionDescription> removals = mock(List.class);
 
         keyring.revokeFrom(target, removals);
 
-        verify(legacyKeyring, times(1)).revokeFrom(target, removals);
-        verifyZeroInteractions(centralKeyring);
+        verify(legacyCollectionKeyring, times(1)).revokeFrom(target, removals);
+        verifyZeroInteractions(collectionKeyring);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
@@ -11,7 +11,7 @@ import com.github.onsdigital.zebedee.content.partial.markdown.MarkdownSection;
 import com.github.onsdigital.zebedee.content.util.ContentUtil;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.util.slack.SlackNotifier;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 public class CollectionMoveTest extends ZebedeeTestBaseFixture {
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring keyring;
 
     @Mock
     private User user;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -13,7 +13,7 @@ import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.approval.ApproveTask;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
 import com.github.onsdigital.zebedee.model.publishing.PublishNotification;
@@ -148,7 +148,7 @@ public class CollectionsTest {
     private EncryptionKeyFactory encryptionKeyFactory;
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
 
     private Collections collections;
     private Path collectionsPath;
@@ -200,7 +200,7 @@ public class CollectionsTest {
         when(zebedeeMock.getEncryptionKeyFactory())
                 .thenReturn(encryptionKeyFactory);
         when(zebedeeMock.getCollectionKeyring())
-                .thenReturn(keyring);
+                .thenReturn(collectionKeyring);
         when(usersServiceMock.getUserByEmail(anyString()))
                 .thenReturn(testUser);
         when(collectionReaderWriterFactoryMock.getWriter(zebedeeMock, collectionMock, sessionMock))
@@ -210,7 +210,7 @@ public class CollectionsTest {
         when(encryptionKeyFactory.newCollectionKey())
                 .thenReturn(key);
 
-        when(keyring.get(any(), any()))
+        when(collectionKeyring.get(any(), any()))
                 .thenReturn(key);
 
         Collection created = Collection.create(desc, zebedeeMock, sessionMock);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
@@ -8,7 +8,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
@@ -59,7 +59,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     private PermissionsService permissionsService;
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring keyring;
 
     @Mock
     private Collection collection;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
@@ -4,7 +4,7 @@ import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
-import com.github.onsdigital.zebedee.keyring.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -50,7 +50,7 @@ public class ZebedeeCollectionWriterTest {
     private UsersService usersService;
 
     @Mock
-    private Keyring keyring;
+    private CollectionKeyring collectionKeyring;
 
     @Mock
     private Collection collection;
@@ -82,7 +82,7 @@ public class ZebedeeCollectionWriterTest {
                 .thenReturn(usersService);
 
         when(zebedee.getCollectionKeyring())
-                .thenReturn(keyring);
+                .thenReturn(collectionKeyring);
 
         when(collection.getDescription())
                 .thenReturn(description);
@@ -93,7 +93,7 @@ public class ZebedeeCollectionWriterTest {
         when(usersService.getUserByEmail(EMAIL))
                 .thenReturn(user);
 
-        when(keyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(key);
 
         when(session.getEmail())
@@ -207,7 +207,7 @@ public class ZebedeeCollectionWriterTest {
 
     @Test
     public void testNew_getKeyThrowsException_shouldThrowException() throws Exception {
-        when(keyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenThrow(KeyringException.class);
 
         IOException ex = assertThrows(IOException.class,
@@ -215,12 +215,12 @@ public class ZebedeeCollectionWriterTest {
 
         verify(permissionsService, times(1)).canEdit(session);
         verify(usersService, times(1)).getUserByEmail(EMAIL);
-        verify(keyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).get(user, collection);
     }
 
     @Test
     public void testNew_getKeyReturnsNull_shouldThrowException() throws Exception {
-        when(keyring.get(user, collection))
+        when(collectionKeyring.get(user, collection))
                 .thenReturn(null);
 
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
@@ -229,6 +229,6 @@ public class ZebedeeCollectionWriterTest {
         assertThat(ex.getMessage(), equalTo(COLLECTION_KEY_NULL_ERR));
         verify(permissionsService, times(1)).canEdit(session);
         verify(usersService, times(1)).getUserByEmail(EMAIL);
-        verify(keyring, times(1)).get(user, collection);
+        verify(collectionKeyring, times(1)).get(user, collection);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/user/service/UsersServiceTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/user/service/UsersServiceTest.java
@@ -8,6 +8,7 @@ import com.github.onsdigital.zebedee.json.AdminOptions;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.json.Keyring;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -84,11 +85,11 @@ public class UsersServiceTest {
     private UsersServiceImpl.UserFactory userFactory;
 
     @Mock
-    private com.github.onsdigital.zebedee.keyring.Keyring centralKeyring;
+    private CollectionKeyring collectionKeyring;
 
     private UsersService service;
     private User user;
-    private Supplier<com.github.onsdigital.zebedee.keyring.Keyring> keyringSupplier;
+    private Supplier<CollectionKeyring> keyringSupplier;
 
     @Before
     public void setUp() throws Exception {
@@ -101,7 +102,7 @@ public class UsersServiceTest {
         user.setTemporaryPassword(false);
         user.setAdminOptions(new AdminOptions());
 
-        keyringSupplier = () -> centralKeyring;
+        keyringSupplier = () -> collectionKeyring;
 
         service = new UsersServiceImpl(userStore, collections, permissions, keyringSupplier);
 
@@ -437,7 +438,7 @@ public class UsersServiceTest {
         verify(permissions, times(1)).addEditor(EMAIL_2, session);
         verify(lockMock, times(3)).lock();
         verify(lockMock, times(3)).unlock();
-        verifyZeroInteractions(centralKeyring);
+        verifyZeroInteractions(collectionKeyring);
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -822,7 +823,7 @@ public class UsersServiceTest {
         List<CollectionDescription> expected = new ArrayList<>();
         expected.add(desc1);
         expected.add(desc2);
-        verify(centralKeyring, times(1)).assignTo(adminUser, userMock, expected);
+        verify(collectionKeyring, times(1)).assignTo(adminUser, userMock, expected);
         verify(userStore, times(1)).save(userMock);
     }
 


### PR DESCRIPTION
### What

I've renamed the new `Keyring` interface to `CollectionKeyring` to prevent confusion with the existing legacy `Keyring` class - this is a large and complex change and the clashing names was making very difficult to understand.

There should be no functional change at all - its just a rename.