### PR TITLE
Add published index endpoint for search reindexing

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/filters/AuthenticationFilter.java
@@ -15,6 +15,7 @@ import com.github.onsdigital.zebedee.api.cmd.UserDatasetPermissions;
 import com.github.onsdigital.zebedee.api.cmd.UserInstancePermissions;
 import com.github.onsdigital.zebedee.reader.api.endpoint.Health;
 import com.github.onsdigital.zebedee.reader.api.endpoint.PublishedData;
+import com.github.onsdigital.zebedee.reader.api.endpoint.PublishedIndex;
 import com.github.onsdigital.zebedee.search.api.endpoint.ReIndex;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
@@ -74,6 +75,7 @@ public class AuthenticationFilter implements PreFilter {
             .add(ServiceInstancePermissions.class)
             .add(Health.class)
             .add(PublishedData.class)
+            .add(PublishedIndex.class)
             .build();
 
     /**

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponse.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponse.java
@@ -35,7 +35,7 @@ public class PublishedIndexResponse {
                 .map(d -> new Item(d.getUri()))
                 .forEach(d -> this.items.add(d));
 
-        count += docs.size();
+        count = this.items.size();
     }
 
     public int getCount() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponse.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponse.java
@@ -1,0 +1,87 @@
+package com.github.onsdigital.zebedee.reader.api.bean;
+
+import com.github.onsdigital.zebedee.search.indexing.Document;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Object representing a response for the PublishedIndex endpoint
+ */
+public class PublishedIndexResponse {
+
+    private int count;
+    private List<Item> items;
+    private int limit;
+    private int offset;
+    @SerializedName("total_count")
+    private int totalCount;
+
+    public PublishedIndexResponse() {
+        this.items = new ArrayList<>();
+    }
+
+    /**
+     * Adds a list of documents to the response as Items. Also updates the
+     *
+     * @param docs  List of Documents to add to response
+     */
+    public void addDocuments(List<Document> docs) {
+        if (docs == null) {
+            return;
+        }
+        docs.stream()
+                .map(d -> new Item(d.getUri()))
+                .forEach(d -> this.items.add(d));
+
+        count += docs.size();
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<Item> getItems() {
+        return items;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    /**
+     * Sub-object representing an individual document returned by the PublishedIndex
+     */
+    public class Item {
+        private String uri;
+
+        public Item(String uri) {
+            this.uri = uri;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+    }
+}

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedData.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedData.java
@@ -29,8 +29,7 @@ public class PublishedData {
      * <p>
      * e.g. ?uri=/economy/environmentalaccounts/articles/greenhousegasemissions/2015-06-02&title will only return title of the requested content
      *
-     * @param request  This should contain a X-Florence-Token header for the current session and the collection id being worked on
-     *                 If no collection id is given published contents will be served
+     * @param request  No authentication headers are required due to this only serving published content
      * @param response Servlet response
      * @return
      * @throws IOException           If an error occurs in processing data, typically to the filesystem, but also on the HTTP connection.

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndex.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndex.java
@@ -29,9 +29,9 @@ public class PublishedIndex {
 
         List<Document> docs = new FileScanner().scan();
 
-        /* TODO paging is not currently implemented (there would be complications involving ensuring that
-            duplicates or omissions of documents added or removed between pages) so for now the endpoint always
-            returns all published documents and ignores any supplied parameters
+        /*  Paging is not currently implemented (there would be complications involving ensuring that duplicates or
+            omissions of documents added or removed between pages) so for now the endpoint always returns all published
+            documents and ignores any supplied parameters
         */
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
         publishedIndexResponse.addDocuments(docs);

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndex.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndex.java
@@ -1,0 +1,44 @@
+package com.github.onsdigital.zebedee.reader.api.endpoint;
+
+import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.zebedee.reader.api.bean.PublishedIndexResponse;
+import com.github.onsdigital.zebedee.search.indexing.Document;
+import com.github.onsdigital.zebedee.search.indexing.FileScanner;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import java.io.IOException;
+import java.util.List;
+
+@Api
+public class PublishedIndex {
+
+    /**
+     * Retrieves list of content for endpoint <code>/publishedindex</code>
+     * <p>
+     * This endpoint returns a list of URIs for all the published content served by zebedee
+     *
+     * @param request  No authentication headers are required due to this only serving published content
+     * @param response Servlet response
+     * @return
+     * @throws IOException If an error occurs in processing data, typically to the filesystem, but also on the HTTP connection.
+     */
+    @GET
+    public PublishedIndexResponse read(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        List<Document> docs = new FileScanner().scan();
+
+        /* TODO paging is not currently implemented (there would be complications involving ensuring that
+            duplicates or omissions of documents added or removed between pages) so for now the endpoint always
+            returns all published documents and ignores any supplied parameters
+        */
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(docs);
+        publishedIndexResponse.setOffset(0);
+        publishedIndexResponse.setLimit(docs.size());
+        publishedIndexResponse.setTotalCount(docs.size());
+        return publishedIndexResponse;
+
+    }
+}

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
@@ -21,7 +21,7 @@ public class PublishedIndexResponseTest {
     @Test
     public void testSerialisation() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
-        publishedIndexResponse.setTotalCount(20);
+        publishedIndexResponse.setTotalCount(TOTAL_COUNT);
 
         Gson gson = new GsonBuilder()
                 .setPrettyPrinting()

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
@@ -1,6 +1,8 @@
 package com.github.onsdigital.zebedee.reader.api.bean;
 
 import com.github.onsdigital.zebedee.search.indexing.Document;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -9,76 +11,91 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
-public class PublishedIndexResponseTest  {
+public class PublishedIndexResponseTest {
 
     static final String URI1 = "/uri/1";
     static final String URI2 = "/uri/2";
+    static final int TOTAL_COUNT = 20;
+    static final String TOTAL_COUNT_KEY = "total_count";
+
+    @Test
+    public void testSerialisation() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.setTotalCount(20);
+
+        Gson gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .create();
+        String jsonString = gson.toJson(publishedIndexResponse);
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("\""+TOTAL_COUNT_KEY+"\": "+TOTAL_COUNT));
+    }
 
     @Test
     public void testAddDocument_null() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
         publishedIndexResponse.addDocuments(null);
-        assertEquals(publishedIndexResponse.getCount(),0);
+        assertEquals(0, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),0);
+        assertEquals(0, publishedIndexResponse.getItems().size());
     }
 
     @Test
     public void testAddDocument_noDocuments() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
         publishedIndexResponse.addDocuments(listOfDocuments());
-        assertEquals(publishedIndexResponse.getCount(),0);
+        assertEquals(0, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),0);
+        assertEquals(0, publishedIndexResponse.getItems().size());
     }
 
     @Test
     public void testAddDocument_oneDocument() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
         publishedIndexResponse.addDocuments(listOfDocuments(URI1));
-        assertEquals(publishedIndexResponse.getCount(),1);
+        assertEquals(1, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),1);
+        assertEquals(1, publishedIndexResponse.getItems().size());
         assertNotNull(publishedIndexResponse.getItems().get(0));
-        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        assertEquals(URI1, publishedIndexResponse.getItems().get(0).getUri());
     }
 
     @Test
     public void testAddDocument_twoDocuments() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
-        publishedIndexResponse.addDocuments(listOfDocuments(URI1,URI2));
-        assertEquals(publishedIndexResponse.getCount(),2);
+        publishedIndexResponse.addDocuments(listOfDocuments(URI1, URI2));
+        assertEquals(2, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),2);
+        assertEquals(2, publishedIndexResponse.getItems().size());
         assertNotNull(publishedIndexResponse.getItems().get(0));
