### PR TITLE
Updated listKeyring endpoint to accept src param

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -93,6 +93,8 @@ public class Zebedee {
     private final StartUpAlerter startUpAlerter;
     private final Notifier slackNotifier;
     private final KeyringHealthChecker keyringHealthChecker;
+    private final CollectionKeyring legacyCollCollectionKeyring;
+    private final CollectionKeyring centralCollectinKeying;
 
     /**
      * Create a new instance of Zebedee setting.
@@ -132,6 +134,9 @@ public class Zebedee {
         this.startUpAlerter = cfg.getStartUpAlerter();
         this.slackNotifier = cfg.getSlackNotifier();
         this.keyringHealthChecker = cfg.getKeyringHealthChecker();
+
+        this.legacyCollCollectionKeyring = cfg.getLegacyCollectionKeyring();
+        this.centralCollectinKeying = cfg.getCentralCollectionKeyring();
     }
 
     /**
@@ -434,6 +439,14 @@ public class Zebedee {
 
     public Notifier getSlackNotifier() {
         return slackNotifier;
+    }
+
+    public CollectionKeyring getLegacyCollCollectionKeyring() {
+        return legacyCollCollectionKeyring;
+    }
+
+    public CollectionKeyring getCentralCollectinKeying() {
+        return centralCollectinKeying;
     }
 }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/ListKeyring.java
@@ -72,7 +72,7 @@ public class ListKeyring {
         checkPermission(getSession(request));
         String src = request.getParameter("src");
 
-        CollectionKeyring keyringSrc = "central".equalsIgnoreCase(src) ? legacyKeyring : centralKeyring;
+        CollectionKeyring keyringSrc = "central".equalsIgnoreCase(src) ? centralKeyring : legacyKeyring;
 
         User user = getUser(usersService, getEmail(request));
         return listKeyring(user, keyringSrc);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -228,6 +228,23 @@ public class Configuration {
     }
 
     /**
+     * Get collection keyring vector key
+     */
+    public static IvParameterSpec getKeyringInitVector() {
+        String vectorStr = getValue(KEYRING_INIT_VECTOR);
+        if (StringUtils.isEmpty(vectorStr)) {
+            throw new RuntimeException("expected keyring init vector in environment variable but was empty");
+        }
+
+        byte[] vectorBytes = Base64.getDecoder().decode(vectorStr);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(vectorBytes);
+
+        Arrays.fill(vectorBytes, (byte) 0);
+
+        return ivParameterSpec;
+    }
+
+    /**
      * Get a map of cognito id and signing key pairs
      */
     public static Map<String, String> getCognitoKeyIdPairs() {
@@ -253,23 +270,6 @@ public class Configuration {
         idKeyPairMap.put(awsCognitoKeyIdTwo, awsCognitoSigningKeyTwo);
 
         return idKeyPairMap;
-    }
-
-    /**
-     * Get collection keyring vector key
-     */
-    public static IvParameterSpec getKeyringInitVector() {
-        String vectorStr = getValue(KEYRING_INIT_VECTOR);
-        if (StringUtils.isEmpty(vectorStr)) {
-            throw new RuntimeException("expected keyring init vector in environment variable but was empty");
-        }
-
-        byte[] vectorBytes = Base64.getDecoder().decode(vectorStr);
-        IvParameterSpec ivParameterSpec = new IvParameterSpec(vectorBytes);
-
-        Arrays.fill(vectorBytes, (byte) 0);
-
-        return ivParameterSpec;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NopCollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/NopCollectionKeyringImpl.java
@@ -7,6 +7,7 @@ import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.user.model.User;
 
 import javax.crypto.SecretKey;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -42,7 +43,7 @@ public class NopCollectionKeyringImpl implements CollectionKeyring {
     @Override
     public Set<String> list(User user) throws KeyringException {
         info().user(user.getEmail()).log("no-op keyring list keys");
-        return null;
+        return new HashSet<>();
     }
 
     @Override

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ListKeyringTest.java
@@ -28,7 +28,8 @@ import static org.mockito.Mockito.when;
 public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Mock
-    private CollectionKeyring collectionKeyring;
+    private CollectionKeyring legacyKeyring;
+    private CollectionKeyring centralKeyring;
 
     @Mock
     private Sessions sessions;
@@ -48,7 +49,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Override
     protected void customSetUp() throws Exception {
-        endpoint = new ListKeyring(collectionKeyring, sessions, permissionsService, usersService);
+        endpoint = new ListKeyring(legacyKeyring, centralKeyring, sessions, permissionsService, usersService);
         email = "123@test.com";
 
         when(sessions.get(mockRequest))
@@ -136,7 +137,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
 
     @Test
     public void testGet_keyringListError_shouldThrowInternalServerErrorException() throws Exception {
-        when(collectionKeyring.list(user))
+        when(legacyKeyring.list(user))
                 .thenThrow(KeyringException.class);
 
         InternalServerError ex = assertThrows(InternalServerError.class,
@@ -150,7 +151,7 @@ public class ListKeyringTest extends ZebedeeAPIBaseTestCase {
         Set<String> userKeys = new HashSet<>();
         userKeys.add("666");
 
-        when(collectionKeyring.list(user))
+        when(legacyKeyring.list(user))
                 .thenReturn(userKeys);
 
         Set<String> actual = endpoint.listUserKeys(mockRequest, mockResponse);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyCacheImplTest.java
@@ -1,15 +1,19 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyStore;
 import com.github.onsdigital.zebedee.keyring.KeyNotFoundException;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
-import com.github.onsdigital.zebedee.keyring.CollectionKeyStore;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.crypto.SecretKey;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +55,21 @@ public class CollectionKeyCacheImplTest {
 
     @Mock
     private SecretKey secretKey;
+
+    /**
+     * Ensure that the instance is null before each test with the reflection magic.
+     */
+    @BeforeClass
+    public static void clear() throws Exception {
+        Field f = CollectionKeyCacheImpl.class.getDeclaredField("INSTANCE");
+        f.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
+
+        f.set(null, null);
+    }
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
### What

- Updated `ListKeyring` endpoint to accept src param to allow the caller to specify which keyring to use.
- Updated CMS config to use the migration keyring by default. The CMS will now write/remove from both keyring impls in parallel.

If the central keyring feature flag is enabled then get key requests will attempt to read from the central keyring first and default to the legacy impl if the key is not found.
If the feature flag is disabled then write/remove keys will update both BUT get requests will only use the legacy keyring.

### How to review

Code review. I have separate integration tests to prove this functionality is correct.

### Who can review

Anyone.
