### PR TITLE
fix performance issues for collection keyring remove key

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -11,8 +11,8 @@ import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
-import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyringUtil;
+import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
@@ -323,6 +323,7 @@ public class Collection {
             throw new InternalServerError(message, ex);
         }
 
+        info().collectionID(c).log("collection deleted removing key from keyring");
         try {
             collectionKeyring.remove(user, c);
         } catch (KeyringException ex) {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/BaseLegacyKeyringTest.java
@@ -150,6 +150,9 @@ public abstract class BaseLegacyKeyringTest {
         when(bertKeyring.unlock(TEST_PASSWORD))
                 .thenReturn(true);
 
+        when(bertKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
         when(keyringCache.get(bert))
                 .thenReturn(bertKeyring);
     }
@@ -167,6 +170,9 @@ public abstract class BaseLegacyKeyringTest {
         when(ernieKeyring.unlock(TEST_PASSWORD))
                 .thenReturn(true);
 
+        when(ernieKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
         when(keyringCache.get(ernie))
                 .thenReturn(ernieKeyring);
     }
@@ -183,6 +189,9 @@ public abstract class BaseLegacyKeyringTest {
 
         when(theCountKeyring.unlock(TEST_PASSWORD))
                 .thenReturn(true);
+
+        when(theCountKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
 
         when(keyringCache.get(theCount))
                 .thenReturn(theCountKeyring);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RemoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/legacy/LegacyCollectionKeyringImpl_RemoveTest.java
@@ -253,4 +253,35 @@ public class LegacyCollectionKeyringImpl_RemoveTest extends BaseLegacyKeyringTes
         verify(users, times(1)).list();
         verify(users, times(3)).removeKeyFromKeyring(any(), any());
     }
+
+    @Test
+    public void testRemove_success_shouldUpdateUsersWhoHaveKey() throws Exception {
+        // Given remove is success
+        // And the user's keyring is in the cache
+
+        when(bertKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
+        when(ernieKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(null);
+
+        when(theCountKeyring.get(TEST_COLLECTION_ID))
+                .thenReturn(secretKey);
+
+        // When remove is called
+        legacyCollectionKeyring.remove(null, collection);
+
+        // Then the key is successfully removed from only users who have the key in their keyring.
+        verifyUserKeyringRetrievedFromCache(bert);
+        verifyKeyRemovedFromUser(bert, bertKeyring);
+
+        verifyKeyNotRemovedFromUser(ernie, ernieKeyring);
+        verifyUserKeyringNotRetrievedFromCache(ernie);
+
+        verifyUserKeyringRetrievedFromCache(theCount);
+        verifyKeyRemovedFromUser(theCount, theCountKeyring);
+
+        verify(users, times(1)).list();
+        verify(users, times(2)).removeKeyFromKeyring(any(), any());
+    }
 }


### PR DESCRIPTION
### Fix for keyring prod issue. 

Added performance optimisation to legacy `keyring.add`. The thread safe measures implemented in the `Userservice` have a pretty negative impact on performance and throughput. Updating a large number of users in 1 operation can be very slow. 

There are currently ~1900 users, each time a team is added/removed to/from a collection we're updating ~1900 user files 1 at a time which is causing request timeouts and Florence retrying creating a cycle.

To address this so I've update the keying logic to first reduce the list of updates to only user who currently have the key in their keyring making only the absolute necessary updates.
