### PR TITLE
refactored CMS start up - it no longer uses falls back on default con…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+        <restolino.version>v0.4.0</restolino.version>
         <fasterxml.jackson.version>2.13.0</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
     </properties>
@@ -108,7 +109,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>restolino</artifactId>
-                <version>v0.3.0</version>
+                <version>${restolino.version}</version>
             </dependency>
 
             <!-- Cryptography -->

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee;
 
+import com.github.davidcarboni.restolino.framework.Priority;
 import com.github.davidcarboni.restolino.framework.Startup;
 import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.Logger;
@@ -22,6 +23,7 @@ import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 /**
  * Created by bren on 31/07/15.
  */
+@Priority(2)
 public class Init implements Startup {
 
     private static final String FORMAT_LOGS_KEY = "FORMAT_LOGGING";
@@ -42,6 +44,8 @@ public class Init implements Startup {
             System.err.println(ex);
             System.exit(1);
         }
+
+        info().log("initialising Zebedee CMS");
 
         info().log("loading CMS feature flags");
         CMSFeatureFlags.cmsFeatureFlags();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Init.java
@@ -16,7 +16,8 @@ import com.github.onsdigital.zebedee.model.ZebedeeCollectionReaderFactory;
 import com.github.onsdigital.zebedee.persistence.dao.CollectionHistoryDaoFactory;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 
 /**
  * Created by bren on 31/07/15.
@@ -45,11 +46,16 @@ public class Init implements Startup {
         info().log("loading CMS feature flags");
         CMSFeatureFlags.cmsFeatureFlags();
 
-        Root.init();
-        ZebedeeReader.setCollectionReaderFactory(new ZebedeeCollectionReaderFactory(Root.zebedee));
+        try {
+            Root.init();
+            ZebedeeReader.setCollectionReaderFactory(new ZebedeeCollectionReaderFactory(Root.zebedee));
+            CollectionHistoryDaoFactory.initialise();
+        } catch (Exception ex) {
+            error().exception(ex).log("CMS start up failed with error, exiting application");
+            System.exit(1);
+        }
 
-        CollectionHistoryDaoFactory.initialise();
-        info().log("zebedee cms start up completed");
+        info().log("zebedee cms start up completed successfully");
     }
 
     private LogSerialiser getLogSerialiser() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/ReaderInit.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/ReaderInit.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee;
 
 import ch.qos.logback.classic.LoggerContext;
+import com.github.davidcarboni.restolino.framework.Priority;
 import com.github.davidcarboni.restolino.framework.Startup;
 import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.Logger;
@@ -28,6 +29,7 @@ import static com.github.onsdigital.zebedee.logging.ReaderLogger.error;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.info;
 import static com.github.onsdigital.zebedee.search.configuration.SearchConfiguration.getSearchAlias;
 
+@Priority(1)
 public class ReaderInit implements Startup {
 
     private static final String FORMAT_LOGS_KEY = "FORMAT_LOGGING";
@@ -53,6 +55,8 @@ public class ReaderInit implements Startup {
                 System.exit(1);
             }
         }
+
+        info().log("initialising Zebedee Reader");
 
         info().log("loading zebedee reader configuration");
         ReaderConfiguration.get();


### PR DESCRIPTION
- Refactored CMS start up so it no longer falls back on default content if there is an error starting up. 
  
  Previously any error starting up would be caught and it would attempt to start up again using the default content. This functionality is misleading, masks issues and makes the CMS seem healthy when its not. 

  With these new changes any error initialising the CMS will causing the application to shutdown with an explicit message about the error encountered. 
- Updated `Restolino` to latest version.
- Added `@Priority(n)` annotations to init classes to guarantee start up order - Reader 1st, CMS 2nd.
