### PR TITLE
fix for legacy keyring login

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -286,6 +286,8 @@ public class ZebedeeConfiguration {
         this.schedulerKeyCache = new MigrationCollectionKeyCacheImpl(
                 new LegacySchedulerKeyCacheImpl(), new NopCollectionKeyCacheImpl(), false);
 
+        this.legacyKeyringCache = new com.github.onsdigital.zebedee.model.KeyringCache(sessions, schedulerKeyCache);
+
         CollectionKeyring legacyCollectionKeyring = new LegacyCollectionKeyringImpl(
                 sessions, usersService, permissionsService, this.legacyKeyringCache, schedulerKeyCache);
 


### PR DESCRIPTION
### What

Fixed legacy keyring configuration - it was not initialising the legacy `KeyringCache`