-        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        assertEquals(URI1, publishedIndexResponse.getItems().get(0).getUri());
         assertNotNull(publishedIndexResponse.getItems().get(1));
-        assertEquals(publishedIndexResponse.getItems().get(1).getUri(),URI2);
+        assertEquals(URI2, publishedIndexResponse.getItems().get(1).getUri());
     }
 
     @Test
     public void testAddDocument_multipleCalls() {
         PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
         publishedIndexResponse.addDocuments(listOfDocuments(URI1));
-        assertEquals(publishedIndexResponse.getCount(),1);
+        assertEquals(1, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),1);
+        assertEquals(1, publishedIndexResponse.getItems().size());
         assertNotNull(publishedIndexResponse.getItems().get(0));
-        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
-        
+        assertEquals(URI1, publishedIndexResponse.getItems().get(0).getUri());
+
         publishedIndexResponse.addDocuments(listOfDocuments(URI2));
-        assertEquals(publishedIndexResponse.getCount(),2);
+        assertEquals(2, publishedIndexResponse.getCount());
         assertNotNull(publishedIndexResponse.getItems());
-        assertEquals(publishedIndexResponse.getItems().size(),2);
+        assertEquals(2, publishedIndexResponse.getItems().size());
         assertNotNull(publishedIndexResponse.getItems().get(0));
