### PR TITLE
updated Zebedee to use No op alternatives for Slack integration when …

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -92,7 +92,6 @@ public class Zebedee {
     private final KafkaService kafkaService;
     private final ServiceStoreImpl serviceStoreImpl;
     private final StartUpAlerter startUpAlerter;
-    private final SlackClient slackClient;
     private final Notifier slackNotifier;
 
     /**
@@ -131,8 +130,7 @@ public class Zebedee {
         this.servicePath = cfg.getServicePath();
         this.keyRingPath = cfg.getKeyRingPath();
         this.startUpAlerter = cfg.getStartUpAlerter();
-        this.slackClient = cfg.getSlackClient();
-        this.slackNotifier = new SlackNotifier(slackClient);
+        this.slackNotifier = cfg.getSlackNotifier();
     }
 
     /**
@@ -430,10 +428,6 @@ public class Zebedee {
 
     public StartUpAlerter getStartUpAlerter() {
         return this.startUpAlerter;
-    }
-
-    public SlackClient getSlackClient() {
-        return this.slackClient;
     }
 
     public Notifier getSlackNotifier() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -26,7 +26,6 @@ import com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyCac
 import com.github.onsdigital.zebedee.keyring.migration.MigrationCollectionKeyringImpl;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.model.Content;
-import com.github.onsdigital.zebedee.model.KeyringCache;
 import com.github.onsdigital.zebedee.model.RedirectTablePartialMatch;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
@@ -54,6 +53,10 @@ import com.github.onsdigital.zebedee.user.service.UsersService;
 import com.github.onsdigital.zebedee.user.service.UsersServiceImpl;
 import com.github.onsdigital.zebedee.user.store.UserStoreFileSystemImpl;
 import com.github.onsdigital.zebedee.util.slack.NoOpStartUpAlerter;
+import com.github.onsdigital.zebedee.util.slack.NopNotifierImpl;
+import com.github.onsdigital.zebedee.util.slack.NopSlackClientImpl;
+import com.github.onsdigital.zebedee.util.slack.Notifier;
+import com.github.onsdigital.zebedee.util.slack.SlackNotifier;
 import com.github.onsdigital.zebedee.util.slack.StartUpAlerter;
 import com.github.onsdigital.zebedee.util.slack.StartUpAlerterImpl;
 import com.github.onsdigital.zebedee.util.versioning.VersionsService;
@@ -94,6 +97,7 @@ import static com.github.onsdigital.zebedee.configuration.Configuration.getKeyri
 import static com.github.onsdigital.zebedee.configuration.Configuration.getServiceAuthToken;
 import static com.github.onsdigital.zebedee.configuration.Configuration.slackChannelsToNotfiyOnStartUp;
 import static com.github.onsdigital.zebedee.permissions.store.PermissionsStoreFileSystemImpl.initialisePermissions;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Object encapsulating the set up configuration required by {@link Zebedee}. Set paths to & create relevant
@@ -132,6 +136,7 @@ public class ZebedeeConfiguration {
     private EncryptionKeyFactory encryptionKeyFactory;
     private StartUpAlerter startUpAlerter;
     private SlackClient slackClient;
+    private Notifier slackNotifier;
 
     /**
      * Create a new configuration object.
@@ -237,7 +242,7 @@ public class ZebedeeConfiguration {
             kafkaService = new NoOpKafkaService();
         }
 
-        this.startUpAlerter = initStartUpAlerter();
+        initSlackIntegration();
 
         info().data("root_path", rootPath.toString())
                 .data("zebedee_path", zebedeePath.toString())
@@ -290,14 +295,43 @@ public class ZebedeeConfiguration {
                 false, legacyCollectionKeyring, nopCollectionKeyring);
     }
 
-    private StartUpAlerter initStartUpAlerter() {
+    /**
+     * Initalise the CMS's Slack integration. If the required configuration values are not available the CMS will
+     * default to No Op implementation - slack messages will be logged but sent to the Slack API.
+     */
+    private void initSlackIntegration() {
+        String slackToken = System.getenv("slack_api_token");
         List<String> startUpNotificationRecipients = slackChannelsToNotfiyOnStartUp();
 
-        if (startUpNotificationRecipients == null || startUpNotificationRecipients.isEmpty()) {
-            warn().log("startUpNotificationRecipients was null or empty NoOpStartUpAlerter will be initialized.");
-            return new NoOpStartUpAlerter();
+        boolean validConfig = true;
+        if (isEmpty(slackToken)) {
+            warn().log("env var slack_api_token is null or empty");
+            validConfig = false;
         }
-        return new StartUpAlerterImpl(slackClient, slackChannelsToNotfiyOnStartUp());
+
+        if (startUpNotificationRecipients == null || startUpNotificationRecipients.isEmpty()) {
+            warn().log("env var START_UP_NOTIFY_LIST is null or empty");
+            validConfig = false;
+        }
+
+        if (validConfig) {
+            info().log("valid Slack configuation found for CMS/Slack integration");
+
+            this.slackClient = new SlackClientImpl(new Profile.Builder()
+                    .emoji(":flo:")
+                    .username("Florence")
+                    .authToken(slackToken)
+                    .create());
+
+            this.slackNotifier = new SlackNotifier(this.slackClient);
+            this.startUpAlerter = new StartUpAlerterImpl(slackClient, startUpNotificationRecipients);
+        } else {
+            warn().log("slack configuration missing/empty defaulting to No op implementation");
+
+            this.slackClient = new NopSlackClientImpl();
+            this.slackNotifier = new NopNotifierImpl();
+            this.startUpAlerter = new NoOpStartUpAlerter();
+        }
     }
 
     public boolean isUseVerificationAgent() {
@@ -446,7 +480,7 @@ public class ZebedeeConfiguration {
         return this.startUpAlerter;
     }
 
-    public SlackClient getSlackClient() {
-        return slackClient;
+    public Notifier getSlackNotifier() {
+        return slackNotifier;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopNotifierImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopNotifierImpl.java
@@ -27,24 +27,24 @@ public class NopNotifierImpl implements Notifier {
 
     @Override
     public PostMessage createPostMessage(String channel, String text) {
-        return null;
+        return new PostMessage("NopNotifierImpl", channel, text);
     }
 
     @Override
     public boolean sendCollectionAlarm(Collection c, String channel, String message, Exception ex) {
         info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionAlarm");
-        return false;
+        return true;
     }
 
     @Override
     public boolean sendCollectionWarning(Collection c, String channel, String message, AttachmentField... attachments) {
         info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionWarning");
-        return false;
+        return true;
     }
 
     @Override
     public boolean sendCollectionAlarm(Collection c, String channel, String message, AttachmentField... attachments) {
         info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionAlarm");
-        return false;
+        return true;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopNotifierImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopNotifierImpl.java
@@ -1,0 +1,50 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.slack.messages.PostMessage;
+import com.github.onsdigital.zebedee.model.Collection;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+
+/**
+ * No op impl of {@link Notifier}
+ */
+public class NopNotifierImpl implements Notifier {
+
+    @Override
+    public void collectionAlarm(Collection c, String alarm, PostMessageField... args) {
+        info().collectionID(c).data("message", alarm).log("NopNotifierImpl collectionAlaram");
+    }
+
+    @Override
+    public void alarm(String alarm, PostMessageField... args) {
+        info().data("message", alarm).log("NopNotifierImpl alarm");
+    }
+
+    @Override
+    public void sendSlackMessage(PostMessage message) throws Exception {
+        info().data("message", message.getText()).log("NopNotifierImpl sendSlackMessage");
+    }
+
+    @Override
+    public PostMessage createPostMessage(String channel, String text) {
+        return null;
+    }
+
+    @Override
+    public boolean sendCollectionAlarm(Collection c, String channel, String message, Exception ex) {
+        info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionAlarm");
+        return false;
+    }
+
+    @Override
+    public boolean sendCollectionWarning(Collection c, String channel, String message, AttachmentField... attachments) {
+        info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionWarning");
+        return false;
+    }
+
+    @Override
+    public boolean sendCollectionAlarm(Collection c, String channel, String message, AttachmentField... attachments) {
+        info().collectionID(c).data("message", message).log("NopNotifierImpl sendCollectionAlarm");
+        return false;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopSlackClientImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopSlackClientImpl.java
@@ -1,0 +1,31 @@
+package com.github.onsdigital.zebedee.util.slack;
+
+import com.github.onsdigital.slack.Profile;
+import com.github.onsdigital.slack.client.PostMessageResponse;
+import com.github.onsdigital.slack.client.SlackClient;
+import com.github.onsdigital.slack.messages.PostMessage;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+
+/**
+ * No op implementation of {@link SlackClient}
+ */
+public class NopSlackClientImpl implements SlackClient {
+
+    @Override
+    public PostMessageResponse sendMessage(PostMessage postMessage) {
+        info().data("message", postMessage.getText()).log("NopSlackClientImpl.sendMessage");
+        return null;
+    }
+
+    @Override
+    public PostMessageResponse updateMessage(PostMessage postMessage) {
+        info().data("message", postMessage.getText()).log("NopSlackClientImpl.updateMessage");
+        return null;
+    }
+
+    @Override
+    public Profile getProfile() {
+        return null;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopSlackClientImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/slack/NopSlackClientImpl.java
@@ -12,16 +12,22 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
  */
 public class NopSlackClientImpl implements SlackClient {
 
+    /**
+     * No op implementation - returns hardcoded {@link PostMessageResponse} stub.
+     */
     @Override
     public PostMessageResponse sendMessage(PostMessage postMessage) {
         info().data("message", postMessage.getText()).log("NopSlackClientImpl.sendMessage");
-        return null;
+        return new PostMessageResponse(true, "stubbed response","");
     }
 
+    /**
+     * No op implementation - returns hardcoded {@link PostMessageResponse} stub.
+     */
     @Override
     public PostMessageResponse updateMessage(PostMessage postMessage) {
         info().data("message", postMessage.getText()).log("NopSlackClientImpl.updateMessage");
-        return null;
+        return new PostMessageResponse(true, "stubbed response","");
     }
 
     @Override

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -18,6 +18,7 @@ import com.github.onsdigital.zebedee.session.store.JWTStore;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import com.github.onsdigital.zebedee.user.service.UsersService;
+import com.github.onsdigital.zebedee.util.slack.Notifier;
 import com.github.onsdigital.zebedee.util.slack.StartUpAlerter;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,10 +59,7 @@ public abstract class ZebedeeTestBaseFixture {
     protected ZebedeeConfiguration zebCfg;
 
     @Mock
-    protected SlackClient slackClient;
-
-    @Mock
-    protected Profile slackProfile;
+    protected Notifier slackNotifier;
 
     @Mock
     protected Sessions sessions;
@@ -168,11 +166,8 @@ public abstract class ZebedeeTestBaseFixture {
         when(zebCfg.getPermissionsService())
                 .thenReturn(permissionsService);
 
-        when(zebCfg.getSlackClient())
-                .thenReturn(slackClient);
-
-        when(slackClient.getProfile())
-                .thenReturn(slackProfile);
+        when(zebCfg.getSlackNotifier())
+                .thenReturn(slackNotifier);
     }
 
     protected void verifyKeyAddedToCollectionKeyring() throws Exception {


### PR DESCRIPTION
### What
Added no op alternatives for the Slack integration classes. These will be used when the Slack config is not available on start up.

No op `SlackClient`  and `Notifier` will log the messages but no post requests to the Slack API.
