### PR TITLE
hotfix to  disabled keyring healthchecker which is null pointering

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -307,7 +307,8 @@ public class Zebedee {
 
         if (permissionsService.isAdministrator(session)) {
             startUpAlerter.queueUnlocked();
-            keyringHealthChecker.check(session);
+            // Disable hotfix
+            //keyringHealthChecker.check(session);
         }
 
         return session;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -436,6 +436,6 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(collectionKeyring, times(1)).cacheKeyring(user);
 
         verify(startUpAlerter, times(1)).queueUnlocked();
-        verify(keyringHealthChecker, times(1)).check(userSession);
+//        verify(keyringHealthChecker, times(1)).check(userSession);
     }
 }


### PR DESCRIPTION
### What

One of the collections is causing a null pointer in the keyring health checker logic. Hotfix to remove the call to this to get prod back working.

Proper fix to follow.