### PR TITLE
Prepare teams handling for JWT migration

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -41,6 +41,7 @@ import com.github.onsdigital.zebedee.service.ZebedeeDatasetService;
 import com.github.onsdigital.zebedee.session.service.JWTSessionsServiceImpl;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.session.service.SessionsServiceImpl;
+import com.github.onsdigital.zebedee.teams.service.StubbedTeamsServiceImpl;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.teams.service.TeamsServiceImpl;
 import com.github.onsdigital.zebedee.teams.store.TeamsStoreFileSystemImpl;
@@ -178,8 +179,13 @@ public class ZebedeeConfiguration {
             this.sessions = new SessionsServiceImpl(sessionsPath);
         }
 
-        this.teamsService = new TeamsServiceImpl(
-                new TeamsStoreFileSystemImpl(teamsPath), this::getPermissionsService);
+        // TODO: Remove after migration to JWT sessions is complete
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            this.teamsService = new StubbedTeamsServiceImpl();
+        } else {
+            this.teamsService = new TeamsServiceImpl(
+                    new TeamsStoreFileSystemImpl(teamsPath), this::getPermissionsService);
+        }
 
         this.published = createPublished();
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Teams.java
@@ -43,8 +43,12 @@ import java.util.stream.Collectors;
  * <li>{@code /teams/[teamname]?email=user@example.com}</li>
  * </ul>
  * </p>
+ *
+ * @deprecated The teams management in zebedee is deprecated in favour of the dp-identity-api with its JWT based auth
+ *             and will be removed after migration of users and teams to the new service.
  */
 @Api