-        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        assertEquals(URI1, publishedIndexResponse.getItems().get(0).getUri());
         assertNotNull(publishedIndexResponse.getItems().get(1));
-        assertEquals(publishedIndexResponse.getItems().get(1).getUri(),URI2);
+        assertEquals(URI2, publishedIndexResponse.getItems().get(1).getUri());
     }
 
     private List<Document> listOfDocuments(String... uris) {
         return Arrays.stream(uris)
-                .map(u -> new Document(u,null))
+                .map(u -> new Document(u, null))
                 .collect(Collectors.toList());
     }
 }

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/bean/PublishedIndexResponseTest.java
@@ -1,0 +1,84 @@
+package com.github.onsdigital.zebedee.reader.api.bean;
+
+import com.github.onsdigital.zebedee.search.indexing.Document;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class PublishedIndexResponseTest  {
+
+    static final String URI1 = "/uri/1";
+    static final String URI2 = "/uri/2";
+
+    @Test
+    public void testAddDocument_null() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(null);
+        assertEquals(publishedIndexResponse.getCount(),0);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),0);
+    }
+
+    @Test
+    public void testAddDocument_noDocuments() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(listOfDocuments());
+        assertEquals(publishedIndexResponse.getCount(),0);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),0);
+    }
+
+    @Test
+    public void testAddDocument_oneDocument() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(listOfDocuments(URI1));
+        assertEquals(publishedIndexResponse.getCount(),1);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),1);
+        assertNotNull(publishedIndexResponse.getItems().get(0));
+        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+    }
+
+    @Test
+    public void testAddDocument_twoDocuments() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(listOfDocuments(URI1,URI2));
+        assertEquals(publishedIndexResponse.getCount(),2);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),2);
+        assertNotNull(publishedIndexResponse.getItems().get(0));
+        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        assertNotNull(publishedIndexResponse.getItems().get(1));
+        assertEquals(publishedIndexResponse.getItems().get(1).getUri(),URI2);
+    }
+
+    @Test
+    public void testAddDocument_multipleCalls() {
+        PublishedIndexResponse publishedIndexResponse = new PublishedIndexResponse();
+        publishedIndexResponse.addDocuments(listOfDocuments(URI1));
+        assertEquals(publishedIndexResponse.getCount(),1);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),1);
+        assertNotNull(publishedIndexResponse.getItems().get(0));
+        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        
+        publishedIndexResponse.addDocuments(listOfDocuments(URI2));
+        assertEquals(publishedIndexResponse.getCount(),2);
+        assertNotNull(publishedIndexResponse.getItems());
+        assertEquals(publishedIndexResponse.getItems().size(),2);
+        assertNotNull(publishedIndexResponse.getItems().get(0));
+        assertEquals(publishedIndexResponse.getItems().get(0).getUri(),URI1);
+        assertNotNull(publishedIndexResponse.getItems().get(1));
+        assertEquals(publishedIndexResponse.getItems().get(1).getUri(),URI2);
+    }
+
+    private List<Document> listOfDocuments(String... uris) {
+        return Arrays.stream(uris)
+                .map(u -> new Document(u,null))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### What

Add a Published Index endpoint to Zebedee
- Does not need authentication as it only returns uris of published data
- Does not currently implement paging, although the model allows for paging support to be added in future.

### How to review

Check endpoint only returns published content etc.

### Who can review

Anyone but me