### PR TITLE
renamed remaining new collection classes and interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ xcuserdata/
 *.xcscmblueprint
 
 \.vscode/
+
+run.sh

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -12,7 +12,7 @@ import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.KeyringUtil;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
@@ -317,7 +317,7 @@ public class Collection {
         // Remove the collection encryption key from the keyring
         User user = null;
         try {
-            user = KeyringUtil.getUser(usersService, s.getEmail());
+            user = CollectionKeyringUtil.getUser(usersService, s.getEmail());
         } catch (Exception ex) {
             String message = format("error attempting to get user from session details: {0}", s.getEmail());
             throw new InternalServerError(message, ex);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
@@ -20,7 +20,7 @@ import javax.ws.rs.GET;
 import java.io.IOException;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.getUser;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.getUser;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 
 /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Permission.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.getUser;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.getUser;
 
 /**
  * Created by david on 12/03/2015.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.getUser;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.getUser;
 
 /**
  * Created by thomasridd on 28/04/15.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyCache.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyCache.java
@@ -11,7 +11,7 @@ import java.util.Set;
  * {@link com.github.onsdigital.zebedee.model.Collection}s. Provides methods to add, retrieve and remove keys to/from
  * the keyring.
  */
-public interface KeyringCache {
+public interface CollectionKeyCache {
 
     /**
      * Populate the keyring.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyStore.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyStore.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * Defines the behaviour of a class for storing {@link SecretKey}s.
  */
-public interface KeyringStore {
+public interface CollectionKeyStore {
 
     /**
      * Read and decrypt all collection key files into a {@link java.util.HashMap}.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringUtil.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringUtil.java
@@ -10,12 +10,12 @@ import java.io.IOException;
 
 import static java.text.MessageFormat.format;
 
-public class KeyringUtil {
+public class CollectionKeyringUtil {
 
     public static final String GET_USER_ERR_FMT = "get user returned unexpected error: {0}";
     public static final String USER_NOT_FOUND_ERR_FMT = "requested user was not found: {0}";
 
-    private KeyringUtil() {
+    private CollectionKeyringUtil() {
         // Utility class with static only methods so hide constructor.
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/KeyringException.java
@@ -3,7 +3,7 @@ package com.github.onsdigital.zebedee.keyring;
 import java.io.IOException;
 
 /**
- * Exception type for errors while accessing/storing collection keys in the {@link KeyringCache}
+ * Exception type for errors while accessing/storing collection keys in the {@link CollectionKeyCache}
  */
 public class KeyringException extends IOException {
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImpl.java
@@ -1,9 +1,9 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
-import com.github.onsdigital.zebedee.keyring.KeyringCache;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.SchedulerKeyCache;
-import com.github.onsdigital.zebedee.keyring.KeyringStore;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyStore;
 import liquibase.util.StringUtils;
 
 import javax.crypto.SecretKey;
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * In memory {@link KeyringCache} implementation. Keyring uses a {@link KeyringStore} to persist entries to storage
+ * In memory {@link CollectionKeyCache} implementation. Keyring uses a {@link CollectionKeyStore} to persist entries to storage
  * whilst maintaining a copy of the data in an in-memory cache for speedy retrieval. If an attempt is made to add a
  * duplicate key the Keyring will compare the new & existing {@link SecretKey} values. If the keys are not equal then a
  * {@link KeyringException} is thrown. This aims to prevent collection key values being overwritten as this will
@@ -28,7 +28,7 @@ import java.util.Set;
  * However if this does become an issue consider replacing the Hashmap with some type time based cache object to
  * automatically evicted after a duration of inactivity.
  */
-public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache {
+public class CollectionKeyCacheImpl implements CollectionKeyCache, SchedulerKeyCache {
 
     static final String INVALID_COLLECTION_ID_ERR = "expected collection ID but was null or empty";
     static final String INVALID_SECRET_KEY_ERR = "expected secret key but was null";
@@ -39,26 +39,26 @@ public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache 
     static final String KEYSTORE_NULL_ERR = "collection key store required but was null";
     static final String NOT_INITIALISED_ERR = "keyringCache accessed but not yet initialised";
 
-    private KeyringStore keyStore;
+    private CollectionKeyStore keyStore;
     private Map<String, SecretKey> cache;
 
-    private static KeyringCache INSTANCE = null;
+    private static CollectionKeyCache INSTANCE = null;
 
     /**
-     * KeyringCache is a singleton instance. Use {@link CentralKeyringCacheImpl#init(KeyringStore)} to initialise and
-     * {@link CentralKeyringCacheImpl#getInstance()} to access the singleton.
+     * KeyringCache is a singleton instance. Use {@link CollectionKeyCacheImpl#init(CollectionKeyStore)} to initialise and
+     * {@link CollectionKeyCacheImpl#getInstance()} to access the singleton.
      */
-    private CentralKeyringCacheImpl() {
+    private CollectionKeyCacheImpl() {
         // private constructor to force use of static get instance method.
     }
 
     /**
-     * Create a new instance of the Keyring. Use {@link CentralKeyringCacheImpl#init(KeyringStore)} to constuct a new
+     * Create a new instance of the Keyring. Use {@link CollectionKeyCacheImpl#init(CollectionKeyStore)} to constuct a new
      * instance.
      *
-     * @param keyStore {@link KeyringStore} to use to read/write entries to/from persistent storage.
+     * @param keyStore {@link CollectionKeyStore} to use to read/write entries to/from persistent storage.
      */
-    CentralKeyringCacheImpl(final KeyringStore keyStore) throws KeyringException {
+    CollectionKeyCacheImpl(final CollectionKeyStore keyStore) throws KeyringException {
         if (keyStore == null) {
             throw new KeyringException(KEYSTORE_NULL_ERR);
         }
@@ -68,7 +68,7 @@ public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache 
         this.load();
     }
 
-    CentralKeyringCacheImpl(final KeyringStore keyStore, final Map<String, SecretKey> cache) {
+    CollectionKeyCacheImpl(final CollectionKeyStore keyStore, final Map<String, SecretKey> cache) {
         this.keyStore = keyStore;
         this.cache = cache;
     }
@@ -76,7 +76,7 @@ public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache 
     /**
      * {@inheritDoc}
      * <b>WARNING: This action is destructive</b>. Calling load on a populated keyring will clear all existing values
-     * from it before repopulating it with the the values returned by {@link KeyringStore#readAll()}. It is
+     * from it before repopulating it with the the values returned by {@link CollectionKeyStore#readAll()}. It is
      * strongly advised to only use this method when the keyring is initialised on start up.
      *
      * @throws KeyringException problem loading the keyring.
@@ -146,7 +146,7 @@ public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache 
     }
 
     /**
-     * Check if an entry for this collection ID already exists in the {@link KeyringStore}. If so retieve the entry from the
+     * Check if an entry for this collection ID already exists in the {@link CollectionKeyStore}. If so retieve the entry from the
      * store and check the existing key matches the key being added.
      *
      * @param collectionID the collection ID the entry is being added against.
@@ -214,25 +214,25 @@ public class CentralKeyringCacheImpl implements KeyringCache, SchedulerKeyCache 
     /**
      * Construct and initialise a new singleton instance of the keyring.
      *
-     * @param keystore the {@link KeyringStore} to use.
-     * @return a new {@link KeyringCache} instance.
+     * @param keystore the {@link CollectionKeyStore} to use.
+     * @return a new {@link CollectionKeyCache} instance.
      * @throws KeyringException problem initalising the keyring.
      */
-    public static void init(KeyringStore keystore) throws KeyringException {
+    public static void init(CollectionKeyStore keystore) throws KeyringException {
         if (INSTANCE == null) {
-            synchronized (CentralKeyringCacheImpl.class) {
+            synchronized (CollectionKeyCacheImpl.class) {
                 if (INSTANCE == null) {
-                    INSTANCE = new CentralKeyringCacheImpl(keystore);
+                    INSTANCE = new CollectionKeyCacheImpl(keystore);
                 }
             }
         }
     }
 
     /**
-     * @return a singleton instance of the {@link KeyringCache}
+     * @return a singleton instance of the {@link CollectionKeyCache}
      * @throws KeyringException the instance has not been initalised before being accessed.
      */
-    public static KeyringCache getInstance() throws KeyringException {
+    public static CollectionKeyCache getInstance() throws KeyringException {
         if (INSTANCE == null) {
             throw new KeyringException(NOT_INITIALISED_ERR);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyStoreImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyStoreImpl.java
@@ -1,7 +1,7 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.KeyringStore;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyStore;
 import org.apache.commons.io.IOUtils;
 
 import javax.crypto.Cipher;
@@ -27,7 +27,7 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
- * {@link java.io.File} based implementation of {@link KeyringStore}. Reads and writes
+ * {@link java.io.File} based implementation of {@link CollectionKeyStore}. Reads and writes
  * {@link SecretKey} objects to/from encrypted files on disk. Each method employs a synchronized block to prevent
  * race conditions whilst accessing the key files. This negative performance impact is a necessary and unavoidable
  * drawback to using files on disk instead of database.
@@ -35,7 +35,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  * <p><b>We strongly advised against using/extending this code for anything other than maintaining legacy
  * functionality in Zebedee CMS.</b></p>For all other purposes it should be considered deprecated. Use at your own risk.
  */
-public class CentralKeyringStoreImpl implements KeyringStore {
+public class CollectionKeyStoreImpl implements CollectionKeyStore {
 
     static final String INVALID_COLLECTION_ID_ERR = "collectionID required but was null or empty";
     static final String COLLECTION_KEY_NULL_ERR = "collectionKey required but was null";
@@ -78,7 +78,7 @@ public class CentralKeyringStoreImpl implements KeyringStore {
      * @param masterKey  the {@link SecretKey} to use when decrypting the collection key files.
      * @param masterIv   the {@link IvParameterSpec} to use when initializing the encryption {@link Cipher}.
      */
-    public CentralKeyringStoreImpl(final Path keyringDir, final SecretKey masterKey, final IvParameterSpec masterIv) {
+    public CollectionKeyStoreImpl(final Path keyringDir, final SecretKey masterKey, final IvParameterSpec masterIv) {
         this.keyringDir = keyringDir;
         this.masterKey = masterKey;
         this.masterIv = masterIv;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NopCollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NopCollectionKeyringImpl.java
@@ -13,10 +13,10 @@ import java.util.Set;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 
 /**
- * No-op implementation of the keyring interface - empty keyring stubbed placeholder for the new cenral keyring. DO
- * NOTHING JUST LOOK PRETTY.
+ * No-op implementation of the CollectionKeyring interface - empty keyring stubbed placeholder for the new cenral
+ * keyring. DO NOTHING JUST LOOK PRETTY.
  */
-public class NoOpCentralKeyring implements CollectionKeyring {
+public class NopCollectionKeyringImpl implements CollectionKeyring {
 
     @Override
     public void cacheKeyring(User user) throws KeyringException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl.java
@@ -32,7 +32,7 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
  * the new {@link CollectionKeyring} abstraction while maintaing backwards compatability and the ability to swicth back if
  * necessary.
  */
-public class LegacyKeyringImpl implements CollectionKeyring {
+public class LegacyCollectionKeyringImpl implements CollectionKeyring {
 
     static final String USER_NULL_ERR = "user required but was null";
     static final String EMAIL_EMPTY_ERR = "user email required but was empty";
@@ -68,8 +68,9 @@ public class LegacyKeyringImpl implements CollectionKeyring {
      * @param sessions the {@link Sessions} service to use.
      * @param cache    the {@link KeyringCache} to use.
      */
-    public LegacyKeyringImpl(final Sessions sessions, final UsersService usersService, PermissionsService permissions,
-                             final KeyringCache cache, final SchedulerKeyCache schedulerKeyCache) {
+    public LegacyCollectionKeyringImpl(final Sessions sessions, final UsersService usersService,
+                                       PermissionsService permissions, final KeyringCache cache,
+                                       final SchedulerKeyCache schedulerKeyCache) {
         this.sessions = sessions;
         this.usersService = usersService;
         this.permissions = permissions;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/MigrationCollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/MigrationCollectionKeyringImpl.java
@@ -15,7 +15,7 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 import static java.text.MessageFormat.format;
 
 /**
- * KeyringMigrator serves 2 purposes:
+ * MigrationCollectionKeyringImpl serves 2 purposes:
  * <ul>
  *     <li>It uses a feature flag to determine which {@link CollectionKeyring} implementation to use (legacy or new central).</li>
  *     <li>If the central keyring feature is disabled keys are read from the legacy keyring but adds/removes are
@@ -23,7 +23,7 @@ import static java.text.MessageFormat.format;
  *     without losing any keys.</li>
  * </ul>
  */
-public class MigrationKeyringImpl implements CollectionKeyring {
+public class MigrationCollectionKeyringImpl implements CollectionKeyring {
 
     static final String WRAPPED_ERR_FMT = "{0}: Migration enabled: {1}";
     static final String MIGRATE_ENABLED = "migration_enabled";
@@ -52,8 +52,9 @@ public class MigrationKeyringImpl implements CollectionKeyring {
      * @param legacyCollectionKeyring    the legacy keyring implementation to use.
      * @param collectionKeyring   the new central keyring implementation to use.
      */
-    public MigrationKeyringImpl(final boolean migrationEnabled, final CollectionKeyring legacyCollectionKeyring,
-                                final CollectionKeyring collectionKeyring) {
+    public MigrationCollectionKeyringImpl(final boolean migrationEnabled,
+                                          final CollectionKeyring legacyCollectionKeyring,
+                                          final CollectionKeyring collectionKeyring) {
         this.migrationEnabled = migrationEnabled;
         this.legacyCollectionKeyring = legacyCollectionKeyring;
         this.collectionKeyring = collectionKeyring;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -23,7 +23,7 @@ import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Events;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
-import com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl;
+import com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl;
 import com.github.onsdigital.zebedee.model.approval.tasks.ReleasePopulator;
 import com.github.onsdigital.zebedee.model.content.item.ContentItemVersion;
 import com.github.onsdigital.zebedee.model.content.item.VersionedContentItem;
@@ -81,7 +81,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.getUser;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.getUser;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
@@ -476,7 +476,7 @@ public class Collection {
          *
          * However, to maintain backwards compatability while we are in the process of migrating we still need to
          * distribute the key. This logic is now encapsulated within
-         * {@link LegacyKeyringImpl#add(User, Collection, SecretKey)} so we
+         * {@link LegacyCollectionKeyringImpl#add(User, Collection, SecretKey)} so we
          * invoke add again which will update all users either adding/removing the key to/from their keyring.
          */
         User user = getUser(zebedee.getUsersService(), session.getEmail());

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.GET_USER_ERR_FMT;
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.USER_NOT_FOUND_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.GET_USER_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.USER_NOT_FOUND_ERR_FMT;
 import static java.text.MessageFormat.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringUtilTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/CollectionKeyringUtilTest.java
@@ -11,8 +11,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.GET_USER_ERR_FMT;
-import static com.github.onsdigital.zebedee.keyring.KeyringUtil.USER_NOT_FOUND_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.GET_USER_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil.USER_NOT_FOUND_ERR_FMT;
 import static java.text.MessageFormat.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class KeyringUtilTest {
+public class CollectionKeyringUtilTest {
 
     static String EMAIL = "robertBobby@test.com";
 
@@ -39,7 +39,8 @@ public class KeyringUtilTest {
 
     @Test
     public void getUser_userServiceNull_shouldThrowException() {
-        InternalServerError ex = assertThrows(InternalServerError.class, () -> KeyringUtil.getUser(null, null));
+        InternalServerError ex = assertThrows(InternalServerError.class,
+                () -> CollectionKeyringUtil.getUser(null, null));
         assertThat(ex.getMessage(), equalTo("get user requires non null userService"));
     }
 
@@ -49,7 +50,7 @@ public class KeyringUtilTest {
                 .thenThrow(IOException.class);
 
         InternalServerError ex = assertThrows(InternalServerError.class,
-                () -> KeyringUtil.getUser(usersService, EMAIL));
+                () -> CollectionKeyringUtil.getUser(usersService, EMAIL));
 
         assertThat(ex.getMessage(), equalTo(format(GET_USER_ERR_FMT, EMAIL)));
         verify(usersService, times(1)).getUserByEmail(EMAIL);
@@ -60,7 +61,8 @@ public class KeyringUtilTest {
         when(usersService.getUserByEmail(any()))
                 .thenReturn(null);
 
-        NotFoundException ex = assertThrows(NotFoundException.class, () -> KeyringUtil.getUser(usersService, EMAIL));
+        NotFoundException ex = assertThrows(NotFoundException.class,
+                () -> CollectionKeyringUtil.getUser(usersService, EMAIL));
 
         assertThat(ex.getMessage(), equalTo(format(USER_NOT_FOUND_ERR_FMT, EMAIL)));
         verify(usersService, times(1)).getUserByEmail(EMAIL);
@@ -71,7 +73,7 @@ public class KeyringUtilTest {
         when(usersService.getUserByEmail(EMAIL))
                 .thenReturn(user);
 
-        User actual = KeyringUtil.getUser(usersService, EMAIL);
+        User actual = CollectionKeyringUtil.getUser(usersService, EMAIL);
 
         assertThat(actual, equalTo(user));
         verify(usersService, times(1)).getUserByEmail(EMAIL);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImplTest.java
@@ -1,9 +1,8 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
-import com.github.onsdigital.zebedee.keyring.KeyringCache;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl;
-import com.github.onsdigital.zebedee.keyring.KeyringStore;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -14,14 +13,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.INVALID_COLLECTION_ID_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.INVALID_SECRET_KEY_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.KEYSTORE_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.KEY_MISMATCH_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.KEY_NOT_FOUND_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.LOAD_KEYS_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.NOT_INITIALISED_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringCacheImpl.getInstance;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.INVALID_COLLECTION_ID_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.INVALID_SECRET_KEY_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.KEYSTORE_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.KEY_MISMATCH_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.KEY_NOT_FOUND_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.LOAD_KEYS_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.NOT_INITIALISED_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyCacheImpl.getInstance;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -38,15 +37,15 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class CentralKeyringCacheImplTest {
+public class CollectionKeyCacheImplTest {
 
     private static final String TEST_COLLECTION_ID = "138"; // We are 138! We are 138 \m/
 
-    private KeyringCache keyringCache;
+    private CollectionKeyCache keyCache;
     private Map<String, SecretKey> cache;
 
     @Mock
-    private KeyringStore keyStore;
+    private CollectionKeyStore keyStore;
 
     @Mock
     private SecretKey secretKey;
@@ -56,12 +55,12 @@ public class CentralKeyringCacheImplTest {
         MockitoAnnotations.initMocks(this);
 
         this.cache = new HashMap<>();
-        this.keyringCache = new CentralKeyringCacheImpl(keyStore, cache);
+        this.keyCache = new CollectionKeyCacheImpl(keyStore, cache);
     }
 
     @Test
     public void testAdd_collectionIDNull_shouldThrowException() {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(null, null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
         assertTrue(cache.isEmpty());
@@ -69,7 +68,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testAdd_collectionIDEmpty_shouldThrowException() throws Exception {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add("", null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add("", null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
         assertTrue(cache.isEmpty());
@@ -77,7 +76,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testAdd_secretKeyNull_shouldThrowException() throws Exception {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(TEST_COLLECTION_ID, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(TEST_COLLECTION_ID, null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_SECRET_KEY_ERR));
         assertThat(ex.getCollectionID(), equalTo(TEST_COLLECTION_ID));
@@ -89,7 +88,7 @@ public class CentralKeyringCacheImplTest {
         cache.put(TEST_COLLECTION_ID, secretKey);
         assertThat(cache.size(), equalTo(1));
 
-        keyringCache.add(TEST_COLLECTION_ID, secretKey);
+        keyCache.add(TEST_COLLECTION_ID, secretKey);
 
         assertThat(cache.size(), equalTo(1));
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
@@ -102,7 +101,7 @@ public class CentralKeyringCacheImplTest {
         SecretKey key2 = mock(SecretKey.class);
         cache.put(TEST_COLLECTION_ID, key2);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(TEST_COLLECTION_ID, secretKey));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(TEST_COLLECTION_ID, secretKey));
 
         verifyZeroInteractions(keyStore);
         assertThat(cache.size(), equalTo(1));
@@ -116,7 +115,7 @@ public class CentralKeyringCacheImplTest {
                 .when(keyStore)
                 .write(TEST_COLLECTION_ID, secretKey);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(TEST_COLLECTION_ID, secretKey));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(TEST_COLLECTION_ID, secretKey));
 
         verify(keyStore, times(1)).write(TEST_COLLECTION_ID, secretKey);
         assertTrue(cache.isEmpty());
@@ -130,7 +129,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.read(TEST_COLLECTION_ID))
                 .thenReturn(secretKey);
 
-        keyringCache.add(TEST_COLLECTION_ID, secretKey);
+        keyCache.add(TEST_COLLECTION_ID, secretKey);
 
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
         assertThat(cache.get(TEST_COLLECTION_ID), equalTo(secretKey));
@@ -144,7 +143,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.read(TEST_COLLECTION_ID))
                 .thenThrow(new KeyringException("unexpected error"));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(TEST_COLLECTION_ID, secretKey));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(TEST_COLLECTION_ID, secretKey));
 
         assertTrue(cache.isEmpty());
         assertThat(ex.getMessage(), equalTo("unexpected error"));
@@ -162,7 +161,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.read(TEST_COLLECTION_ID))
                 .thenReturn(mock(SecretKey.class));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.add(TEST_COLLECTION_ID, secretKey));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.add(TEST_COLLECTION_ID, secretKey));
 
         assertThat(ex.getMessage(), equalTo(KEY_MISMATCH_ERR));
         assertThat(ex.getCollectionID(), equalTo(TEST_COLLECTION_ID));
@@ -174,7 +173,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testAdd_success_shouldWriteKeyToStoreAndCache() throws Exception {
-        keyringCache.add(TEST_COLLECTION_ID, secretKey);
+        keyCache.add(TEST_COLLECTION_ID, secretKey);
 
         verify(keyStore, times(1)).write(TEST_COLLECTION_ID, secretKey);
         assertThat(cache.size(), equalTo(1));
@@ -184,7 +183,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testGet_collectionIDNull_shouldThrowException() throws Exception {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.get(null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.get(null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
         verifyZeroInteractions(keyStore);
@@ -192,7 +191,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testGet_collectionIDEmpty_shouldThrowException() throws Exception {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.get(null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.get(null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
         verifyZeroInteractions(keyStore);
@@ -202,7 +201,7 @@ public class CentralKeyringCacheImplTest {
     public void testGet_keyExistsInCache_shouldReturnKey() throws Exception {
         cache.put(TEST_COLLECTION_ID, secretKey);
 
-        SecretKey actual = keyringCache.get(TEST_COLLECTION_ID);
+        SecretKey actual = keyCache.get(TEST_COLLECTION_ID);
 
         assertThat(actual, equalTo(secretKey));
         verifyZeroInteractions(keyStore);
@@ -213,7 +212,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.exists(TEST_COLLECTION_ID))
                 .thenReturn(false);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.get(TEST_COLLECTION_ID));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.get(TEST_COLLECTION_ID));
 
         assertThat(ex.getMessage(), equalTo(KEY_NOT_FOUND_ERR));
         assertThat(ex.getCollectionID(), equalTo(TEST_COLLECTION_ID));
@@ -229,7 +228,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.read(TEST_COLLECTION_ID))
                 .thenReturn(secretKey);
 
-        SecretKey actual = keyringCache.get(TEST_COLLECTION_ID);
+        SecretKey actual = keyCache.get(TEST_COLLECTION_ID);
 
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
         assertThat(cache.get(TEST_COLLECTION_ID), equalTo(actual));
@@ -247,7 +246,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.read(TEST_COLLECTION_ID))
                 .thenThrow(new KeyringException("error"));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.get(TEST_COLLECTION_ID));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.get(TEST_COLLECTION_ID));
 
         assertThat(ex.getMessage(), equalTo("error"));
         assertFalse(cache.containsKey(TEST_COLLECTION_ID));
@@ -259,7 +258,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testRemove_collectionIDNull_shouldThrowException() {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.remove(null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.remove(null));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
 
@@ -268,7 +267,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testRemove_collectionIDEmpty_shouldThrowException() {
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.remove(""));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.remove(""));
 
         assertThat(ex.getMessage(), equalTo(INVALID_COLLECTION_ID_ERR));
 
@@ -280,7 +279,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.exists(TEST_COLLECTION_ID))
                 .thenReturn(false);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.remove(TEST_COLLECTION_ID));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.remove(TEST_COLLECTION_ID));
 
         assertThat(ex.getMessage(), equalTo(KEY_NOT_FOUND_ERR));
 
@@ -297,7 +296,7 @@ public class CentralKeyringCacheImplTest {
                 .when(keyStore)
                 .delete(TEST_COLLECTION_ID);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.remove(TEST_COLLECTION_ID));
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.remove(TEST_COLLECTION_ID));
 
         assertThat(ex.getMessage(), equalTo("pr review me"));
 
@@ -310,7 +309,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.exists(TEST_COLLECTION_ID))
                 .thenReturn(true);
 
-        keyringCache.remove(TEST_COLLECTION_ID);
+        keyCache.remove(TEST_COLLECTION_ID);
 
         verify(keyStore, times(1)).exists(TEST_COLLECTION_ID);
         verify(keyStore, times(1)).delete(TEST_COLLECTION_ID);
@@ -325,7 +324,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.exists(TEST_COLLECTION_ID))
                 .thenReturn(true);
 
-        keyringCache.remove(TEST_COLLECTION_ID);
+        keyCache.remove(TEST_COLLECTION_ID);
 
         assertFalse(cache.containsKey(TEST_COLLECTION_ID));
 
@@ -337,7 +336,7 @@ public class CentralKeyringCacheImplTest {
     public void testLoad_keystoreException_shouldThrowException() throws Exception {
         when(keyStore.readAll()).thenThrow(new KeyringException("boom"));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.load());
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.load());
 
         assertThat(ex.getMessage(), equalTo("boom"));
         verify(keyStore, times(1)).readAll();
@@ -348,7 +347,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(null);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.load());
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.load());
 
         assertThat(ex.getMessage(), equalTo(LOAD_KEYS_NULL_ERR));
         verify(keyStore, times(1)).readAll();
@@ -359,7 +358,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(new HashMap<>());
 
-        keyringCache.load();
+        keyCache.load();
 
         assertTrue(cache.isEmpty());
         verify(keyStore, times(1)).readAll();
@@ -374,7 +373,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(keysInStore);
 
-        keyringCache.load();
+        keyCache.load();
 
         assertThat(cache.size(), equalTo(1));
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
@@ -394,7 +393,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(keysInStore);
 
-        keyringCache.load();
+        keyCache.load();
 
         assertThat(cache.size(), equalTo(1));
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
@@ -405,7 +404,7 @@ public class CentralKeyringCacheImplTest {
 
     @Test
     public void testInit_keystoreNull_shouldThrowException() {
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringCacheImpl.init(null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyCacheImpl.init(null));
 
         assertThat(ex.getMessage(), equalTo(KEYSTORE_NULL_ERR));
     }
@@ -415,7 +414,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenThrow(new KeyringException("boom"));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringCacheImpl.init(keyStore));
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyCacheImpl.init(keyStore));
 
         assertThat(ex.getMessage(), equalTo("boom"));
         verify(keyStore, times(1)).readAll();
@@ -426,7 +425,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(null);
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringCacheImpl.init(keyStore));
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyCacheImpl.init(keyStore));
 
         assertThat(ex.getMessage(), equalTo(LOAD_KEYS_NULL_ERR));
         verify(keyStore, times(1)).readAll();
@@ -440,10 +439,10 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenReturn(keys);
 
-        CentralKeyringCacheImpl.init(keyStore);
-        KeyringCache keyringCache = getInstance();
+        CollectionKeyCacheImpl.init(keyStore);
+        CollectionKeyCache collectionKeyCache = getInstance();
 
-        assertThat(keyringCache.get(TEST_COLLECTION_ID), equalTo(secretKey));
+        assertThat(collectionKeyCache.get(TEST_COLLECTION_ID), equalTo(secretKey));
         verify(keyStore, times(1)).readAll();
     }
 
@@ -452,7 +451,7 @@ public class CentralKeyringCacheImplTest {
         // Given the KeyringCache has not been initalised
 
         // When getInstance is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringCacheImpl.getInstance());
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyCacheImpl.getInstance());
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(NOT_INITIALISED_ERR));
@@ -461,10 +460,10 @@ public class CentralKeyringCacheImplTest {
     @Test
     public void testGetInstance_success() throws Exception {
         // Given the KeyringCache has been initialised
-        CentralKeyringCacheImpl.init(keyStore);
+        CollectionKeyCacheImpl.init(keyStore);
 
         // When getInstance is called
-        KeyringCache actual = CentralKeyringCacheImpl.getInstance();
+        CollectionKeyCache actual = CollectionKeyCacheImpl.getInstance();
 
         // Then the singleton instance is returned
         assertThat(actual, is(notNullValue()));
@@ -474,7 +473,7 @@ public class CentralKeyringCacheImplTest {
     public void testList_keysExistsInCache_shouldReturnSetOfCollectionIDs() throws Exception {
         cache.put(TEST_COLLECTION_ID, secretKey);
 
-        Set<String> actual = keyringCache.list();
+        Set<String> actual = keyCache.list();
 
         assertTrue(actual.contains(TEST_COLLECTION_ID));
         verifyZeroInteractions(keyStore);
@@ -490,7 +489,7 @@ public class CentralKeyringCacheImplTest {
 
         assertTrue(cache.isEmpty());
 
-        Set<String> actual = keyringCache.list();
+        Set<String> actual = keyCache.list();
 
         assertTrue(cache.containsKey(TEST_COLLECTION_ID));
         assertTrue(actual.contains(TEST_COLLECTION_ID));
@@ -504,7 +503,7 @@ public class CentralKeyringCacheImplTest {
         when(keyStore.readAll())
                 .thenThrow(new KeyringException("error"));
 
-        KeyringException ex = assertThrows(KeyringException.class, () -> keyringCache.list());
+        KeyringException ex = assertThrows(KeyringException.class, () -> keyCache.list());
 
         assertThat(ex.getMessage(), equalTo("error"));
         assertFalse(cache.containsKey(TEST_COLLECTION_ID));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImplTest.java
@@ -2,7 +2,7 @@ package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
-import com.github.onsdigital.zebedee.keyring.KeyringCache;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
@@ -22,19 +22,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.COLLECTIONS_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.COLLECTION_DESCRIPTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.COLLECTION_ID_NULL_OR_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.FILTER_COLLECTIONS_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.KEYRING_CACHE_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.NOT_INITIALISED_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.PERMISSION_SERVICE_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.SECRET_KEY_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.USER_EMAIL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.USER_KEYRING_LOCKED_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.USER_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.central.CentralKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.COLLECTIONS_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.COLLECTION_DESCRIPTION_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.COLLECTION_ID_NULL_OR_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.COLLECTION_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.FILTER_COLLECTIONS_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.KEYRING_CACHE_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.NOT_INITIALISED_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.PERMISSION_SERVICE_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.SECRET_KEY_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.USER_EMAIL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.USER_KEYRING_LOCKED_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.central.CollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class CentralKeyringImplTest {
+public class CollectionKeyringImplTest {
 
     static final String TEST_COLLECTION_ID = "44";
     static final String SECRET_KEY = "441";
@@ -57,7 +57,7 @@ public class CentralKeyringImplTest {
     private CollectionKeyring keyring;
 
     @Mock
-    private KeyringCache keyringCache;
+    private CollectionKeyCache keyCache;
 
     @Mock
     private User user;
@@ -84,8 +84,8 @@ public class CentralKeyringImplTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        CentralKeyringImpl.init(keyringCache, permissionsService, collections);
-        keyring = CentralKeyringImpl.getInstance();
+        CollectionKeyringImpl.init(keyCache, permissionsService, collections);
+        keyring = CollectionKeyringImpl.getInstance();
     }
 
     @After
@@ -101,7 +101,7 @@ public class CentralKeyringImplTest {
 
         // then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
-        verifyZeroInteractions(keyringCache);
+        verifyZeroInteractions(keyCache);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class CentralKeyringImplTest {
 
         // Then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_NULL_ERR));
-        verifyZeroInteractions(keyringCache);
+        verifyZeroInteractions(keyCache);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class CentralKeyringImplTest {
 
         // Then a Keyring exception is thrown.
         assertThat(ex.getMessage(), equalTo(USER_KEYRING_LOCKED_ERR));
-        verifyZeroInteractions(keyringCache);
+        verifyZeroInteractions(keyCache);
     }
 
     @Test
@@ -160,7 +160,7 @@ public class CentralKeyringImplTest {
         keyring.cacheKeyring(user);
 
         // Then the central keyring is not updated.
-        verifyZeroInteractions(keyringCache);
+        verifyZeroInteractions(keyCache);
     }
 
     @Test
@@ -184,14 +184,14 @@ public class CentralKeyringImplTest {
                 .thenReturn(secretKey);
 
         doThrow(KeyringException.class)
-                .when(keyringCache)
+                .when(keyCache)
                 .add(any(), any());
 
         // When cacheKeyring is called
         assertThrows(KeyringException.class, () -> keyring.cacheKeyring(user));
 
         // Then the central keyring is not updated.
-        verify(keyringCache, times(1)).add(any(), any());
+        verify(keyCache, times(1)).add(any(), any());
     }
 
     @Test
@@ -218,7 +218,7 @@ public class CentralKeyringImplTest {
         keyring.cacheKeyring(user);
 
         // Then the central keyring is updated with each entry in the user keyring.
-        verify(keyringCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
+        verify(keyCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
     }
 
     @Test
@@ -228,7 +228,7 @@ public class CentralKeyringImplTest {
 
         // When GetInstance is called
         // Then an exception is thrown
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringImpl.getInstance());
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyringImpl.getInstance());
         assertThat(ex.getMessage(), equalTo(NOT_INITIALISED_ERR));
     }
 
@@ -237,7 +237,7 @@ public class CentralKeyringImplTest {
         // Given CollectionKeyring has been initialised
 
         // When GetInstance is called
-        CollectionKeyring keyring = CentralKeyringImpl.getInstance();
+        CollectionKeyring keyring = CollectionKeyringImpl.getInstance();
 
         // Then a non null instance is returned
         assertThat(keyring, is(notNullValue()));
@@ -248,7 +248,7 @@ public class CentralKeyringImplTest {
         resetInstanceToNull();
 
         // When init is called
-        KeyringException ex = assertThrows(KeyringException.class, () -> CentralKeyringImpl.init(null, null, null));
+        KeyringException ex = assertThrows(KeyringException.class, () -> CollectionKeyringImpl.init(null, null, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(KEYRING_CACHE_NULL_ERR));
@@ -260,7 +260,7 @@ public class CentralKeyringImplTest {
 
         // When init is called
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> CentralKeyringImpl.init(keyringCache, null, null));
+                () -> CollectionKeyringImpl.init(keyCache, null, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(PERMISSION_SERVICE_NULL_ERR));
@@ -272,7 +272,7 @@ public class CentralKeyringImplTest {
 
         // When init is called
         KeyringException ex = assertThrows(KeyringException.class,
-                () -> CentralKeyringImpl.init(keyringCache, permissionsService, null));
+                () -> CollectionKeyringImpl.init(keyCache, permissionsService, null));
 
         // Then an exception is thrown
         assertThat(ex.getMessage(), equalTo(COLLECTIONS_NULL_ERR));
@@ -422,14 +422,14 @@ public class CentralKeyringImplTest {
         when(permissionsService.canEdit(TEST_EMAIL_ID))
                 .thenReturn(true);
 
-        when(keyringCache.get(TEST_COLLECTION_ID))
+        when(keyCache.get(TEST_COLLECTION_ID))
                 .thenThrow(new KeyringException("Beep"));
 
         KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(user, collection));
         assertThat(ex.getMessage(), equalTo("Beep"));
 
         verify(permissionsService, times(1)).canEdit(TEST_EMAIL_ID);
-        verify(keyringCache, times(1)).get(TEST_COLLECTION_ID);
+        verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
     @Test
@@ -446,14 +446,14 @@ public class CentralKeyringImplTest {
         when(permissionsService.canEdit(TEST_EMAIL_ID))
                 .thenReturn(true);
 
-        when(keyringCache.get(TEST_COLLECTION_ID))
+        when(keyCache.get(TEST_COLLECTION_ID))
                 .thenReturn(null);
 
         SecretKey key = keyring.get(user, collection);
 
         assertThat(key, is(nullValue()));
         verify(permissionsService, times(1)).canEdit(TEST_EMAIL_ID);
-        verify(keyringCache, times(1)).get(TEST_COLLECTION_ID);
+        verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
     @Test
@@ -470,14 +470,14 @@ public class CentralKeyringImplTest {
         when(permissionsService.canEdit(TEST_EMAIL_ID))
                 .thenReturn(true);
 
-        when(keyringCache.get(TEST_COLLECTION_ID))
+        when(keyCache.get(TEST_COLLECTION_ID))
                 .thenReturn(secretKey);
 
         SecretKey key = keyring.get(user, collection);
 
         assertThat(key, equalTo(secretKey));
         verify(permissionsService, times(1)).canEdit(TEST_EMAIL_ID);
-        verify(keyringCache, times(1)).get(TEST_COLLECTION_ID);
+        verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
     @Test
@@ -643,7 +643,7 @@ public class CentralKeyringImplTest {
         keyring.remove(user, collection);
 
         verify(permissionsService, times(1)).canEdit(user.getEmail());
-        verify(keyringCache, times(1)).remove(TEST_COLLECTION_ID);
+        verify(keyCache, times(1)).remove(TEST_COLLECTION_ID);
     }
 
     @Test
@@ -807,7 +807,7 @@ public class CentralKeyringImplTest {
         keyring.add(user, collection, secretKey);
 
         verify(permissionsService, times(1)).canEdit(user.getEmail());
-        verifyZeroInteractions(keyringCache);
+        verifyZeroInteractions(keyCache);
     }
 
     @Test
@@ -827,7 +827,7 @@ public class CentralKeyringImplTest {
         keyring.add(user, collection, secretKey);
 
         verify(permissionsService, times(1)).canEdit(user.getEmail());
-        verify(keyringCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
+        verify(keyCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
     }
 
     @Test
@@ -908,7 +908,7 @@ public class CentralKeyringImplTest {
             add("333");
         }};
 
-        when(keyringCache.list())
+        when(keyCache.list())
                 .thenReturn(expected);
 
         Set<String> actual = keyring.list(user);
@@ -984,7 +984,7 @@ public class CentralKeyringImplTest {
             add(TEST_COLLECTION_ID);
             add("333");
         }};
-        when(keyringCache.list())
+        when(keyCache.list())
                 .thenReturn(cacheValues);
 
         when(collection.getId())
@@ -1014,12 +1014,12 @@ public class CentralKeyringImplTest {
         keyring.unlock(null, null);
 
         // Then no action is taken
-        verifyZeroInteractions(user, keyringCache, permissionsService);
+        verifyZeroInteractions(user, keyCache, permissionsService);
     }
 
     private void resetInstanceToNull() throws Exception {
         // Use some evil reflection magic to set the instance back to null for this test case.
-        Field field = CentralKeyringImpl.class.getDeclaredField("INSTANCE");
+        Field field = CollectionKeyringImpl.class.getDeclaredField("INSTANCE");
         field.setAccessible(true);
         field.set(null, null);
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
@@ -108,7 +108,8 @@ public abstract class BaseLegacyKeyringTest {
 
         setUpTests();
 
-        legacyCollectionKeyring = new LegacyKeyringImpl(sessionsService, users, permissions, keyringCache, schedulerCache);
+        legacyCollectionKeyring = new LegacyCollectionKeyringImpl(
+                sessionsService, users, permissions, keyringCache, schedulerCache);
 
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_AddTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_AddTest.java
@@ -9,14 +9,14 @@ import org.mockito.Mock;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.ADD_KEY_SAVE_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_DESC_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_ID_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.GET_KEY_RECIPIENTS_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.LIST_USERS_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.REMOVE_KEY_SAVE_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.SECRET_KEY_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.ADD_KEY_SAVE_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_DESC_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_ID_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.GET_KEY_RECIPIENTS_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.LIST_USERS_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.REMOVE_KEY_SAVE_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.SECRET_KEY_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests to verify LegacyKeyringImpl#Add().
  */
-public class LegacyKeyringImpl_AddTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_AddTest extends BaseLegacyKeyringTest {
 
     @Mock
     private User user;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_AssignToTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_AssignToTest.java
@@ -11,11 +11,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.CACHE_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.KEYRING_LOCKED_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.CACHE_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.KEYRING_LOCKED_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_AssignToTest extends BaseLegacyKeyringTest {
 
     @Mock
     private Keyring bertCachedKeyring, ernieCachedKeyring;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_GetTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_GetTest.java
@@ -6,12 +6,12 @@ import org.junit.Test;
 import javax.crypto.SecretKey;
 import java.io.IOException;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.CACHE_GET_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_DESC_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_ID_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.CACHE_GET_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_DESC_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_ID_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_GetTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_GetTest extends BaseLegacyKeyringTest {
 
     @Override
     public void setUpTests() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_ListTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_ListTest.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.GET_USER_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.GET_USER_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_ListTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_ListTest extends BaseLegacyKeyringTest {
 
     @Override
     public void setUpTests() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RemoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RemoveTest.java
@@ -7,11 +7,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_DESC_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_ID_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.LIST_USERS_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.REMOVE_KEY_SAVE_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_DESC_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_ID_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.COLLECTION_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.LIST_USERS_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.REMOVE_KEY_SAVE_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_RemoveTest extends BaseLegacyKeyringTest {
 
     @Override
     public void setUpTests() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RevokeFromTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RevokeFromTest.java
@@ -9,10 +9,10 @@ import org.mockito.Mock;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.CACHE_GET_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.CACHE_GET_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_RevokeFromTest extends BaseLegacyKeyringTest {
 
     @Mock
     private Keyring bertCachedKeyring;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_UnlockTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_UnlockTest.java
@@ -3,11 +3,11 @@ package com.github.onsdigital.zebedee.keyring.legacy;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import org.junit.Test;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.PASSWORD_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.UNLOCK_KEYRING_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.PASSWORD_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.UNLOCK_KEYRING_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
+public class LegacyCollectionKeyringImpl_UnlockTest extends BaseLegacyKeyringTest {
 
     @Override
     public void setUpTests() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_CacheCollectionKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyKeyringImpl_CacheCollectionKeyringTest.java
@@ -5,11 +5,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.CACHE_PUT_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.EMAIL_EMPTY_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.GET_SESSION_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_KEYRING_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.legacy.LegacyKeyringImpl.USER_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.CACHE_PUT_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.EMAIL_EMPTY_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.GET_SESSION_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_KEYRING_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.legacy.LegacyCollectionKeyringImpl.USER_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class LegacyKeyringImpl_CacheKeyringTest extends BaseLegacyKeyringTest {
+public class LegacyKeyringImpl_CacheCollectionKeyringTest extends BaseLegacyKeyringTest {
 
     @Override
     public void setUpTests() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/migration/MigrationCollectionKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/migration/MigrationCollectionKeyringImplTest.java
@@ -15,15 +15,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.ADD_KEY_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.GET_KEY_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.KEY_NULL_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.LIST_KEYS_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.POPULATE_FROM_USER_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.REMOVE_KEY_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.ROLLBACK_FAILED_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.UNLOCK_KEYRING_ERR;
-import static com.github.onsdigital.zebedee.keyring.migration.MigrationKeyringImpl.WRAPPED_ERR_FMT;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.ADD_KEY_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.GET_KEY_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.KEY_NULL_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.LIST_KEYS_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.POPULATE_FROM_USER_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.REMOVE_KEY_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.ROLLBACK_FAILED_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.UNLOCK_KEYRING_ERR;
+import static com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl.WRAPPED_ERR_FMT;
 import static java.text.MessageFormat.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class MigrationKeyringImplTest {
+public class MigrationCollectionKeyringImplTest {
 
     @Mock
     private User user;
@@ -84,7 +84,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void cacheKeyring_migrateDisabled_success_shouldUpdateBothKeyrings() throws Exception {
         // Given keyring migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When cacheKeyring is called
         keyring.cacheKeyring(user);
@@ -97,7 +97,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void cacheKeyring_migrateEnabled_success_shouldUpdateBothKeyrings() throws Exception {
         // Given keyring migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When cacheKeyring is called
         keyring.cacheKeyring(user);
@@ -111,7 +111,7 @@ public class MigrationKeyringImplTest {
     public void cacheKeyring_migrateDisabled_legacyKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And legacy keyring errors when called.
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
                 .when(legacyCollectionKeyring)
@@ -134,7 +134,7 @@ public class MigrationKeyringImplTest {
     public void cacheKeyring_migrateEnabled_legacyKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And legacy keyring errors when called.
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
                 .when(legacyCollectionKeyring)
@@ -157,7 +157,7 @@ public class MigrationKeyringImplTest {
     public void cacheKeyring_migrateDisabled_centralKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And central keyring errors when called.
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
                 .when(collectionKeyring)
@@ -180,7 +180,7 @@ public class MigrationKeyringImplTest {
     public void cacheKeyring_migrateEnabled_centralKeyringException_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And central keyring errors when called.
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(KeyringException.class)
                 .when(collectionKeyring)
@@ -202,7 +202,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void get_migrateDisabled_success_shouldReadFromLegacyKeyring() throws Exception {
         // Given keyring migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -220,7 +220,7 @@ public class MigrationKeyringImplTest {
     public void get_migrateDisabled_keyringError_shouldThrowException() throws Exception {
         // Given keyring migration is disabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenThrow(KeyringException.class);
@@ -241,7 +241,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void get_migrateEnabled_success_shouldReadFromCentralKeyring() throws Exception {
         // Given keyring migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -259,7 +259,7 @@ public class MigrationKeyringImplTest {
     public void get_migrateEnabled_keyringError_shouldThrowException() throws Exception {
         // Given keyring migration is enabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenThrow(KeyringException.class);
@@ -281,7 +281,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateDisabled_getKeyError_shouldThrownException() throws Exception {
         // Given migration is disabled
         // And get key returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenThrow(keyringException);
@@ -300,7 +300,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateEnabled_getKeyError_shouldThrownException() throws Exception {
         // Given migration is enabled
         // And get key returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenThrow(keyringException);
@@ -319,7 +319,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateDisabled_keyNull_shouldThrowException() throws Exception {
         // Given migration is disabled
         // And get key returns null
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(null);
@@ -338,7 +338,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateEnabled_keyNull_shouldThrowException() throws Exception {
         // Given migration is enabled
         // And get key returns null
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(null);
@@ -357,7 +357,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateDisabled_centralKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is disabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -380,7 +380,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateEnabled_centralKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is enabled
         // And central keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -403,7 +403,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateDisabled_legacyKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is disabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -426,7 +426,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateEnabled_legacyKeyringRemoveException_shouldThrowException() throws KeyringException {
         // Given migration is enabled
         // And legacy keyring returns an error
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -451,7 +451,7 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And legacy keyring returns an error
         // And remove rollback fails
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -480,7 +480,7 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And legacy keyring returns an error
         // And remove rollback fails
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -508,7 +508,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateDisabled_success_shouldRemoveKeyFromBothKeyrings() throws Exception {
         // Given migration is disabled
         // And remove is successful
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -527,7 +527,7 @@ public class MigrationKeyringImplTest {
     public void remove_migrateEnabled_success_shouldRemoveKeyFromBothKeyrings() throws Exception {
         // Given migration is enabled
         // And remove is successful
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.get(user, collection))
                 .thenReturn(secretKey);
@@ -546,7 +546,7 @@ public class MigrationKeyringImplTest {
     public void add_migrateDisabled_legacyKeyringError_shouldThrowException() throws Exception {
         // Given migration is disabled
         // And legacy keyring.add is unsuccessful
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(legacyCollectionKeyring)
@@ -566,7 +566,7 @@ public class MigrationKeyringImplTest {
     public void add_migrateEnabled_legacyKeyringError_shouldThrowException() throws Exception {
         // Given migration is enabled
         // And legacy keyring.add is unsuccessful
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(legacyCollectionKeyring)
@@ -587,7 +587,7 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And central keyring.add is unsuccessful
         // And rollback is unsuccessful
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(collectionKeyring)
@@ -613,7 +613,7 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And central keyring.add is unsuccessful
         // And rollback is unsuccessful
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(collectionKeyring)
@@ -639,7 +639,7 @@ public class MigrationKeyringImplTest {
         // Given migration is disabled
         // And central keyring.add is unsuccessful
         // And rollback is successful
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(collectionKeyring)
@@ -661,7 +661,7 @@ public class MigrationKeyringImplTest {
         // Given migration is enabled
         // And central keyring.add is unsuccessful
         // And rollback is successful
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         doThrow(keyringException).
                 when(collectionKeyring)
@@ -681,7 +681,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void add_migrateDisabled_success_shouldAddKeyToBothKeyrings() throws Exception {
         // Given migration is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When add is called
         keyring.add(user, collection, secretKey);
@@ -695,7 +695,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void add_migrateEnabled_success_shouldAddKeyToBothKeyrings() throws Exception {
         // Given migration is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When add is called
         keyring.add(user, collection, secretKey);
@@ -710,7 +710,7 @@ public class MigrationKeyringImplTest {
     public void list_migrateDisabled_listError_shouldThrowException() throws Exception {
         // Given migrate is disabled
         // And legacy keyring.list throws an exception
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         when(legacyCollectionKeyring.list(user))
                 .thenThrow(keyringException);
@@ -728,7 +728,7 @@ public class MigrationKeyringImplTest {
     public void list_migrateEnabled_listError_shouldThrowException() throws Exception {
         // Given migrate is enabled
         // And legacy keyring.list throws an exception
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         when(collectionKeyring.list(user))
                 .thenThrow(keyringException);
@@ -745,7 +745,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void list_migrateDisabled_success_shouldListKeys() throws Exception {
         // Given migrate is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         Set<String> keys = new HashSet<String>() {{
             add("1234567890");
@@ -766,7 +766,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void list_migrateEnabled_success_shouldListKeys() throws Exception {
         // Given migrate is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         Set<String> keys = new HashSet<String>() {{
             add("1234567890");
@@ -787,7 +787,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void unlock_migrateDisbaled_shouldCallLegacyKeyringUnlock() throws Exception {
         // Given migrate is disabled
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         // When unlocked is called
         keyring.unlock(user, "1234");
@@ -800,7 +800,7 @@ public class MigrationKeyringImplTest {
     @Test
     public void unlock_migrateEnabled_shouldCallLegacyKeyringOnly() throws Exception {
         // Given migrate is enabled
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         // When unlocked is called
         keyring.unlock(user, "1234");
@@ -814,7 +814,7 @@ public class MigrationKeyringImplTest {
     public void unlock_migrateDisabled_unlockErrorShouldThrowException() throws Exception {
         // Given migrate is disabled
         // And legacy keyring unlock throws an exception
-        keyring = new MigrationKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(disabled, legacyCollectionKeyring, collectionKeyring);
 
         String password = "1234";
 
@@ -836,7 +836,7 @@ public class MigrationKeyringImplTest {
     public void unlock_migrateEnabled_unlockErrorShouldThrowException() throws Exception {
         // Given migrate is enabled
         // And legacy keyring unlock throws an exception
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         String password = "1234";
 
@@ -857,7 +857,7 @@ public class MigrationKeyringImplTest {
 
     @Test
     public void testAssignTo_shouldCallLegacyKeyring() throws Exception {
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         User src = mock(User.class);
         User target = mock(User.class);
@@ -871,7 +871,7 @@ public class MigrationKeyringImplTest {
 
     @Test
     public void testRemoveFrom_shouldCallLegacyKeyring() throws Exception {
-        keyring = new MigrationKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
+        keyring = new MigrationCollectionKeyringImpl(enabled, legacyCollectionKeyring, collectionKeyring);
 
         User target = mock(User.class);
         List<CollectionDescription> removals = mock(List.class);


### PR DESCRIPTION
### What

Renamed remaining new collection key classes to make it clearer and easier to differentiate between the legacy/new code. No functional changes - just renaming. I have run my Keyring integration tests against my local build to confirm no regressions.