+@Deprecated
 public class Teams {
 
     private Sessions sessionsService;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/TeamsReport.java
@@ -8,6 +8,7 @@ import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
+import org.apache.http.HttpStatus;
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFFont;
@@ -15,7 +16,6 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
-import org.apache.http.HttpStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -33,8 +33,12 @@ import static java.text.MessageFormat.format;
 
 /**
  * API endpoint for generating Team members XLS report.
+ *
+ * @deprecated The teams management in zebedee is deprecated in favour of the dp-identity-api with its JWT based auth
+ *             and will be removed after migration of users and teams to the new service.
  */
 @Api
+@Deprecated
 public class TeamsReport {
 
     private static final String CONTENT_DISPOSITION_VALUE = "attachment;filename=teams-report-{0}.xls";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -22,7 +22,6 @@ import com.github.onsdigital.zebedee.json.ContentStatus;
 import com.github.onsdigital.zebedee.json.Event;
 import com.github.onsdigital.zebedee.json.EventType;
 import com.github.onsdigital.zebedee.json.Events;
-import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.approval.tasks.ReleasePopulator;
 import com.github.onsdigital.zebedee.model.content.item.ContentItemVersion;
 import com.github.onsdigital.zebedee.model.content.item.VersionedContentItem;
@@ -41,7 +40,6 @@ import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.user.model.User;
-import com.github.onsdigital.zebedee.user.service.UsersService;
 import com.github.onsdigital.zebedee.util.versioning.VersionsService;
 import com.github.onsdigital.zebedee.util.versioning.VersionsServiceImpl;
 import com.google.common.annotations.VisibleForTesting;
@@ -218,10 +216,8 @@ public class Collection {
                 collectionCreated(collectionDescription));
 
         if (collectionDescription.getTeams() != null) {
-            for (String teamName : collectionDescription.getTeams()) {
-                Team team = zebedee.getTeamsService().findTeam(teamName);
-                zebedee.getPermissionsService().addViewerTeam(collectionDescription, team, session);
-            }
+            // TODO: Remove dependency on the deprecated {@link TeamsService}. See addTeamsToCollection below for more details.
+            addTeamsToCollection(zebedee.getTeamsService(), zebedee.getPermissionsService(), collectionDescription, session);
         }
 
         // Add the collection key to the keying - user is not required
@@ -478,58 +474,49 @@ public class Collection {
         Set<String> teamsUpdated = new HashSet<>();
 
         if (desc != null && desc.getTeams() != null) {
-            UsersService users = zebedee.getUsersService();
             PermissionsService permissions = zebedee.getPermissionsService();
-            TeamsService teams = zebedee.getTeamsService();
-            CollectionKeyring collectionKeyring = zebedee.getCollectionKeyring();
-
 
             // Remove any teams that should no longer have access.
-            removeTeamsFromCollection(teams, users, permissions, collectionKeyring, desc, session);
+            removeTeamsFromCollection(permissions, desc, session);
 
             // Add any new teams that have been granted access.
-            teamsUpdated.addAll(addTeamsToCollection(teams, users, permissions, collectionKeyring, desc, session));
+            // TODO: Remove dependency on the deprecated {@link TeamsService}. See addTeamsToCollection below for more details.
+            teamsUpdated.addAll(addTeamsToCollection(zebedee.getTeamsService(), permissions, desc, session));
         }
 
         return teamsUpdated;
     }
 
     /**
-     * Remove any Teams from the collection if it is no longer assigned. For each team that is removed the collection
-     * key is revoked from each member of the team.
+     * Remove any Teams from the collection if it is no longer assigned.
      */
-    private static void removeTeamsFromCollection(TeamsService teams,
-                                                  UsersService users, PermissionsService permissions, CollectionKeyring collectionKeyring,
-                                                  CollectionDescription desc, Session session)
+    private static void removeTeamsFromCollection(PermissionsService permissions, CollectionDescription desc,
+                                                  Session session)
             throws IOException, ZebedeeException {
         Set<Integer> teamIDs = permissions.listViewerTeams(desc, session);
 
-        List<Team> teamsToRemove = teams.resolveTeams(teamIDs)
-                .stream()
-                .filter(t -> !desc.getTeams().contains(t.getId()))
+        List<Integer> teamsToRemove = teamIDs.stream().filter(t -> !desc.getTeams().contains(t))
                 .collect(Collectors.toList());
 
         if (teamsToRemove != null && !teamsToRemove.isEmpty()) {
 
-            for (Team t : teamsToRemove) {
-
-                // Remove the team from the collection first...
+            for (int t : teamsToRemove) {
                 permissions.removeViewerTeam(desc, t, session);
             }
         }
     }
 
     /**
-     * Adds teams to a collection if they should have access. Updates the members of each team assigned to the
-     * collection to assign the collection encryption key to them.
+     * Adds teams to a collection if they should have access.
+     *
+     * TODO: Remove dependency on the deprecated {@link TeamsService#findTeam} by updating the logic to pass in the
+     *       team ID from florence rather than the team name.
      */
-    private static Set<String> addTeamsToCollection(TeamsService teams, UsersService users,
-                                                    PermissionsService permissions, CollectionKeyring collectionKeyring,
+    private static Set<String> addTeamsToCollection(TeamsService teams, PermissionsService permissions,
                                                     CollectionDescription desc, Session session)
             throws IOException, ZebedeeException {
 
         Set<String> teamsUpdated = new HashSet<>();
-        User srcUser = getUser(users, session.getEmail());
 
         for (String teamName : desc.getTeams()) {
             Team team = teams.findTeam(teamName);
@@ -537,7 +524,7 @@ public class Collection {
                 throw new NotFoundException("team assigned to collection expected but does not exist");
             }
 
-            permissions.addViewerTeam(desc, team, session);
+            permissions.addViewerTeam(desc, team.getId(), session);
             teamsUpdated.add(teamName);
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
@@ -57,15 +57,6 @@ public interface PermissionsService {
     boolean isAdministrator(String email) throws IOException;
 
     /**
-     * Return a list of {@link User} who have access to the specified collection.
-     *
-     * @param collection the collection to check users against.
-     * @return {@link List} of {@link User} who have access to the collection.
-     * @throws IOException unexpected error checking the users against the collection.
-     */
-    List<User> getCollectionAccessMapping(Collection collection) throws IOException;
-
-    /**
      * @return true if an Admin user exists, false otherwise.
      * @throws IOException unexpected error accessing users.
      */
@@ -173,15 +164,15 @@ public interface PermissionsService {
     boolean canView(String email, CollectionDescription collectionDescription) throws IOException;
 
     /**
-     * Grant view permissions to a {@link Team}.
+     * Grant view permissions to a team.
      *
-     * @param collectionDescription the {@link CollectionDescription} of the {@link Collection} in question.
-     * @param team                  the {@link Team} to permit view permission to.
-     * @param session               the {@link Session} of the user granting the permission.
-     * @throws IOException      unexpected error while checking permissions.
-     * @throws ZebedeeException unexpected error while checking permissions.
+     * @param collectionDescription The {@link CollectionDescription} of the collection to give the team access to.
+     * @param teamId                the ID of the team to permit view permission to.
+     * @param session               the {@link Session} of the user granting the permission. Only editors can permit a team access to a collection.
+     * @throws IOException If a filesystem error occurs.
+     * @throws ZebedeeException if the user is not authorised to add view team permissions.
      */
-    void addViewerTeam(CollectionDescription collectionDescription, Team team, Session session) throws IOException, ZebedeeException;
+    void addViewerTeam(CollectionDescription collectionDescription, Integer teamId, Session session) throws IOException, ZebedeeException;
 
     /**
      * Returns a {@link List} of {@link Team}s that have viewer permissions on the specified collection.
@@ -199,12 +190,12 @@ public interface PermissionsService {
      * Revoke view permission from a {@link Team} for the specified {@link Collection}.
      *
      * @param collectionDescription the {@link CollectionDescription} of the {@link Collection} to remove the team.
-     * @param team                  the {@link Team} to remove.
+     * @param teamId                the ID of the {@link Team} to remove.
      * @param session               the {@link Session} of the user revoking view permission.
      * @throws IOException      unexpected error while revoking permissions.
      * @throws ZebedeeException unexpected error while revoking permissions.
      */
-    void removeViewerTeam(CollectionDescription collectionDescription, Team team, Session session) throws IOException, ZebedeeException;
+    void removeViewerTeam(CollectionDescription collectionDescription, Integer teamId, Session session) throws IOException, ZebedeeException;
 
     /**
      * Return {@link PermissionDefinition} for the specified {@link User}.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
@@ -6,7 +6,6 @@ import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
-import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.PathUtils;
 import com.github.onsdigital.zebedee.permissions.model.AccessMapping;
 import com.github.onsdigital.zebedee.permissions.store.PermissionsStore;
@@ -20,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -120,32 +118,6 @@ public class PermissionsServiceImpl implements PermissionsService {
             return false;
         }
         return isAdministrator(email, permissionsStore.getAccessMapping());
-    }
-
-    @Override
-    public List<User> getCollectionAccessMapping(Collection collection) throws IOException {
-        AccessMapping accessMapping = permissionsStore.getAccessMapping();
-        List<Team> teamsList = teamsServiceSupplier.getService().listTeams();
-        List<User> keyUsers = usersServiceSupplier
-                .getService()
-                .list()
-                .stream()
-                .filter(user -> isCollectionKeyRecipient(accessMapping, teamsList, user, collection))
-                .collect(Collectors.toList());
-        return keyUsers;
-    }
-
-    private boolean isCollectionKeyRecipient(AccessMapping accessMapping, List<Team> teamsList, User user, Collection collection) {
-        boolean result = false;
-        try {
-            result = isAdministrator(user.getEmail(), accessMapping)
-                    || canEdit(user.getEmail())
-                    || canView(user.getEmail(), collection.getDescription(), accessMapping, teamsList);
-        } catch (IOException e) {
-            error().logException(e, "PermissionsServiceImpl: unexpected error encountered.");
-            throw new RuntimeException(e);
-        }
-        return result;
     }
 
     private boolean isAdministrator(String email, AccessMapping accessMapping) {
@@ -337,15 +309,16 @@ public class PermissionsServiceImpl implements PermissionsService {
     }
 
     /**
-     * Grants the given team access to the given collection.
+     * Grant view permissions to a team.
      *
-     * @param collectionDescription The collection to give the team access to.
-     * @param team                  The team to be granted access.
-     * @param session               Only editors can permit a team access to a collection.
+     * @param collectionDescription The {@link CollectionDescription} of the collection to give the team access to.
+     * @param teamId                the ID of the team to permit view permission to.
+     * @param session               the {@link Session} of the user granting the permission. Only editors can permit a team access to a collection.
      * @throws IOException If a filesystem error occurs.
+     * @throws ZebedeeException if the user is not authorised to add view team permissions.
      */
     @Override
-    public void addViewerTeam(CollectionDescription collectionDescription, Team team, Session session) throws IOException, ZebedeeException {
+    public void addViewerTeam(CollectionDescription collectionDescription, Integer teamId, Session session) throws IOException, ZebedeeException {
         if (session == null || !canEdit(session.getEmail())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
@@ -357,11 +330,13 @@ public class PermissionsServiceImpl implements PermissionsService {
             accessMapping.getCollections().put(collectionDescription.getId(), collectionTeams);
         }
 
-        Team teamAdded = !collectionTeams.contains(team.getId()) ? team : null;
-        collectionTeams.add(team.getId());
-        permissionsStore.saveAccessMapping(accessMapping);
 
-        if (teamAdded != null) {
+        if (!collectionTeams.contains(teamId)) {
+            collectionTeams.add(teamId);
+            permissionsStore.saveAccessMapping(accessMapping);
+
+            Team team = new Team();
+            team.setId(teamId);
             getCollectionHistoryDao().saveCollectionHistoryEvent(collectionDescription.getId(), collectionDescription
                     .getName(), session, COLLECTION_VIEWER_TEAM_ADDED, teamAdded(collectionDescription, session, team));
         }
@@ -393,12 +368,12 @@ public class PermissionsServiceImpl implements PermissionsService {
      * Revokes access for given team to the given collection.
      *
      * @param collectionDescription The collection to revoke team access to.
-     * @param team                  The team to be revoked access.
+     * @param teamId                The id of the team to be revoked access.
      * @param session               Only editors can revoke team access to a collection.
      * @throws IOException If a filesystem error occurs.
      */
     @Override
-    public void removeViewerTeam(CollectionDescription collectionDescription, Team team, Session session) throws IOException, ZebedeeException {
+    public void removeViewerTeam(CollectionDescription collectionDescription, Integer teamId, Session session) throws IOException, ZebedeeException {
         if (session == null || !canEdit(session.getEmail())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
@@ -411,14 +386,14 @@ public class PermissionsServiceImpl implements PermissionsService {
         }
 
         boolean teamRemoved = false;
-        if (collectionTeams.contains(team.getId())) {
-            collectionTeams.remove(team.getId());
+        if (collectionTeams.contains(teamId)) {
+            collectionTeams.remove(teamId);
             permissionsStore.saveAccessMapping(accessMapping);
         }
 
         if (teamRemoved) {
             getCollectionHistoryDao().saveCollectionHistoryEvent(collectionDescription.getId(), collectionDescription.getName(),
-                    session, COLLECTION_VIEWER_TEAM_REMOVED, teamRemoved(collectionDescription, session, team));
+                    session, COLLECTION_VIEWER_TEAM_REMOVED, teamRemoved(collectionDescription, session, teamId));
         }
     }
 
@@ -427,34 +402,25 @@ public class PermissionsServiceImpl implements PermissionsService {
         return (digitalPublishingTeam != null && digitalPublishingTeam.contains(standardise(email)));
     }
 
-
+    /**
+     * @deprecated this method is deprecated and needs to be reimplemented to use the JWT session to determine the
+     *             groups/teams a user is a member of.
+     *
+     * TODO: Add an implementation of this method that will use the groups stored in the JWT session rather than using
+     *       the Teams service
+     */
+    @Deprecated
     private boolean canView(String email, CollectionDescription collectionDescription, AccessMapping accessMapping)
             throws IOException {
 
         // Check to see if the email is a member of a team associated with the given collection:
-        Set<Integer> teams = accessMapping.getCollections().get(collectionDescription.getId());
-        if (teams == null) {
+        Set<Integer> teamIds = accessMapping.getCollections().get(collectionDescription.getId());
+        if (teamIds == null) {
             return false;
         }
 
-        return teamsServiceSupplier.getService()
-                .listTeams()
-                .stream()
-                .filter(team -> teams.contains(team.getId()) && team.getMembers().contains(standardise(email)))
-                .findFirst()
-                .isPresent();
-    }
-
-    private boolean canView(String email, CollectionDescription collectionDescription,
-                            AccessMapping accessMapping, List<Team> teamsList) throws IOException {
-        Set<Integer> collectionTeams = accessMapping.getCollections().get(collectionDescription.getId());
-        if (collectionTeams == null || collectionTeams.isEmpty()) {
-            return false;
-        }
-        return teamsList.stream()
-                .filter(t -> collectionTeams.contains(t.getId()) && t.getMembers().contains(standardise(email)))
-                .findFirst()
-                .isPresent();
+        return teamsServiceSupplier.getService().resolveTeams(teamIds).stream()
+                .anyMatch(team -> team.getMembers().contains(standardise(email)));
     }
 
     private String standardise(String email) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImpl.java
@@ -385,13 +385,9 @@ public class PermissionsServiceImpl implements PermissionsService {
             accessMapping.getCollections().put(collectionDescription.getId(), collectionTeams);
         }
 
-        boolean teamRemoved = false;
         if (collectionTeams.contains(teamId)) {
             collectionTeams.remove(teamId);
             permissionsStore.saveAccessMapping(accessMapping);
-        }
-
-        if (teamRemoved) {
             getCollectionHistoryDao().saveCollectionHistoryEvent(collectionDescription.getId(), collectionDescription.getName(),
                     session, COLLECTION_VIEWER_TEAM_REMOVED, teamRemoved(collectionDescription, session, teamId));
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
@@ -20,8 +20,8 @@ import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -90,11 +90,9 @@ public class CollectionEventMetaData {
      * Create a {@link CollectionEventMetaData} for viewer team removed event.
      */
     public static CollectionEventMetaData[] teamRemoved(CollectionDescription collectionDescription,
-                                                        Session session, Integer teamId) throws IOException, ZebedeeException {
+                                                        Session session, int teamId) throws IOException, ZebedeeException {
         List<CollectionEventMetaData> list = new ArrayList<>();
-        if (teamId != null) {
-            list.add(new CollectionEventMetaData(TEAM_REMOVED_KEY, Integer.toString(teamId)));
-        }
+        list.add(new CollectionEventMetaData(TEAM_REMOVED_KEY, Integer.toString(teamId)));
 
         if (collectionDescription != null && session != null) {
             list.add(new CollectionEventMetaData(VIEWER_TEAMS_KEY, viewerTeamsAsStr(collectionDescription,
@@ -124,13 +122,8 @@ public class CollectionEventMetaData {
     private static String viewerTeamsAsStr(CollectionDescription collectionDescription, Session session)
             throws
             IOException, ZebedeeException {
-        Iterator<Integer> iterator = Root.zebedee.getPermissionsService().listViewerTeams(collectionDescription, session).iterator();
-        StringBuilder teamsListStr = new StringBuilder();
-
-        while (iterator.hasNext()) {
-            teamsListStr.append(iterator.next()).append(iterator.hasNext() ? ", " : "");
-        }
-        return teamsListStr.toString();
+        Set<Integer> teams = Root.zebedee.getPermissionsService().listViewerTeams(collectionDescription, session);
+        return StringUtils.join(teams, ",");
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/persistence/model/CollectionEventMetaData.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -91,10 +90,10 @@ public class CollectionEventMetaData {
      * Create a {@link CollectionEventMetaData} for viewer team removed event.
      */
     public static CollectionEventMetaData[] teamRemoved(CollectionDescription collectionDescription,
-                                                        Session session, Team team) throws IOException, ZebedeeException {
+                                                        Session session, Integer teamId) throws IOException, ZebedeeException {
         List<CollectionEventMetaData> list = new ArrayList<>();
-        if (team != null && StringUtils.isNotEmpty(team.getName())) {
-            list.add(new CollectionEventMetaData(TEAM_REMOVED_KEY, team.getName()));
+        if (teamId != null) {
+            list.add(new CollectionEventMetaData(TEAM_REMOVED_KEY, Integer.toString(teamId)));
         }
 
         if (collectionDescription != null && session != null) {
@@ -125,12 +124,11 @@ public class CollectionEventMetaData {
     private static String viewerTeamsAsStr(CollectionDescription collectionDescription, Session session)
             throws
             IOException, ZebedeeException {
-        Set<Integer> teams = Root.zebedee.getPermissionsService().listViewerTeams(collectionDescription, session);
-        Iterator<Team> iterator = Root.zebedee.getTeamsService().resolveTeams(teams).iterator();
+        Iterator<Integer> iterator = Root.zebedee.getPermissionsService().listViewerTeams(collectionDescription, session).iterator();
         StringBuilder teamsListStr = new StringBuilder();
 
         while (iterator.hasNext()) {
-            teamsListStr.append(iterator.next().getName()).append(iterator.hasNext() ? ", " : "");
+            teamsListStr.append(iterator.next()).append(iterator.hasNext() ? ", " : "");
         }
         return teamsListStr.toString();
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/StubbedTeamsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/StubbedTeamsServiceImpl.java
@@ -1,0 +1,122 @@
+package com.github.onsdigital.zebedee.teams.service;
+
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.teams.model.Team;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Set;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+
+/**
+ * Implementation of the TeamsService to be used during migration to JWT login using the dp-identity-api. All methods
+ * will throw exceptions to help in identifying any missing dependencies we forget to update.
+ */
+public class StubbedTeamsServiceImpl implements TeamsService {
+
+    private static final String UNSUPPORTED_METHOD = "unsupported attempt to call pre-JWT team service when JWT sessions are enabled";
+
+    /**
+     * @deprecated as Florence can request the team names from the dp-identity-api for presentation on the front end
+     */
+    @Deprecated
+    @Override
+    public List<Team> resolveTeamDetails(Set<Integer> teamIds) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as teams management is moving to the dp-identity-api and the references to this method that will still
+     *             be required after migration (i.e. those in the current {@link com.github.onsdigital.zebedee.permissions.service.PermissionsService}
+     *             implementation can be reworked to use the groups list within the JWT session rather than needing to
+     *             implement calls to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public List<Team> listTeams() {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as teams management is moving to the dp-identity-api and the references to this method will be
+     *             removed.
+     */
+    @Deprecated
+    @Override
+    public List<Team> resolveTeams(Set<Integer> teamIds) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because this would be ugly to implement in the old world, and it is basically tech debt anyways since
+     *             it is used when the collection endpoints accept the `teams` array as a list of team names rather than
+     *             a list of team IDs as the comment on the original field in {@link com.github.onsdigital.zebedee.json.CollectionBase}
+     *             describes. After the migration the model will be returned to the original state of passing the ids
+     *             rather than the names and this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public Team findTeam(String teamName) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public Team createTeam(String teamName, Session session) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public void deleteTeam(Team delete, Session session) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public void addTeamMember(String email, Team team, Session session) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public void removeTeamMember(String email, Team team, Session session) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
+     */
+    @Deprecated
+    @Override
+    public List<AbstractMap.SimpleEntry<String, String>> getTeamMembersSummary(Session session) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsService.java
@@ -1,6 +1,10 @@
 package com.github.onsdigital.zebedee.teams.service;
 
-import com.github.onsdigital.zebedee.exceptions.*;
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.exceptions.NotFoundException;
+import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.teams.model.Team;
 
@@ -10,28 +14,42 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Created by dave on 08/06/2017.
+ * @deprecated this service is deprecated in favour of the dp-identity-api. Any additional code added should avoid using
+ *             service directly.
+ * TODO: Remove this service after the migration to the JWT sessions is complete
  */
+@Deprecated
 public interface TeamsService {
 
     /**
      * Return a list of the current teams.
      *
      * @throws IOException unexpected error listing the current teams.
+     *
+     * @deprecated as teams management is moving to the dp-identity-api this method can be removed when the teams
+     *             endpoints are removed.
      */
+    @Deprecated
     List<Team> listTeams() throws IOException;
 
     /**
      * @param teamIds
      * @return
      * @throws IOException
+     *
+     * @deprecated as teams management is moving to the dp-identity-api and the references to this method will be
+     *             removed.
      */
+    @Deprecated
     List<Team> resolveTeams(Set<Integer> teamIds) throws IOException;
 
     /**
      * Return a list of {@link Team} matching the IDS provided containing only the team name & ID.
      * @param teamIds the ID of the {@link Team}s to get
+     *
+     * @deprecated as Florence can request the team names from the dp-identity-api for presentation on the front end
      */
+    @Deprecated
     List<Team> resolveTeamDetails(Set<Integer> teamIds) throws IOException;
 
     /**
@@ -41,7 +59,13 @@ public interface TeamsService {
      * @return
      * @throws IOException
      * @throws NotFoundException
+     *
+     * @deprecated as this is actually a legacy carry over. The collection endpoints are accepting the teams array as a
+     *             list of team names, but according to the comment in {@link com.github.onsdigital.zebedee.json.CollectionBase}
+     *             the array was always intended to be an array of IDs therefore negating the need for this method.
+     *             This method will be removed after migration to the dp-identity-api.
      */
+    @Deprecated
     Team findTeam(String teamName) throws IOException, NotFoundException;
 
     /**
@@ -51,7 +75,11 @@ public interface TeamsService {
      * @param session  Only administrators can create a team.
      * @return The created team.
      * @throws IOException If a filesystem error occurs.
+     *
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
      */
+    @Deprecated
     Team createTeam(String teamName, Session session) throws IOException, UnauthorizedException, ConflictException, NotFoundException, ForbiddenException;
 
     /**
@@ -60,7 +88,11 @@ public interface TeamsService {
      * @param delete  The team to be deleted. The ID will be used to find the existing team.
      * @param session Only an administrator can delete a team.
      * @throws IOException If a filesystem error occurs.
+     *
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
      */
+    @Deprecated
     void deleteTeam(Team delete, Session session) throws IOException, UnauthorizedException, NotFoundException, BadRequestException, ForbiddenException;
 
     /**
@@ -69,7 +101,11 @@ public interface TeamsService {
      * @param email The user's email.
      * @param team  The team to add the given email to.
      * @throws IOException If a filesystem error occurs.
+     *
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
      */
+    @Deprecated
     void addTeamMember(String email, Team team, Session session) throws IOException, UnauthorizedException, NotFoundException, ForbiddenException;
 
     /**
@@ -78,13 +114,21 @@ public interface TeamsService {
      * @param email The user's email.
      * @param team  The team to remove the given email from.
      * @throws IOException If a filesystem error occurs.
+     *
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
      */
+    @Deprecated
     void removeTeamMember(String email, Team team, Session session) throws IOException, UnauthorizedException, NotFoundException, ForbiddenException;
 
     /**
      * @return on the fly mapping of which teams currently contain which users. Format is teamName -> userEmail.
      * @throws IOException
+     *
+     * @deprecated because teams management will be moving to the dp-identity-api. Once the migration to the new service
+     *             is completed this method will be removed.
      */
+    @Deprecated
     List<AbstractMap.SimpleEntry<String, String>> getTeamMembersSummary(Session session) throws IOException,
             UnauthorizedException, ForbiddenException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
@@ -26,14 +26,16 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.github.onsdigital.zebedee.configuration.Configuration.getUnauthorizedMessage;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.zebedee.configuration.Configuration.getUnauthorizedMessage;
 import static com.github.onsdigital.zebedee.teams.model.Team.teamIDComparator;
 
 /**
  * Handles permissions mapping between users and {@link com.github.onsdigital.zebedee.Zebedee} functions.
- * Created by david on 12/03/2015.
+ *
+ * @deprecated in favour of the dp-identity-api and will be removed after the migration to JWT sessions is complete.
  */
+@Deprecated
 public class TeamsServiceImpl implements TeamsService {
 
     private static final String FORBIDDEN_ERR_MSG = "User does not have the required admin permission to perform " +

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStore.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStore.java
@@ -7,8 +7,9 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Created by dave on 08/06/2017.
+ * @deprecated in favour of the dp-identity-api and will be removed after the migration to JWT sessions is complete.
  */
+@Deprecated
 public interface TeamsStore {
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/store/TeamsStoreFileSystemImpl.java
@@ -24,7 +24,10 @@ import java.util.stream.StreamSupport;
 
 import static org.apache.commons.io.FilenameUtils.isExtension;
 
-
+/**
+ * @deprecated in favour of the dp-identity-api and will be removed after the migration to JWT sessions is complete.
+ */
+@Deprecated
 public class TeamsStoreFileSystemImpl implements TeamsStore {
 
     private static final String JSON_EXT = ".json";

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplTest.java
@@ -470,58 +470,6 @@ public class PermissionsServiceImplTest {
         verifyZeroInteractions(usersService, teamsService);
     }
 
-    @Test
-    public void getCollectionAccessMapping_ForAdminUserSuccess() throws Exception {
-        admins.add(EMAIL);
-
-        when(permissionsStore.getAccessMapping())
-                .thenReturn(accessMapping);
-        when(teamsService.listTeams())
-                .thenReturn(teamsList);
-        when(usersService.list())
-                .thenReturn(userList);
-        when(accessMapping.getAdministrators())
-                .thenReturn(admins);
-
-        List<User> result = permissions.getCollectionAccessMapping(collectionMock);
-
-        verify(permissionsStore, times(1)).getAccessMapping();
-        verify(teamsService, times(1)).listTeams();
-        verify(usersService, times(1)).list();
-        verify(userMock, times(1)).getEmail();
-        verify(accessMapping, times(2)).getAdministrators();
-    }
-
-    @Test
-    public void getCollectionAccessMapping_ForPublisherUserSuccess() throws Exception {
-        digitalPublishingTeam.add(EMAIL);
-
-        List<User> expected = new ArrayList<>();
-        expected.add(userMock);
-
-        when(permissionsStore.getAccessMapping())
-                .thenReturn(accessMapping);
-        when(teamsService.listTeams())
-                .thenReturn(teamsList);
-        when(usersService.list())
-                .thenReturn(userList);
-        when(accessMapping.getAdministrators())
-                .thenReturn(admins);
-        when(accessMapping.getDigitalPublishingTeam())
-                .thenReturn(digitalPublishingTeam);
-        when(collectionMock.getDescription())
-                .thenReturn(collectionDescription);
-
-        List<User> result = permissions.getCollectionAccessMapping(collectionMock);
-
-        assertThat(result, equalTo(expected));
-        verify(permissionsStore, times(2)).getAccessMapping();
-        verify(teamsService, times(1)).listTeams();
-        verify(usersService, times(1)).list();
-        verify(userMock, times(2)).getEmail();
-        verify(accessMapping, times(2)).getAdministrators();
-    }
-
     @Test(expected = UnauthorizedException.class)
     public void addAdministrator_ShouldThrowErrorSessionNull() throws Exception {
         admins.add(EMAIL);


### PR DESCRIPTION
### What

Deprecate and minimise usage of the teams service in preparation for
migration to the JWT sessions. Once we migrate to using the JWTs,
zebedee will no longer have access to the group details as is currently done.

Some further work is required to change the Teams model to use a string
rather than an int for the id. This will also require the access mapping
to be updated as well. Also, the collection details should return the
team ids in the array rather than the team names. This final API change
will need to be managed and coordinated with Florence by means of the
JWT feature flag.

~🚨 Depends on: https://github.com/ONSdigital/zebedee/pull/553~ (Merged)

### Who can review

Anyone but me.
