### PR TITLE
fix for potential null pointer in keyring health checker

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/KeyringHealthCheckerImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/migration/KeyringHealthCheckerImpl.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import static com.github.onsdigital.slack.messages.Colour.DANGER;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getDefaultSlackAlarmChannel;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getSlackUsername;
-import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 
 /**
@@ -165,13 +164,13 @@ public class KeyringHealthCheckerImpl implements KeyringHealthChecker {
         List<PostMessageAttachment> attachments = new ArrayList<>();
 
         for (Collection c : missing) {
-            attachments.add(createMsgAttatchment(c, session));
+            attachments.add(createMsgAttachment(c, session));
         }
 
         return attachments;
     }
 
-    private PostMessageAttachment createMsgAttatchment(Collection c, Session session) {
+    private PostMessageAttachment createMsgAttachment(Collection c, Session session) {
         if (c == null) {
             throw new IllegalArgumentException("collection expected but was null");
         }


### PR DESCRIPTION
### What

Added defensive code to `KeyringHealthCheckerImpl` to handle potential null value for `collection.description.events`. This should never happened but when this feature was deployed into prod it failed and broke login. I believe this was caused by a borked collection with an invalid `data.json`.

I've updated this health checker to handle to be more resilient and to handle any exception _quietly_. The health checker is a diagnostic tool and any errors it encounters should not prevent the CMS from carrying out its tasks. I've updated the HC so any exception thrown is caught, logged and swallowed preventing it from blocking login or other features in future  

### How to review
Testing locally with a valid collection:
<img width="694" alt="Screenshot 2021-09-27 at 16 09 03" src="https://user-images.githubusercontent.com/14196957/134935766-78147145-bf0b-4294-ac31-24f75d5fc5d2.png">

Testing locally with a collection where `collection.description.events` is null:
<img width="697" alt="Screenshot 2021-09-27 at 16 09 19" src="https://user-images.githubusercontent.com/14196957/134935926-c0b2fea2-0b00-4cf5-84eb-8892c4992799.png">
The collection creation date and created data is contained in the collection events. In this 2nd example you can see the alert is still sent but the `Creation Date` and `Created By` fields are omitted.

