### PR TITLE
reenable keyring health checker

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -307,8 +307,7 @@ public class Zebedee {
 
         if (permissionsService.isAdministrator(session)) {
             startUpAlerter.queueUnlocked();
-            // Disable hotfix
-            //keyringHealthChecker.check(session);
+            keyringHealthChecker.check(session);
         }
 
         return session;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -436,6 +436,6 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         verify(collectionKeyring, times(1)).cacheKeyring(user);
 
         verify(startUpAlerter, times(1)).queueUnlocked();
-//        verify(keyringHealthChecker, times(1)).check(userSession);
+        verify(keyringHealthChecker, times(1)).check(userSession);
     }
 }


### PR DESCRIPTION
### What

Undo the hotfix to disable the keyring health checker - a proper fix to address the defect has already been merged.