### PR TITLE
Prepare user handling for JWT migration

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -45,6 +45,7 @@ import com.github.onsdigital.zebedee.teams.service.StubbedTeamsServiceImpl;
 import com.github.onsdigital.zebedee.teams.service.TeamsService;
 import com.github.onsdigital.zebedee.teams.service.TeamsServiceImpl;
 import com.github.onsdigital.zebedee.teams.store.TeamsStoreFileSystemImpl;
+import com.github.onsdigital.zebedee.user.service.StubbedUsersServiceImpl;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import com.github.onsdigital.zebedee.user.service.UsersServiceImpl;
 import com.github.onsdigital.zebedee.user.store.UserStoreFileSystemImpl;
@@ -200,8 +201,13 @@ public class ZebedeeConfiguration {
 
         Supplier<CollectionKeyring> keyringSupplier = () -> collectionKeyring;
 
-        this.usersService = UsersServiceImpl.getInstance(
-                new UserStoreFileSystemImpl(this.usersPath), collections, permissionsService, keyringSupplier);
+        // TODO: Remove after migration to JWT sessions is complete
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            this.usersService = StubbedUsersServiceImpl.getInstance();
+        } else {
+            this.usersService = UsersServiceImpl.getInstance(
+                    new UserStoreFileSystemImpl(this.usersPath), collections, permissionsService, keyringSupplier);
+        }
 
         // Init the collection keyring and scheduler cache.
         initCollectionKeyring();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Root.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
 
 public class Root {
 
@@ -208,7 +209,11 @@ public class Root {
     private static Zebedee initialiseZebedee(Path root) throws IOException, NotFoundException, BadRequestException,
             UnauthorizedException {
         zebedee = new Zebedee(new ZebedeeConfiguration(root, true));
-        createSystemUser();
+
+        // TODO: Remove this logic after migration to using the dp-identity-api
+        if (! cmsFeatureFlags().isJwtSessionsEnabled()) {
+            createSystemUser();
+        }
         return zebedee;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Users.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Users.java
@@ -7,11 +7,11 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import com.github.onsdigital.zebedee.user.model.UserSanitised;
-import com.github.onsdigital.zebedee.service.ServiceSupplier;
 import com.github.onsdigital.zebedee.user.service.UsersService;
 import org.apache.commons.lang3.StringUtils;
 
@@ -27,8 +27,12 @@ import java.util.List;
 
 /**
  * API for managing user accounts. For password management, see {@link Password}.
+ *
+ * @deprecated The user management in zebedee is deprecated in favour of the dp-identity-api with its JWT based auth
+ *             and will be removed after migration of users and teams to the new service.
  */
 @Api
+@Deprecated
 public class Users {
 
     private static final String EMAIL_PARAM = "email";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/model/User.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/model/User.java
@@ -2,13 +2,14 @@ package com.github.onsdigital.zebedee.user.model;
 
 import com.github.davidcarboni.cryptolite.Password;
 import com.github.onsdigital.zebedee.json.Keyring;
-import org.apache.commons.lang3.BooleanUtils;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
 
 /**
  * Represents a user account. NB this record intentionally does not contain any permission-related information.
- * This is purely acconut information.
+ * This is purely account information.
  * Created by david on 12/03/2015.
  */
 public class User extends UserSanitised {
@@ -18,6 +19,8 @@ public class User extends UserSanitised {
     // manage these fields together.
     private String passwordHash;
     private Keyring keyring;
+
+    private static final String UNSUPPORTED_METHOD = "unsupported attempt to call user password related method when JWT sessions are enabled";
 
     /**
      * Constructor for deserialisation.
@@ -30,9 +33,18 @@ public class User extends UserSanitised {
      * Authenticates this user.
      * @param password The user's password.
      * @return If the given password can be verified against {@link #passwordHash}, true.
+     *
+     * @deprecated the JWT session validation supersedes this functionality and this will method will be removed after
+     *             the migration is complete.
      */
+    @Deprecated
     public boolean authenticate(String password) {
-        return Password.verify(password, passwordHash);
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            error().log(UNSUPPORTED_METHOD);
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+        } else {
+            return Password.verify(password, passwordHash);
+        }
     }
 
     /**
@@ -40,52 +52,54 @@ public class User extends UserSanitised {
      * @param oldPassword The user's current password.
      * @param newPassword The new password.
      * @return If the old password can be authenticated and the keyring password is successfully changed, true.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     public boolean changePassword(String oldPassword, String newPassword) {
-        boolean result = true;
-
-        if (authenticate(oldPassword)) {
-            if (keyring().changePassword(oldPassword, newPassword)) {
-                passwordHash = Password.hash(newPassword);
-                result = true;
-            } else {
-                info().log("Unable to change keyring password");
-            }
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            error().log(UNSUPPORTED_METHOD);
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
         } else {
-            info().log("Could not authenticate with the old password");
-        }
+            boolean result = true;
 
-        return result;
+            if (authenticate(oldPassword)) {
+                if (keyring.changePassword(oldPassword, newPassword)) {
+                    passwordHash = Password.hash(newPassword);
+                    result = true;
+                } else {
+                    info().log("Unable to change keyring password");
+                }
+            } else {
+                info().log("Could not authenticate with the old password");
+            }
+
+            /*
+             FIXME: this always returns true regardless of whether the password change succeeds. Not fixing now since
+                    this method will be removed shortly once the JWT session migration is complete.
+             */
+            return result;
+        }
     }
 
     /**
      * Sets the user's password and generates a new, empty keyring.
      * @param password The new password for the user.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     public void resetPassword(String password) {
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            error().log(UNSUPPORTED_METHOD);
+            throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+        } else {
+            // Update the password hash
+            passwordHash = Password.hash(password);
 
-        // Update the password hash
-        passwordHash = Password.hash(password);
-
-
-        // Generate a new key pair and wipe out any stored keys.
-        // Without the original password none of the stored keys can be recovered.
-        keyring = Keyring.generate(password);
-    }
-
-    /**
-     * @return {@link #keyring}.
-     */
-    public Keyring keyring() {
-        return keyring;
-    }
-
-    public void setKeyring(Keyring keyring) {
-        this.keyring = keyring;
-    }
-
-    @Override
-    public String toString() {
-        return name + ", " + email + (BooleanUtils.isTrue(inactive) ? " (inactive)" : "");
+            // Generate a new key pair and wipe out any stored keys.
+            // Without the original password none of the stored keys can be recovered.
+            keyring = Keyring.generate(password);
+        }
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/model/User.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/model/User.java
@@ -42,9 +42,9 @@ public class User extends UserSanitised {
         if (cmsFeatureFlags().isJwtSessionsEnabled()) {
             error().log(UNSUPPORTED_METHOD);
             throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
-        } else {
-            return Password.verify(password, passwordHash);
         }
+
+        return Password.verify(password, passwordHash);
     }
 
     /**
@@ -60,26 +60,26 @@ public class User extends UserSanitised {
         if (cmsFeatureFlags().isJwtSessionsEnabled()) {
             error().log(UNSUPPORTED_METHOD);
             throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
-        } else {
-            boolean result = true;
-
-            if (authenticate(oldPassword)) {
-                if (keyring.changePassword(oldPassword, newPassword)) {
-                    passwordHash = Password.hash(newPassword);
-                    result = true;
-                } else {
-                    info().log("Unable to change keyring password");
-                }
-            } else {
-                info().log("Could not authenticate with the old password");
-            }
-
-            /*
-             FIXME: this always returns true regardless of whether the password change succeeds. Not fixing now since
-                    this method will be removed shortly once the JWT session migration is complete.
-             */
-            return result;
         }
+
+        boolean result = true;
+
+        if (authenticate(oldPassword)) {
+            if (keyring.changePassword(oldPassword, newPassword)) {
+                passwordHash = Password.hash(newPassword);
+                result = true;
+            } else {
+                info().log("Unable to change keyring password");
+            }
+        } else {
+            info().log("Could not authenticate with the old password");
+        }
+
+        /*
+         FIXME: this always returns true regardless of whether the password change succeeds. Not fixing now since
+                this method will be removed shortly once the JWT session migration is complete.
+         */
+        return result;
     }
 
     /**
@@ -93,13 +93,13 @@ public class User extends UserSanitised {
         if (cmsFeatureFlags().isJwtSessionsEnabled()) {
             error().log(UNSUPPORTED_METHOD);
             throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
-        } else {
-            // Update the password hash
-            passwordHash = Password.hash(password);
-
-            // Generate a new key pair and wipe out any stored keys.
-            // Without the original password none of the stored keys can be recovered.
-            keyring = Keyring.generate(password);
         }
+
+        // Update the password hash
+        passwordHash = Password.hash(password);
+
+        // Generate a new key pair and wipe out any stored keys.
+        // Without the original password none of the stored keys can be recovered.
+        keyring = Keyring.generate(password);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/StubbedUsersServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/StubbedUsersServiceImpl.java
@@ -17,22 +17,11 @@ public class StubbedUsersServiceImpl implements UsersService {
 
     private static final String UNSUPPORTED_METHOD = "unsupported attempt to call pre-JWT user service when JWT sessions are enabled";
 
-    private static UsersService INSTANCE = null;
-    private static final Object MUTEX = new Object();
-
-
     /**
      * Get a singleton instance of {@link StubbedUsersServiceImpl}.
      */
     public static UsersService getInstance() {
-        if (INSTANCE == null) {
-            synchronized (MUTEX) {
-                if (INSTANCE == null) {
-                    INSTANCE = new StubbedUsersServiceImpl();
-                }
-            }
-        }
-        return INSTANCE;
+        return new StubbedUsersServiceImpl();
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/StubbedUsersServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/StubbedUsersServiceImpl.java
@@ -1,0 +1,123 @@
+package com.github.onsdigital.zebedee.user.service;
+
+import com.github.onsdigital.zebedee.json.Credentials;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.user.model.User;
+import com.github.onsdigital.zebedee.user.model.UserList;
+
+import java.io.IOException;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+
+/**
+ * Implementation of the UsersService to be used during migration to JWT login using the dp-identity-api. All methods
+ * will throw exceptions to help in identifying any missing dependencies we forget to update.
+ */
+public class StubbedUsersServiceImpl implements UsersService {
+
+    private static final String UNSUPPORTED_METHOD = "unsupported attempt to call pre-JWT user service when JWT sessions are enabled";
+
+    private static UsersService INSTANCE = null;
+    private static final Object MUTEX = new Object();
+
+
+    /**
+     * Get a singleton instance of {@link StubbedUsersServiceImpl}.
+     */
+    public static UsersService getInstance() {
+        if (INSTANCE == null) {
+            synchronized (MUTEX) {
+                if (INSTANCE == null) {
+                    INSTANCE = new StubbedUsersServiceImpl();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * @deprecated as the users will be moved to dp-identity-api so this sort of lookup will not be possible. Any usages
+     *             should either be written out or should be updated to get the current user from the JWT session instead
+     */
+    @Deprecated
+    @Override
+    public User getUserByEmail(String email) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated when JWT sessions are enabled we are no longer able to complete this check. This check is only used
+     *             by the {@link com.github.onsdigital.zebedee.authorisation.AuthorisationServiceImpl} as an extra
+     *             precaution when checking the users' session. This is because in the old implementation a session
+     *             could live on even if the user was removed. When using the JWTs the need for this check is mitigated
+     *             by the short validity duration of the JWT and the risk of a user continuing to perform for a few
+     *             minutes after their user has been deactivated has been accepted.
+     */
+    @Deprecated
+    @Override
+    public boolean exists(String email) throws IOException {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated since this logic will no longer be required after migrating to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public void createSystemUser(User user, String password) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public User create(Session session, User user) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public boolean setPassword(Session session, Credentials credentials) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public UserList list() throws IOException, UnsupportedOperationException {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public User update(Session session, User user, User updatedUser) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+
+    /**
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
+     */
+    @Deprecated
+    @Override
+    public boolean delete(Session session, User user) {
+        error().log(UNSUPPORTED_METHOD);
+        throw new UnsupportedOperationException(UNSUPPORTED_METHOD);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersService.java
@@ -5,25 +5,21 @@ import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.Credentials;
-import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 
-import javax.crypto.SecretKey;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Interface defining User management functions.
  */
+@Deprecated
 public interface UsersService {
 
     String BLANK_EMAIL_MSG = "User email cannot be blank";
     String UNKNOWN_USER_MSG = "User for email {0} not found";
     String USER_ALREADY_EXISTS_MSG = "User for email {0} already exists";
-    String REMOVING_STALE_KEY_LOG_MSG = "Removing stale collection key from user.";
     String SYSTEM_USER_ALREADY_EXISTS_MSG = "A system user already exists, no futher action required.";
     String CREATE_USER_AUTH_ERROR_MSG = "This account is not permitted to create users.";
     String USER_DETAILS_INVALID_MSG = "Name & email are required fields for User.";
@@ -37,7 +33,11 @@ public interface UsersService {
      * @throws IOException         unexpected error while attempting to find the requested user.
      * @throws NotFoundException   the requested user does not exist.
      * @throws BadRequestException email address was empty or null.
+     *
+     * @deprecated as the users will be moved to dp-identity-api so this sort of lookup will not be possible. Any usages
+     *             should either be written out or should be updated to get the current user from the JWT session instead
      */
+    @Deprecated
     User getUserByEmail(String email) throws IOException, NotFoundException, BadRequestException;
 
     /**
@@ -46,17 +46,16 @@ public interface UsersService {
      * @param email the email address of the user to search for.
      * @return true if a user exists with the specified email address false otherwise.
      * @throws IOException unexpected problem.
-     */
-    boolean exists(String email) throws IOException;
-
-    /**
-     * Check if a user exists for the email address provided.
      *
-     * @param user the user
-     * @return true if a user exists with the specified email address false otherwise.
-     * @throws IOException unexpected problem.
+     * @deprecated when JWT sessions are enabled we are no longer able to complete this check. This check is only used
+     *             by the {@link com.github.onsdigital.zebedee.authorisation.AuthorisationServiceImpl} as an extra
+     *             precaution when checking the users' session. This is because in the old implementation a session
+     *             could live on even if the user was removed. When using the JWTs the need for this check is mitigated
+     *             by the short validity duration of the JWT and the risk of a user continuing to perform for a few
+     *             minutes after their user has been deactivated has been accepted.
      */
-    boolean exists(User user) throws IOException;
+    @Deprecated
+    boolean exists(String email) throws IOException;
 
     /**
      * Create a new system user.
@@ -67,23 +66,11 @@ public interface UsersService {
      * @throws UnauthorizedException unexpected problem creating user.
      * @throws NotFoundException     unexpected problem creating user.
      * @throws BadRequestException   unexpected problem creating user.
-     */
-    void createSystemUser(User user, String password) throws IOException, UnauthorizedException, NotFoundException, BadRequestException;
-
-    /**
-     * Create a new publisher user.
      *
-     * @param user     the user to create.
-     * @param password the password to set.
-     * @param session  the session of the user creating the new publisher user.
-     * @throws IOException           unexpected problem creating user.
-     * @throws UnauthorizedException unexpected problem creating user.
-     * @throws ConflictException     unexpected problem creating user.
-     * @throws BadRequestException   unexpected problem creating user.
-     * @throws NotFoundException     unexpected problem creating user.
+     * @deprecated since this logic will no longer be required after migrating to the dp-identity-api.
      */
-    void createPublisher(User user, String password, Session session) throws IOException,
-            UnauthorizedException, ConflictException, BadRequestException, NotFoundException;
+    @Deprecated
+    void createSystemUser(User user, String password) throws IOException, UnauthorizedException, NotFoundException, BadRequestException;
 
     /**
      * Create a new user.
@@ -95,7 +82,10 @@ public interface UsersService {
      * @throws IOException           unexpected problem creating user.
      * @throws ConflictException     unexpected problem creating user.
      * @throws BadRequestException   unexpected problem creating user.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     User create(Session session, User user) throws UnauthorizedException, IOException, ConflictException,
             BadRequestException;
 
@@ -109,7 +99,10 @@ public interface UsersService {
      * @throws UnauthorizedException unexpected problem setting the user password.
      * @throws BadRequestException   unexpected problem setting the user password.
      * @throws NotFoundException     unexpected problem setting the user password.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     boolean setPassword(Session session, Credentials credentials) throws IOException, UnauthorizedException,
             BadRequestException, NotFoundException;
 
@@ -117,7 +110,10 @@ public interface UsersService {
      * List all of the users.
      *
      * @throws IOException unexpected list the system users.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     UserList list() throws IOException;
 
     /**
@@ -131,7 +127,10 @@ public interface UsersService {
      * @throws UnauthorizedException unexpected problem updating the user.
      * @throws NotFoundException     unexpected problem updating the user.
      * @throws BadRequestException   unexpected problem updating the user.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     User update(Session session, User user, User updatedUser) throws IOException, UnauthorizedException,
             NotFoundException, BadRequestException;
 
@@ -144,7 +143,10 @@ public interface UsersService {
      * @throws IOException           unexpected problem deleting the user.
      * @throws UnauthorizedException unexpected problem deleting the user.
      * @throws NotFoundException     unexpected problem deleting the user.
+     *
+     * @deprecated as the user management functionality is being migrated to the dp-identity-api.
      */
+    @Deprecated
     boolean delete(Session session, User user) throws IOException, UnauthorizedException, NotFoundException,
             BadRequestException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/service/UsersServiceImpl.java
@@ -5,27 +5,19 @@ import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.AdminOptions;
-import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.json.Credentials;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
-import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 import com.github.onsdigital.zebedee.user.store.UserStore;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.crypto.SecretKey;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static java.text.MessageFormat.format;
@@ -40,6 +32,7 @@ import static java.text.MessageFormat.format;
  * overwridden by subsequent updates - leading to data missing from user.<br/> The obvious performance implications
  * are outweighed by the correctness of data. The long term plan is to use a database.
  */
+@Deprecated
 public class UsersServiceImpl implements UsersService {
 
     private static final Object MUTEX = new Object();
@@ -117,11 +110,6 @@ public class UsersServiceImpl implements UsersService {
     }
 
     @Override
-    public boolean exists(User user) throws IOException {
-        return user != null && userStore.exists(user.getEmail());
-    }
-
-    @Override
     public void createSystemUser(User user, String password) throws IOException, UnauthorizedException,
             NotFoundException, BadRequestException {
         if (permissionsService.hasAdministrator()) {
@@ -139,17 +127,6 @@ public class UsersServiceImpl implements UsersService {
         } finally {
             lock.unlock();
         }
-    }
-
-    @Override
-    public void createPublisher(User user, String password, Session session) throws IOException,
-            UnauthorizedException, ConflictException, BadRequestException, NotFoundException {
-        create(session, user);
-        Credentials credentials = new Credentials();
-        credentials.setEmail(user.getEmail());
-        credentials.setPassword(password);
-        setPassword(session, credentials);
-        permissionsService.addEditor(user.getEmail(), session);
     }
 
     @Override

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/store/UserStore.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/store/UserStore.java
@@ -2,7 +2,6 @@ package com.github.onsdigital.zebedee.user.store;
 
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
-import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.model.UserList;
 
@@ -11,6 +10,7 @@ import java.io.IOException;
 /**
  * Created by dave on 30/05/2017.
  */
+@Deprecated
 public interface UserStore {
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/store/UserStoreFileSystemImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/user/store/UserStoreFileSystemImpl.java
@@ -19,6 +19,7 @@ import java.util.stream.StreamSupport;
 /**
  * Created by dave on 30/05/2017.
  */
+@Deprecated
 public class UserStoreFileSystemImpl implements UserStore {
 
     private static final String JSON_EXT = ".json";

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/CustomListCollector.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/CustomListCollector.java
@@ -1,7 +1,5 @@
 package com.github.onsdigital.zebedee.util;
 
-import com.github.onsdigital.zebedee.user.model.User;
-import com.github.onsdigital.zebedee.user.model.UserList;
 import com.google.common.collect.ImmutableList;
 
 import java.util.EnumSet;
@@ -14,7 +12,7 @@ import java.util.stream.Collector;
 
 /**
  * Abstract custom {@link Collector} - If you want to use {@link java.util.stream.Stream} to iterate over the custom
- * collection types in the code base i.e. {@link UserList}.
+ * collection types in the code base.
  */
 public abstract class CustomListCollector<T, R> implements Collector<T, ImmutableList.Builder<T>, R> {
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTest.java
@@ -3,7 +3,6 @@ package com.github.onsdigital.zebedee;
 import com.github.onsdigital.zebedee.api.Root;
 import com.github.onsdigital.zebedee.exceptions.CollectionNotFoundException;
 import com.github.onsdigital.zebedee.json.Credentials;
-import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.apache.commons.io.FileUtils;
@@ -28,10 +27,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -315,7 +311,6 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
         assertThat(ex.getCause().getMessage(), equalTo("boom"));
         verify(usersService, times(1)).getUserByEmail(TEST_EMAIL);
         verify(sessions, times(1)).create(user);
-        verify(user, never()).keyring();
 
         verifyZeroInteractions(collectionKeyring);
     }
@@ -336,9 +331,6 @@ public class ZebedeeTest extends ZebedeeTestBaseFixture {
 
         when(sessions.create(user))
                 .thenReturn(userSession);
-
-        when(user.keyring())
-                .thenReturn(usersKeyring);
 
         when(permissionsService.isAdministrator(any(Session.class)))
                 .thenReturn(true);


### PR DESCRIPTION
### What

Deprecate the Users service in preparation for enabling the JWT
migration. Put a stubbed version in place to ensure that zebedee is able
to start correctly after the migration, while also ensuring that there
isn't any chance of accidentally still relying on the old logic
somewhere.

Any unused methods were removed.

Some further work is required to write out some uses of the
Users service that will exist after the migration to using the
dp-identity-api and JWT sessions. These changes will follow later.

Depends on https://github.com/ONSdigital/zebedee/pull/557.

### Who can review

Anyone but me.
