### PR TITLE
Rename enum values to follow convention

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
@@ -98,7 +98,7 @@ public class Page {
                 new APIDatasetLandingPageDeletionHook(datasetAPIClient);
 
         Map<PageType, PageUpdateHook> deletionHooks = new HashMap<>();
-        deletionHooks.put(PageType.api_dataset_landing_page, datasetLandingPageDeletionHook);
+        deletionHooks.put(PageType.API_DATASET_LANDING_PAGE, datasetLandingPageDeletionHook);
 
         return deletionHooks;
     }
@@ -108,7 +108,7 @@ public class Page {
                 new APIDatasetLandingPageCreationHook(datasetAPIClient);
 
         Map<PageType, PageUpdateHook> creationHooks = new HashMap<>();
-        creationHooks.put(PageType.api_dataset_landing_page, datasetLandingPageCreationHook);
+        creationHooks.put(PageType.API_DATASET_LANDING_PAGE, datasetLandingPageCreationHook);
 
         return creationHooks;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataPublicationFinder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataPublicationFinder.java
@@ -36,7 +36,7 @@ public class DataPublicationFinder {
 
                 // Find all timeseries_datasets
                 Page page = reviewedContentReader.getContent(pageUri);
-                if (page != null && page.getType() == PageType.timeseries_dataset) {
+                if (page != null && page.getType() == PageType.TIMESERIES_DATASET) {
                     DataPublication newPublication = new DataPublication(publishedContentReader, reviewedContentReader, pageUri);
                     results.add(newPublication);
                 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
@@ -5,12 +5,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.github.onsdigital.zebedee.content.page.base.PageType;
+
 /**
  * Class to hold a file uri and any other properties required from that file.
  */
 public class ContentDetail {
     public String uri;
-    public String type;
+    private PageType type;
     public ContentDetailDescription description;
 
     public List<ContentDetail> children;
@@ -20,6 +22,17 @@ public class ContentDetail {
 
     public ContentDetail() {
     }
+    
+    /**
+     * Convenience constructor
+     *
+     * @param uri
+     * @param type
+     */
+    public ContentDetail(String uri, PageType type) {
+        this.uri = uri;
+        this.type = type;
+    }
 
     /**
      * Convenience constructor taking the typical parameters.
@@ -28,10 +41,8 @@ public class ContentDetail {
      * @param uri
      * @param type
      */
-    public ContentDetail(String title, String uri, String type) {
-        this.uri = uri;
-        this.type = type;
-        this.description = new ContentDetailDescription(title);
+    public ContentDetail(String title, String uri, PageType type) {
+        this(new ContentDetailDescription(title), uri, type);
     }
 
     /**
@@ -41,16 +52,13 @@ public class ContentDetail {
      * @param uri
      * @param type
      */
-    public ContentDetail(ContentDetailDescription description, String uri, String type) {
-        this.uri = uri;
-        this.type = type;
+    public ContentDetail(ContentDetailDescription description, String uri, PageType type) {
+        this(uri, type);
         this.description = description;
     }
 
-    public ContentDetail(ContentDetailDescription description, String uri, String type, String contentPath) {
-        this.uri = uri;
-        this.type = type;
-        this.description = description;
+    public ContentDetail(ContentDetailDescription description, String uri, PageType type, String contentPath) {
+        this(description, uri, type);
         this.contentPath = contentPath;
     }
 
@@ -216,5 +224,9 @@ public class ContentDetail {
 
     public void setDeleteMarker(boolean hasDeleteMarker) {
         this.deleteMarker = hasDeleteMarker;
+    }
+    
+    public PageType getType() {
+        return type;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
@@ -22,36 +22,16 @@ public class ContentDetail {
 
     public ContentDetail() {
     }
-    
-    /**
-     * Convenience constructor
-     *
-     * @param uri
-     * @param type
-     */
+
     public ContentDetail(String uri, PageType type) {
         this.uri = uri;
         this.type = type;
     }
 
-    /**
-     * Convenience constructor taking the typical parameters.
-     *
-     * @param title
-     * @param uri
-     * @param type
-     */
     public ContentDetail(String title, String uri, PageType type) {
         this(new ContentDetailDescription(title), uri, type);
     }
 
-    /**
-     * Convenience constructor taking the typical parameters.
-     *
-     * @param description
-     * @param uri
-     * @param type
-     */
     public ContentDetail(ContentDetailDescription description, String uri, PageType type) {
         this(uri, type);
         this.description = description;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1444,7 +1444,7 @@ public class Collection {
         return description.getDatasets().stream().map(ds -> {
 
             String url = URI.create(ds.getUri()).getPath();
-            return new ContentDetail(ds.getTitle(), url, PageType.api_dataset_landing_page.toString());
+            return new ContentDetail(ds.getTitle(), url, PageType.API_DATASET_LANDING_PAGE.toString());
 
         }).collect(Collectors.toList());
     }
@@ -1460,8 +1460,8 @@ public class Collection {
             String datasetURL = "/datasets/" + ds.getId();
             String versionURL = datasetURL + "/editions/" + ds.getEdition() + "/versions/" + ds.getVersion();
 
-            ContentDetail versionDetail = new ContentDetail(ds.getTitle(), versionURL, PageType.api_dataset.toString());
-            ContentDetail datasetDetail = new ContentDetail(ds.getTitle(), datasetURL, PageType.api_dataset_landing_page.toString());
+            ContentDetail versionDetail = new ContentDetail(ds.getTitle(), versionURL, PageType.API_DATASET.toString());
+            ContentDetail datasetDetail = new ContentDetail(ds.getTitle(), datasetURL, PageType.API_DATASET_LANDING_PAGE.toString());
 
             return (new ArrayList<>(Arrays.asList(versionDetail, datasetDetail))).stream();
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1444,7 +1444,7 @@ public class Collection {
         return description.getDatasets().stream().map(ds -> {
 
             String url = URI.create(ds.getUri()).getPath();
-            return new ContentDetail(ds.getTitle(), url, PageType.API_DATASET_LANDING_PAGE.toString());
+            return new ContentDetail(ds.getTitle(), url, PageType.API_DATASET_LANDING_PAGE);
 
         }).collect(Collectors.toList());
     }
@@ -1460,8 +1460,8 @@ public class Collection {
             String datasetURL = "/datasets/" + ds.getId();
             String versionURL = datasetURL + "/editions/" + ds.getEdition() + "/versions/" + ds.getVersion();
 
-            ContentDetail versionDetail = new ContentDetail(ds.getTitle(), versionURL, PageType.API_DATASET.toString());
-            ContentDetail datasetDetail = new ContentDetail(ds.getTitle(), datasetURL, PageType.API_DATASET_LANDING_PAGE.toString());
+            ContentDetail versionDetail = new ContentDetail(ds.getTitle(), versionURL, PageType.API_DATASET);
+            ContentDetail datasetDetail = new ContentDetail(ds.getTitle(), datasetURL, PageType.API_DATASET_LANDING_PAGE);
 
             return (new ArrayList<>(Arrays.asList(versionDetail, datasetDetail))).stream();
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -255,9 +255,7 @@ public class ApproveTask implements Callable<Boolean> {
                 info().data("collectionId", collection.getDescription().getId()).log("adding uri to delete to the publish notification " + node.uri);
 
                 if (!contentToDelete.contains(node.uri)) {
-                    ContentDetail contentDetailToDelete = new ContentDetail();
-                    contentDetailToDelete.uri = node.uri;
-                    contentDetailToDelete.type = node.type;
+                    ContentDetail contentDetailToDelete = new ContentDetail(node.uri, node.getType());
                     contentToDelete.add(contentDetailToDelete);
                 }
             });

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -19,11 +19,11 @@ import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.github.onsdigital.zebedee.content.page.base.PageType.article;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.bulletin;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.compendium_chapter;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.compendium_landing_page;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.static_methodology;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.ARTICLE;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.BULLETIN;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.COMPENDIUM_CHAPTER;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.COMPENDIUM_LANDING_PAGE;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.STATIC_METHODOLOGY;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
 import static java.text.MessageFormat.format;
@@ -42,11 +42,11 @@ public class CollectionPdfGenerator {
         EXECUTOR_SERVICE = Executors.newFixedThreadPool(5); // TODO should this be configurable?
 
         PDF_GENERATING_PAGES = new ArrayList<PageType>() {{
-            add(article);
-            add(bulletin);
-            add(compendium_landing_page);
-            add(compendium_chapter);
-            add(static_methodology);
+            add(ARTICLE);
+            add(BULLETIN);
+            add(COMPENDIUM_LANDING_PAGE);
+            add(COMPENDIUM_CHAPTER);
+            add(STATIC_METHODOLOGY);
         }};
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> closeExecutorService()));
@@ -54,7 +54,7 @@ public class CollectionPdfGenerator {
 
     private PdfService pdfService;
 
-    private Predicate<ContentDetail> isPDFPage = (c -> PDF_GENERATING_PAGES.contains(PageType.valueOf(c.type)));
+    private Predicate<ContentDetail> isPDFPage = (c -> PDF_GENERATING_PAGES.contains(PageType.valueOf(c.type.toUpperCase())));
 
     /**
      * Create a new instance to use the provided PdfService.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -54,7 +54,7 @@ public class CollectionPdfGenerator {
 
     private PdfService pdfService;
 
-    private Predicate<ContentDetail> isPDFPage = (c -> PDF_GENERATING_PAGES.contains(PageType.valueOf(c.type.toUpperCase())));
+    private Predicate<ContentDetail> isPDFPage = (c -> PDF_GENERATING_PAGES.contains(c.getType()));
 
     /**
      * Create a new instance to use the provided PdfService.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -41,10 +41,10 @@ public class ReleasePopulator {
 
     private static void addPageDetailToRelease(Release release, ContentDetail contentDetail) {
 
-        if (contentDetail.type.equals(PageType.article.toString())
-                || contentDetail.type.equals(PageType.article_download.toString())
-                || contentDetail.type.equals(PageType.bulletin.toString())
-                || contentDetail.type.equals(PageType.compendium_landing_page.toString())) {
+        if (contentDetail.type.equals(PageType.ARTICLE.toString())
+                || contentDetail.type.equals(PageType.ARTICLE_DOWNLOAD.toString())
+                || contentDetail.type.equals(PageType.BULLETIN.toString())
+                || contentDetail.type.equals(PageType.COMPENDIUM_LANDING_PAGE.toString())) {
 
             info().data("contentTitle", contentDetail.description.title).data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding document as a link to release");
@@ -52,8 +52,8 @@ public class ReleasePopulator {
             addRelatedDocument(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.dataset_landing_page.toString())
-                || contentDetail.type.equals(PageType.api_dataset_landing_page.toString())) {
+        if (contentDetail.type.equals(PageType.DATASET_LANDING_PAGE.toString())
+                || contentDetail.type.equals(PageType.API_DATASET_LANDING_PAGE.toString())) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
@@ -62,7 +62,7 @@ public class ReleasePopulator {
             addRelatedDataset(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.static_qmi.toString())) {
+        if (contentDetail.type.equals(PageType.STATIC_QMI.toString())) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
@@ -71,8 +71,8 @@ public class ReleasePopulator {
             addRelatedQMI(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.static_methodology.toString())
-                || contentDetail.type.equals(PageType.static_methodology_download.toString())) {
+        if (contentDetail.type.equals(PageType.STATIC_METHODOLOGY.toString())
+                || contentDetail.type.equals(PageType.STATIC_METHODOLOGY_DOWNLOAD.toString())) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -1,6 +1,5 @@
 package com.github.onsdigital.zebedee.model.approval.tasks;
 
-import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.content.page.release.Release;
 import com.github.onsdigital.zebedee.content.partial.Link;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
@@ -40,44 +39,40 @@ public class ReleasePopulator {
     }
 
     private static void addPageDetailToRelease(Release release, ContentDetail contentDetail) {
-        if (contentDetail.getType().equals(PageType.ARTICLE)
-                || contentDetail.getType().equals(PageType.ARTICLE_DOWNLOAD)
-                || contentDetail.getType().equals(PageType.BULLETIN)
-                || contentDetail.getType().equals(PageType.COMPENDIUM_LANDING_PAGE)) {
-
+        switch (contentDetail.getType()) {
+        case ARTICLE:
+        case ARTICLE_DOWNLOAD:
+        case BULLETIN:
+        case COMPENDIUM_LANDING_PAGE:
             info().data("contentTitle", contentDetail.description.title).data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding document as a link to release");
 
             addRelatedDocument(release, contentDetail);
-        }
-
-        if (contentDetail.getType().equals(PageType.DATASET_LANDING_PAGE)
-                || contentDetail.getType().equals(PageType.API_DATASET_LANDING_PAGE)) {
-
+            break;
+        case DATASET_LANDING_PAGE:
+        case API_DATASET_LANDING_PAGE:
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding dataset as a link to release");
 
             addRelatedDataset(release, contentDetail);
-        }
-
-        if (contentDetail.getType().equals(PageType.STATIC_QMI)) {
-
+            break;
+        case STATIC_QMI:
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding qmi as a link to release");
 
             addRelatedQMI(release, contentDetail);
-        }
-
-        if (contentDetail.getType().equals(PageType.STATIC_METHODOLOGY)
-                || contentDetail.getType().equals(PageType.STATIC_METHODOLOGY_DOWNLOAD)) {
-
+            break;
+        case STATIC_METHODOLOGY:
+        case STATIC_METHODOLOGY_DOWNLOAD:
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding methodology article as a link to release");
 
             addRelatedMethodologyArticle(release, contentDetail);
+            break;
+        default: // Do nothing fot other types
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -40,11 +40,10 @@ public class ReleasePopulator {
     }
 
     private static void addPageDetailToRelease(Release release, ContentDetail contentDetail) {
-
-        if (contentDetail.type.equals(PageType.ARTICLE.toString())
-                || contentDetail.type.equals(PageType.ARTICLE_DOWNLOAD.toString())
-                || contentDetail.type.equals(PageType.BULLETIN.toString())
-                || contentDetail.type.equals(PageType.COMPENDIUM_LANDING_PAGE.toString())) {
+        if (contentDetail.getType().equals(PageType.ARTICLE)
+                || contentDetail.getType().equals(PageType.ARTICLE_DOWNLOAD)
+                || contentDetail.getType().equals(PageType.BULLETIN)
+                || contentDetail.getType().equals(PageType.COMPENDIUM_LANDING_PAGE)) {
 
             info().data("contentTitle", contentDetail.description.title).data("releaseTitle", release.getDescription().getTitle())
                     .log("Adding document as a link to release");
@@ -52,8 +51,8 @@ public class ReleasePopulator {
             addRelatedDocument(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.DATASET_LANDING_PAGE.toString())
-                || contentDetail.type.equals(PageType.API_DATASET_LANDING_PAGE.toString())) {
+        if (contentDetail.getType().equals(PageType.DATASET_LANDING_PAGE)
+                || contentDetail.getType().equals(PageType.API_DATASET_LANDING_PAGE)) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
@@ -62,7 +61,7 @@ public class ReleasePopulator {
             addRelatedDataset(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.STATIC_QMI.toString())) {
+        if (contentDetail.getType().equals(PageType.STATIC_QMI)) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())
@@ -71,8 +70,8 @@ public class ReleasePopulator {
             addRelatedQMI(release, contentDetail);
         }
 
-        if (contentDetail.type.equals(PageType.STATIC_METHODOLOGY.toString())
-                || contentDetail.type.equals(PageType.STATIC_METHODOLOGY_DOWNLOAD.toString())) {
+        if (contentDetail.getType().equals(PageType.STATIC_METHODOLOGY)
+                || contentDetail.getType().equals(PageType.STATIC_METHODOLOGY_DOWNLOAD)) {
 
             info().data("contentTitle", contentDetail.description.title)
                     .data("releaseTitle", release.getDescription().getTitle())

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -332,7 +332,7 @@ public class PostPublisher {
                     info().data("uri", node.uri).log("Deleting index from publishing search ");
                     pool.submit(() -> {
                         try {
-                            Indexer.getInstance().deleteContentIndex(node.getType().getSerializedName(), node.uri);
+                            Indexer.getInstance().deleteContentIndex(node.getType().getLabel(), node.uri);
                         } catch (Exception e) {
                             error().logException(e, "Exception reloading search index:");
                         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -332,7 +332,7 @@ public class PostPublisher {
                     info().data("uri", node.uri).log("Deleting index from publishing search ");
                     pool.submit(() -> {
                         try {
-                            Indexer.getInstance().deleteContentIndex(node.type, node.uri);
+                            Indexer.getInstance().deleteContentIndex(node.getType().getSerializedName(), node.uri);
                         } catch (Exception e) {
                             error().logException(e, "Exception reloading search index:");
                         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static com.github.onsdigital.zebedee.content.page.base.PageType.home_page;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.product_page;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.taxonomy_landing_page;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.HOME_PAGE;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.PRODUCT_PAGE;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.TAXONOMY_LANDING_PAGE;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.alreadyMarkedDeleteInCurrentCollectionError;
 import static com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException.deleteForbiddenForPageTypeError;
 import static com.github.onsdigital.zebedee.persistence.CollectionEventType.DELETE_MARKED_ADDED;
@@ -61,7 +61,7 @@ public class ContentDeleteService {
             DELETE_MARKED_REMOVED, EventType.DELETE_MARKER_REMOVED);
 
     private static final ImmutableList<PageType> NON_DELETABLE_PAGE_TYPES =
-            ImmutableList.of(home_page, taxonomy_landing_page, product_page);
+            ImmutableList.of(HOME_PAGE, TAXONOMY_LANDING_PAGE, PRODUCT_PAGE);
 
     public static ContentDeleteService instance = null;
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentDeleteService.java
@@ -84,7 +84,7 @@ public class ContentDeleteService {
         deletes.stream().forEach(delete -> {
             LeafCounter leafCounter = new LeafCounter();
             contentTreeNavigator.applyAndPropagate(delete.getRoot(), (node -> {
-                if (StringUtils.isNotEmpty(node.uri) && node.type != null) {
+                if (StringUtils.isNotEmpty(node.uri) && node.getType() != null) {
                     leafCounter.increment();
                 }
             }));
@@ -189,7 +189,7 @@ public class ContentDeleteService {
         List<String> uris = new ArrayList<>();
         collection.getDescription().getPendingDeletes().forEach(pendingDelete -> {
             contentTreeNavigator.applyAndPropagate(pendingDelete.getRoot(), (node) -> {
-                if (node.type != null && StringUtils.isNotEmpty(node.uri)) {
+                if (node.getType() != null && StringUtils.isNotEmpty(node.uri)) {
                     uris.add(node.uri);
                 }
             });

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
@@ -49,7 +49,7 @@ public class ContentDetailUtil {
                 }
 
                 if (page != null) { //Contents without type is null when deserialised. There should not be no such data
-                    ContentDetail contentDetail = new ContentDetail(page.getDescription().getTitle(), page.getUri().toString(), page.getType().toString());
+                    ContentDetail contentDetail = new ContentDetail(page.getDescription().getTitle(), page.getUri().toString(), page.getType());
                     contentDetail.contentPath = page.getUri().toString();
                     contentDetail.description.edition = page.getDescription().getEdition();
                     contentDetail.description.language = page.getDescription().getLanguage();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
@@ -136,7 +136,7 @@ public class VersionsServiceImpl implements VersionsService {
             Path parent = Paths.get(uri).getParent();
             Page page = reader.getReviewed().getContent(parent.toString());
 
-            if (PageType.dataset.equals(page.getType())) {
+            if (PageType.DATASET.equals(page.getType())) {
                 datasets.add((Dataset) page);
             }
         }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
@@ -168,7 +168,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
 
         // Then
         // we expect it to be a skeleton timeseries
-        assertEquals(PageType.timeseries, initial.getType());
+        assertEquals(PageType.TIMESERIES, initial.getType());
         assertEquals(0, initial.years.size());
         assertEquals(0, initial.months.size());
         assertEquals(0, initial.quarters.size());
@@ -190,7 +190,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
 
         // Then
         // we expect it to be the published timeseries complete with existing data
-        assertEquals(PageType.timeseries, initial.getType());
+        assertEquals(PageType.TIMESERIES, initial.getType());
         assertEquals(republish.timeSeriesList.get(0).getUri(), initial.getUri());
         assertNotEquals(0, initial.years.size());
         assertNotEquals(0, initial.months.size());

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataPublicationDetailsTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataPublicationDetailsTestBaseFixture.java
@@ -90,7 +90,7 @@ public class DataPublicationDetailsTestBaseFixture extends ZebedeeTestBaseFixtur
 
         // Then
         // details landing page should be identified
-        assertEquals(PageType.dataset_landing_page, details.landingPage.getType());
+        assertEquals(PageType.DATASET_LANDING_PAGE, details.landingPage.getType());
         assertEquals(example.datasetLandingPage.getUri().toString(), details.landingPageUri);
     }
 
@@ -110,7 +110,7 @@ public class DataPublicationDetailsTestBaseFixture extends ZebedeeTestBaseFixtur
 
         // Then
         // details landing page should be identified
-        assertEquals(PageType.timeseries_dataset, details.datasetPage.getType());
+        assertEquals(PageType.TIMESERIES_DATASET, details.datasetPage.getType());
         assertEquals(example.timeSeriesDataset.getUri().toString(), details.datasetUri);
     }
 
@@ -153,7 +153,7 @@ public class DataPublicationDetailsTestBaseFixture extends ZebedeeTestBaseFixtur
 
         // Then
         // details landing page should be identified
-        assertEquals(PageType.timeseries_dataset, details.datasetPage.getType());
+        assertEquals(PageType.TIMESERIES_DATASET, details.datasetPage.getType());
         assertEquals(reviewed.timeSeriesDataset.getUri().toString(), details.datasetUri);
 
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/ContentDetailTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/ContentDetailTest.java
@@ -2,6 +2,8 @@ package com.github.onsdigital.zebedee.json;
 
 import org.junit.Test;
 
+import com.github.onsdigital.zebedee.content.page.base.PageType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,13 +15,13 @@ public class ContentDetailTest {
     public void overlayDetailsShouldAddNewItems() {
 
         // Given a content detail instance with a child
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
         detail.children = new ArrayList<>();
         detail.children.add(child);
 
         // When we call the overlayDetails method with a new item
-        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", "bulletin");
+        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", PageType.BULLETIN);
         List<ContentDetail> toOverlay = new ArrayList<>();
         toOverlay.add(descendant);
         detail.overlayDetails(toOverlay);
@@ -32,10 +34,10 @@ public class ContentDetailTest {
     public void overlayDetailsShouldAddNewDirectories() {
 
         // Given a content detail instance
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
 
         // When we call the overlayDetails method with a Content detail instace with new directories to create.
-        ContentDetail descendant = new ContentDetail("descendant content", "/childdir1/childdir2/descendant", "bulletin");
+        ContentDetail descendant = new ContentDetail("descendant content", "/childdir1/childdir2/descendant", PageType.BULLETIN);
         List<ContentDetail> toOverlay = new ArrayList<>();
         toOverlay.add(descendant);
         detail.overlayDetails(toOverlay);
@@ -54,11 +56,11 @@ public class ContentDetailTest {
     public void overlayDetailsShouldIgnoreExistingItems() {
 
         // Given a content detail instance with an existing descendant
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
         detail.children = new ArrayList<>();
         detail.children.add(child);
-        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", "bulletin");
+        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", PageType.BULLETIN);
         child.children = new ArrayList<>();
         child.children.add(descendant);
 
@@ -75,8 +77,8 @@ public class ContentDetailTest {
     public void containsChildShouldReturnTrueIfChildExists() {
 
         // Given a content detail instance with a child
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
         detail.children = new ArrayList<>();
         detail.children.add(child);
 
@@ -91,8 +93,8 @@ public class ContentDetailTest {
     public void containsChildShouldReturnFalseIfChildIsNotFound() {
 
         // Given a content detail instance with a child
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
         detail.children = new ArrayList<>();
 
         // When we call the contains child method with the child instance.
@@ -106,8 +108,8 @@ public class ContentDetailTest {
     public void containsChildShouldReturnFalseIfChildrenIsNull() {
 
         // Given a content detail instance with a child
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
 
         // When we call the contains child method with the child instance.
         boolean containChild = detail.containsChild(child);
@@ -120,9 +122,9 @@ public class ContentDetailTest {
     public void containsDescendantShouldReturnTrueIfFound() {
 
         // Given a content detail instance with a descendant
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
-        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", "bulletin");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
+        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", PageType.BULLETIN);
         detail.children = new ArrayList<>();
         detail.children.add(child);
         child.children = new ArrayList<>();
@@ -140,9 +142,9 @@ public class ContentDetailTest {
     public void containsDescendantShouldReturnFalseIfNotFound() {
 
         // Given a content detail instance without adding a descendant.
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
-        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", "bulletin");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
+        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", PageType.BULLETIN);
         detail.children = new ArrayList<>();
         detail.children.add(child);
         child.children = new ArrayList<>();
@@ -158,15 +160,15 @@ public class ContentDetailTest {
     public void cloneShouldCreateCopyIncludingChildNodes() {
 
         // Given a content detail instance with a child
-        ContentDetail detail = new ContentDetail("base content", "/", "home");
-        ContentDetail child = new ContentDetail("child content", "/child", "article");
+        ContentDetail detail = new ContentDetail("base content", "/", PageType.HOME_PAGE);
+        ContentDetail child = new ContentDetail("child content", "/child", PageType.ARTICLE);
         detail.children = new ArrayList<>();
         detail.children.add(child);
 
         // When we clone it and add an overlay to the clone.
         ContentDetail clone = detail.clone();
 
-        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", "bulletin");
+        ContentDetail descendant = new ContentDetail("descendant content", "/child/descendant", PageType.BULLETIN);
         List<ContentDetail> toOverlay = new ArrayList<>();
         toOverlay.add(descendant);
         clone.overlayDetails(toOverlay);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1309,7 +1309,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.complete(publisher1Session, releaseJsonUri, recursive);
         collection.review(publisher2Session, releaseJsonUri, recursive);
 
-        ContentDetail articleDetail = new ContentDetail("My article", "/some/uri", PageType.article.toString());
+        ContentDetail articleDetail = new ContentDetail("My article", "/some/uri", PageType.ARTICLE.toString());
         FileUtils.write(collection.getReviewed().getPath().resolve("some/uri/data.json").toFile(),
                 Serialiser.serialise(articleDetail));
 
@@ -1719,7 +1719,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         ContentDetail datasetDetail = datasetContent.get(0);
 
         assertEquals("/datasets/123", datasetDetail.uri);
-        assertEquals(PageType.api_dataset_landing_page.toString(), datasetDetail.type);
+        assertEquals(PageType.API_DATASET_LANDING_PAGE.toString(), datasetDetail.type);
         assertEquals(dataset.getTitle(), datasetDetail.description.title);
     }
 
@@ -1743,13 +1743,13 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         // Then the expected values have been set
         ContentDetail versionDetail = datasetContent.get(0);
         assertEquals("/datasets/123/editions/2015/versions/1", versionDetail.uri);
-        assertEquals(PageType.api_dataset.toString(), versionDetail.type);
+        assertEquals(PageType.API_DATASET.toString(), versionDetail.type);
         assertEquals(datasetVersion.getTitle(), versionDetail.description.title);
 
         // Then an entry for the parent dataset is also added
         ContentDetail datasetDetail = datasetContent.get(1);
         assertEquals("/datasets/123", datasetDetail.uri);
-        assertEquals(PageType.api_dataset_landing_page.toString(), datasetDetail.type);
+        assertEquals(PageType.API_DATASET_LANDING_PAGE.toString(), datasetDetail.type);
         assertEquals(datasetVersion.getTitle(), datasetDetail.description.title);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1309,7 +1309,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.complete(publisher1Session, releaseJsonUri, recursive);
         collection.review(publisher2Session, releaseJsonUri, recursive);
 
-        ContentDetail articleDetail = new ContentDetail("My article", "/some/uri", PageType.ARTICLE.toString());
+        ContentDetail articleDetail = new ContentDetail("My article", "/some/uri", PageType.ARTICLE);
         FileUtils.write(collection.getReviewed().getPath().resolve("some/uri/data.json").toFile(),
                 Serialiser.serialise(articleDetail));
 
@@ -1719,7 +1719,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         ContentDetail datasetDetail = datasetContent.get(0);
 
         assertEquals("/datasets/123", datasetDetail.uri);
-        assertEquals(PageType.API_DATASET_LANDING_PAGE.toString(), datasetDetail.type);
+        assertEquals(PageType.API_DATASET_LANDING_PAGE, datasetDetail.getType());
         assertEquals(dataset.getTitle(), datasetDetail.description.title);
     }
 
@@ -1743,13 +1743,13 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         // Then the expected values have been set
         ContentDetail versionDetail = datasetContent.get(0);
         assertEquals("/datasets/123/editions/2015/versions/1", versionDetail.uri);
-        assertEquals(PageType.API_DATASET.toString(), versionDetail.type);
+        assertEquals(PageType.API_DATASET, versionDetail.getType());
         assertEquals(datasetVersion.getTitle(), versionDetail.description.title);
 
         // Then an entry for the parent dataset is also added
         ContentDetail datasetDetail = datasetContent.get(1);
         assertEquals("/datasets/123", datasetDetail.uri);
-        assertEquals(PageType.API_DATASET_LANDING_PAGE.toString(), datasetDetail.type);
+        assertEquals(PageType.API_DATASET_LANDING_PAGE, datasetDetail.getType());
         assertEquals(datasetVersion.getTitle(), datasetDetail.description.title);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ContentTest.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.model;
 
 import com.github.davidcarboni.cryptolite.Random;
 import com.github.davidcarboni.restolino.json.Serialiser;
+import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.json.ContentDetail;
 import com.github.onsdigital.zebedee.json.ContentDetailDescription;
 import org.apache.commons.io.FileUtils;
@@ -57,9 +58,7 @@ public class ContentTest {
         subDirectoryJsonFile = subDirectoryA.resolve(filename);
         Files.createFile(baseJsonFile);
 
-        baseContent = new ContentDetail();
-        baseContent.description = new ContentDetailDescription("Some release 2014");
-        baseContent.type = "home";
+        baseContent = new ContentDetail("Some release 2014", "/", PageType.HOME_PAGE);
 
         // Serialise
         try (OutputStream output = Files.newOutputStream(baseJsonFile)) {
@@ -70,9 +69,7 @@ public class ContentTest {
         Files.createDirectory(subDirectoryA);
         Files.createDirectory(subDirectoryB);
 
-        subContent = new ContentDetail();
-        subContent.description = new ContentDetailDescription("Some sub 2015");
-        subContent.type = "t2";
+        subContent = new ContentDetail("Some sub 2015", "/t2", PageType.DATASET);
 
         // Serialise
         try (OutputStream output = Files.newOutputStream(subDirectoryJsonFile)) {
@@ -91,9 +88,7 @@ public class ContentTest {
         timeseriesDirectory2 = subDirectoryB.resolve(timeseriesDirectoryName);
         Files.createDirectory(timeseriesDirectory2);
 
-        bulletinContent = new ContentDetail();
-        bulletinContent.description = new ContentDetailDescription("Some bulletin 2010");
-        bulletinContent.type = "bulletin";
+        bulletinContent = new ContentDetail("Some bulletin 2010", "/b", PageType.BULLETIN);
 
         // Serialise
         try (OutputStream output = Files.newOutputStream(exampleBulletinJsonFile)) {
@@ -117,7 +112,7 @@ public class ContentTest {
 
         // The result has the expected values
         assertEquals(baseContent.description.title, result.description.title);
-        assertEquals(baseContent.type, result.type);
+        assertEquals(baseContent.getType(), result.getType());
         assertEquals("/", result.uri);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/ApproveTaskTest.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.model.approval;
 
 import com.github.davidcarboni.cryptolite.Random;
+import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.data.processing.DataIndex;
 import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
@@ -95,7 +96,7 @@ public class ApproveTaskTest {
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
         Collection collection = CollectionTest.createCollection(collectionPath, "createPublishNotificationShouldIncludePendingDeletes");
         String uriToDelete = "some/uri/to/check";
-        ContentDetail contentDetail = new ContentDetail("Title", uriToDelete, "type");
+        ContentDetail contentDetail = new ContentDetail("Title", uriToDelete, PageType.DATA_SLICE);
         PendingDelete pendingDelete = new PendingDelete("", contentDetail);
         collection.getDescription().getPendingDeletes().add(pendingDelete);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
@@ -57,7 +57,7 @@ public class CollectionPdfGeneratorTest {
 
         ArrayList<ContentDetail> collectionContent = new ArrayList<>();
         String uri = "/the/uri";
-        collectionContent.add(new ContentDetail("Some article", uri, PageType.ARTICLE.toString()));
+        collectionContent.add(new ContentDetail("Some article", uri, PageType.ARTICLE));
 
         generator.generatePDFsForCollection(collection, mockCollectionWriter, collectionContent);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/approval/task/CollectionPdfGeneratorTest.java
@@ -57,7 +57,7 @@ public class CollectionPdfGeneratorTest {
 
         ArrayList<ContentDetail> collectionContent = new ArrayList<>();
         String uri = "/the/uri";
-        collectionContent.add(new ContentDetail("Some article", uri, PageType.article.toString()));
+        collectionContent.add(new ContentDetail("Some article", uri, PageType.ARTICLE.toString()));
 
         generator.generatePDFsForCollection(collection, mockCollectionWriter, collectionContent);
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/adhoc/AdHoc.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/adhoc/AdHoc.java
@@ -10,7 +10,7 @@ public class AdHoc extends BaseStaticPage {
 
     @Override
     public PageType getType() {
-        return PageType.static_adhoc;
+        return PageType.STATIC_ADHOC;
     }
 
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -9,70 +9,103 @@ import com.google.gson.annotations.SerializedName;
  * @author bren
  */
 public enum PageType {
+
     @SerializedName("home_page")
     HOME_PAGE("Home page"),
+
     @SerializedName("home_page_census")
     HOME_PAGE_CENSUS("Census home page"),
+
     @SerializedName("taxonomy_landing_page")
     TAXONOMY_LANDING_PAGE("Taxonomy landing page"),
+
     @SerializedName("product_page")
     PRODUCT_PAGE("Product page"),
+
     @SerializedName("bulletin")
     BULLETIN("Bulletin"),
+
     @SerializedName("article")
     ARTICLE("Article"),
+
     @SerializedName("article_download")
     ARTICLE_DOWNLOAD("Article download"),
+
     @SerializedName("timeseries_landing_page")
     TIMESERIES_LANDING_PAGE("Timeseries landing page"),
+
     @SerializedName("timeseries")
     TIMESERIES("Timeseries page"),
+
     @SerializedName("data_slice")
     DATA_SLICE("Data slice"),
+
     @SerializedName("compendium_landing_page")
     COMPENDIUM_LANDING_PAGE("Compendium landing page"),
+
     @SerializedName("compendium_chapter")
     COMPENDIUM_CHAPTER("Compendium chapter page"),//Resolve parent
+
     @SerializedName("compendium_data")
     COMPENDIUM_DATA("Compendium data page"),
+
     @SerializedName("static_landing_page")
     STATIC_LANDING_PAGE("Static landing page"),
+
     @SerializedName("static_article")
     STATIC_ARTICLE("Static article"), //With table of contents
+
     @SerializedName("static_methodology")
     STATIC_METHODOLOGY("Static methodology page"),
+
     @SerializedName("static_methodology_download")
     STATIC_METHODOLOGY_DOWNLOAD("Static methodology download page"),
+
     @SerializedName("static_page")
     STATIC_PAGE("Static page"), //Pure markdown
+
     @SerializedName("static_qmi")
     STATIC_QMI("Static QMI page"),
+
     @SerializedName("static_foi")
     STATIC_FOI("Static FOI page"),
+
     @SerializedName("static_adhoc")
     STATIC_ADHOC("Static adhoc page"),
+
     @SerializedName("dataset")
     DATASET("Dataset page"),
+
     @SerializedName("dataset_landing_page")
     DATASET_LANDING_PAGE("Dataset landing page"),
+
     @SerializedName("api_dataset_landing_page")
     API_DATASET_LANDING_PAGE("API Dataset landing page"),
+
     @SerializedName("api_dataset")
     API_DATASET("API Dataset"),
+
     @SerializedName("timeseries_dataset")
     TIMESERIES_DATASET("Timeseries dataset page"),
+
     @SerializedName("release")
     RELEASE("Release page"),
+
     @SerializedName("reference_tables")
     REFERENCE_TABLES("Reference tables"),
+
     @SerializedName("chart")
     CHART("Chart page"),
+
     @SerializedName("table")
     TABLE("Table page"),
+
     @SerializedName("image")
     IMAGE("Image page"),
+
     @SerializedName("visualisation")
     VISUALISATION("Visualisation page"),
+
     @SerializedName("equation")
     EQUATION("Equation page");
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -1,14 +1,9 @@
 package com.github.onsdigital.zebedee.content.page.base;
 
-import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 /**
  * Enumerates the different types of pages on the website.
- * <p>
- * Strictly these would be uppercase, but "shouty caps" looks wrong when
- * serialised to Json. There are ways around it, but the simplest solution is to
- * use lowercase - it's not worth the complexity.
  *
  * @author david
  * @author bren
@@ -91,8 +86,11 @@ public enum PageType {
         return displayName;
     }
 
-    public String getSerializedName() {
-        return new Gson().toJson(this);
+    public String getLabel() {
+        try {
+            return PageType.class.getField(this.name()).getAnnotation(SerializedName.class).value();
+        } catch (NoSuchFieldException | SecurityException e) {
+            throw new RuntimeException("error getting page type label", e);
+        }
     }
-
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -1,5 +1,7 @@
 package com.github.onsdigital.zebedee.content.page.base;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Enumerates the different types of pages on the website.
  * <p>
@@ -11,40 +13,72 @@ package com.github.onsdigital.zebedee.content.page.base;
  * @author bren
  */
 public enum PageType {
-
-    home_page("Home page"),
-    home_page_census("Census home page"),
-    taxonomy_landing_page("Taxonomy landing page"),
-    product_page("Product page"),
-    bulletin("Bulletin"),
-    article("Article"),
-    article_download("Article download"),
-    timeseries_landing_page("Timeseries landing page"),
-    timeseries("Timeseries page"),
-    data_slice("Data slice"),
-    compendium_landing_page("Compendium landing page"),
-    compendium_chapter("Compendium chapter page"),//Resolve parent
-    compendium_data("Compendium data page"),
-    static_landing_page("Static landing page"),
-    static_article("Static article"), //With table of contents
-    static_methodology("Static methodology page"),
-    static_methodology_download("Static methodology download page"),
-    static_page("Static page"), //Pure markdown
-    static_qmi("Static QMI page"),
-    static_foi("Static FOI page"),
-    static_adhoc("Static adhoc page"),
-    dataset("Dataset page"),
-    dataset_landing_page("Dataset landing page"),
-    api_dataset_landing_page("API Dataset landing page"),
-    api_dataset("API Dataset"),
-    timeseries_dataset("Timeseries dataset page"),
-    release("Release page"),
-    reference_tables("Reference tables"),
-    chart("Chart page"),
-    table("Table page"),
-    image("Image page"),
-    visualisation("Visualisation page"),
-    equation("Equation page");
+    @SerializedName("home_page")
+    HOME_PAGE("Home page"),
+    @SerializedName("home_page_census")
+    HOME_PAGE_CENSUS("Census home page"),
+    @SerializedName("taxonomy_landing_page")
+    TAXONOMY_LANDING_PAGE("Taxonomy landing page"),
+    @SerializedName("product_page")
+    PRODUCT_PAGE("Product page"),
+    @SerializedName("bulletin")
+    BULLETIN("Bulletin"),
+    @SerializedName("article")
+    ARTICLE("Article"),
+    @SerializedName("article_download")
+    ARTICLE_DOWNLOAD("Article download"),
+    @SerializedName("timeseries_landing_page")
+    TIMESERIES_LANDING_PAGE("Timeseries landing page"),
+    @SerializedName("timeseries")
+    TIMESERIES("Timeseries page"),
+    @SerializedName("data_slice")
+    DATA_SLICE("Data slice"),
+    @SerializedName("compendium_landing_page")
+    COMPENDIUM_LANDING_PAGE("Compendium landing page"),
+    @SerializedName("compendium_chapter")
+    COMPENDIUM_CHAPTER("Compendium chapter page"),//Resolve parent
+    @SerializedName("compendium_data")
+    COMPENDIUM_DATA("Compendium data page"),
+    @SerializedName("static_landing_page")
+    STATIC_LANDING_PAGE("Static landing page"),
+    @SerializedName("static_article")
+    STATIC_ARTICLE("Static article"), //With table of contents
+    @SerializedName("static_methodology")
+    STATIC_METHODOLOGY("Static methodology page"),
+    @SerializedName("static_methodology_download")
+    STATIC_METHODOLOGY_DOWNLOAD("Static methodology download page"),
+    @SerializedName("static_page")
+    STATIC_PAGE("Static page"), //Pure markdown
+    @SerializedName("static_qmi")
+    STATIC_QMI("Static QMI page"),
+    @SerializedName("static_foi")
+    STATIC_FOI("Static FOI page"),
+    @SerializedName("static_adhoc")
+    STATIC_ADHOC("Static adhoc page"),
+    @SerializedName("dataset")
+    DATASET("Dataset page"),
+    @SerializedName("dataset_landing_page")
+    DATASET_LANDING_PAGE("Dataset landing page"),
+    @SerializedName("api_dataset_landing_page")
+    API_DATASET_LANDING_PAGE("API Dataset landing page"),
+    @SerializedName("api_dataset")
+    API_DATASET("API Dataset"),
+    @SerializedName("timeseries_dataset")
+    TIMESERIES_DATASET("Timeseries dataset page"),
+    @SerializedName("release")
+    RELEASE("Release page"),
+    @SerializedName("reference_tables")
+    REFERENCE_TABLES("Reference tables"),
+    @SerializedName("chart")
+    CHART("Chart page"),
+    @SerializedName("table")
+    TABLE("Table page"),
+    @SerializedName("image")
+    IMAGE("Image page"),
+    @SerializedName("visualisation")
+    VISUALISATION("Visualisation page"),
+    @SerializedName("equation")
+    EQUATION("Equation page");
 
     private final String displayName;
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.content.page.base;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -89,4 +90,9 @@ public enum PageType {
     public String getDisplayName() {
         return displayName;
     }
+
+    public String getSerializedName() {
+        return new Gson().toJson(this);
+    }
+
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/census/HomePageCensus.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/census/HomePageCensus.java
@@ -17,7 +17,7 @@ public class HomePageCensus extends TaxonomyNode {
 
     @Override
     public PageType getType() {
-        return PageType.home_page_census;
+        return PageType.HOME_PAGE_CENSUS;
     }
 
     public MarkdownSection getIntro() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumChapter.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumChapter.java
@@ -18,7 +18,7 @@ public class CompendiumChapter extends StatisticalDocument {
 
     @Override
     public PageType getType() {
-        return PageType.compendium_chapter;
+        return PageType.COMPENDIUM_CHAPTER;
     }
 
     @Override

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumData.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumData.java
@@ -13,7 +13,7 @@ public class CompendiumData extends DatasetLandingPage {
 
     @Override
     public PageType getType() {
-        return PageType.compendium_data;
+        return PageType.COMPENDIUM_DATA;
     }
 
     public Link getParent() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/compendium/CompendiumLandingPage.java
@@ -22,7 +22,7 @@ public class CompendiumLandingPage extends Page {
 
     @Override
     public PageType getType() {
-        return PageType.compendium_landing_page;
+        return PageType.COMPENDIUM_LANDING_PAGE;
     }
 
     public List<Link> getDatasets() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/home/HomePage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/home/HomePage.java
@@ -30,7 +30,7 @@ public class HomePage extends TaxonomyNode {
 
     @Override
     public PageType getType() {
-        return PageType.home_page;
+        return PageType.HOME_PAGE;
     }
 
     public List<HomeContentItem> getFeaturedContent() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/release/Release.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/release/Release.java
@@ -92,7 +92,7 @@ public class Release extends Page{
 
     @Override
     public PageType getType() {
-        return PageType.release;
+        return PageType.RELEASE;
     }
 
     public List<String> getMarkdown() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/Methodology.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/Methodology.java
@@ -21,6 +21,6 @@ public class Methodology extends StaticArticle {
 
     @Override
     public PageType getType() {
-        return PageType.static_methodology;
+        return PageType.STATIC_METHODOLOGY;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/MethodologyDownload.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/MethodologyDownload.java
@@ -46,6 +46,6 @@ public class MethodologyDownload extends BaseStaticPage {
 
     @Override
     public PageType getType() {
-        return PageType.static_methodology_download;
+        return PageType.STATIC_METHODOLOGY_DOWNLOAD;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticArticle.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticArticle.java
@@ -32,7 +32,7 @@ public class StaticArticle extends Page {
 
     @Override
     public PageType getType() {
-        return PageType.static_article;
+        return PageType.STATIC_ARTICLE;
     }
 
     public List<Link> getRelatedData() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticLandingPage.java
@@ -17,7 +17,7 @@ public class StaticLandingPage extends BaseStaticPage {
 
     @Override
     public PageType getType() {
-        return PageType.static_landing_page;
+        return PageType.STATIC_LANDING_PAGE;
     }
 
     public List<StaticPageSection> getSections() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/StaticPage.java
@@ -53,6 +53,6 @@ public class StaticPage extends BaseStaticPage {
 
     @Override
     public PageType getType() {
-        return PageType.static_page;
+        return PageType.STATIC_PAGE;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/foi/FOI.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/foi/FOI.java
@@ -9,6 +9,6 @@ import com.github.onsdigital.zebedee.content.page.staticpage.base.BaseStaticPage
 public class FOI extends BaseStaticPage {
     @Override
     public PageType getType() {
-        return PageType.static_foi;
+        return PageType.STATIC_FOI;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/qmi/QMI.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/staticpage/qmi/QMI.java
@@ -16,7 +16,7 @@ public class QMI extends BaseStaticPage {
 
     @Override
     public PageType getType() {
-        return PageType.static_qmi;
+        return PageType.STATIC_QMI;
     }
 
     public List<Link> getRelatedDocuments() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/data/DataSlice.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/data/DataSlice.java
@@ -10,7 +10,7 @@ public class DataSlice extends StatisticalData {
 
     @Override
     public PageType getType() {
-        return PageType.data_slice;
+        return PageType.DATA_SLICE;
     }
 
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/data/timeseries/TimeSeries.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/data/timeseries/TimeSeries.java
@@ -132,7 +132,7 @@ public class TimeSeries extends StatisticalData implements Comparable<TimeSeries
 
     @Override
     public PageType getType() {
-        return PageType.timeseries;
+        return PageType.TIMESERIES;
     }
 
     public String getCdid() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ApiDatasetLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ApiDatasetLandingPage.java
@@ -9,7 +9,7 @@ public class ApiDatasetLandingPage extends Statistics {
 
     @Override
     public PageType getType() {
-        return PageType.api_dataset_landing_page;
+        return PageType.API_DATASET_LANDING_PAGE;
     }
 
     public String getapiDatasetId() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/Dataset.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/Dataset.java
@@ -16,7 +16,7 @@ public class Dataset extends Page {
 
     @Override
     public PageType getType() {
-        return PageType.dataset;
+        return PageType.DATASET;
     }
 
     public List<DownloadSection> getDownloads() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DatasetLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DatasetLandingPage.java
@@ -27,7 +27,7 @@ public class DatasetLandingPage extends Statistics {
 
     @Override
     public PageType getType() {
-        return PageType.dataset_landing_page;
+        return PageType.DATASET_LANDING_PAGE;
     }
 
     public List<DownloadSection> getDownloads() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ReferenceTables.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/ReferenceTables.java
@@ -11,7 +11,7 @@ public class ReferenceTables extends DatasetLandingPage {
 
     @Override
     public PageType getType() {
-        return PageType.reference_tables;
+        return PageType.REFERENCE_TABLES;
     }
 
     public boolean isMigrated() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/TimeSeriesDataset.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/TimeSeriesDataset.java
@@ -9,6 +9,6 @@ public class TimeSeriesDataset extends Dataset {
 
     @Override
     public PageType getType() {
-        return PageType.timeseries_dataset;
+        return PageType.TIMESERIES_DATASET;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/Article.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/Article.java
@@ -37,7 +37,7 @@ public class Article extends StatisticalDocument {
 
     @Override
     public PageType getType() {
-        return PageType.article;
+        return PageType.ARTICLE;
     }
 
     public void setRelatedArticles(List<Link> relatedArticles) {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/ArticleDownload.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/article/ArticleDownload.java
@@ -96,6 +96,6 @@ public class ArticleDownload extends Statistics {
 
     @Override
     public PageType getType() {
-        return PageType.article_download;
+        return PageType.ARTICLE_DOWNLOAD;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/bulletin/Bulletin.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/bulletin/Bulletin.java
@@ -27,7 +27,7 @@ public class Bulletin extends StatisticalDocument {
 
     @Override
     public PageType getType() {
-        return PageType.bulletin;
+        return PageType.BULLETIN;
     }
 
     public List<Link> getRelatedBulletins() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/chart/Chart.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/chart/Chart.java
@@ -68,7 +68,7 @@ public class Chart extends FigureBase {
 
     @Override
     public PageType getType() {
-        return PageType.chart;
+        return PageType.CHART;
     }
 
     public String getSubtitle() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/equation/Equation.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/equation/Equation.java
@@ -26,6 +26,6 @@ public class Equation extends FigureBase {
 
     @Override
     public PageType getType() {
-        return PageType.equation;
+        return PageType.EQUATION;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/image/Image.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/image/Image.java
@@ -53,6 +53,6 @@ public class Image extends FigureBase {
 
     @Override
     public PageType getType() {
-        return PageType.image;
+        return PageType.IMAGE;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/table/Table.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/document/figure/table/Table.java
@@ -13,7 +13,7 @@ public class Table extends FigureBase {
 
     @Override
     public PageType getType() {
-        return PageType.table;
+        return PageType.TABLE;
     }
 
     public String getHtml() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/taxonomy/ProductPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/taxonomy/ProductPage.java
@@ -23,7 +23,7 @@ public class ProductPage extends TaxonomyNode {
 
     @Override
     public PageType getType() {
-        return PageType.product_page;
+        return PageType.PRODUCT_PAGE;
     }
 
     public List<Link> getItems() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/taxonomy/TaxonomyLandingPage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/taxonomy/TaxonomyLandingPage.java
@@ -20,7 +20,7 @@ public class TaxonomyLandingPage extends TaxonomyNode {
 
     @Override
     public PageType getType() {
-        return PageType.taxonomy_landing_page;
+        return PageType.TAXONOMY_LANDING_PAGE;
     }
 
     public List<Link> getSections() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/visualisation/Visualisation.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/visualisation/Visualisation.java
@@ -58,6 +58,6 @@ public class Visualisation extends Page {
 
     @Override
     public PageType getType() {
-        return PageType.visualisation;
+        return PageType.VISUALISATION;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/partial/AlertType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/partial/AlertType.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 public enum AlertType {
     @SerializedName("alert")
     ALERT,
+
     @SerializedName("correction")
-    CORRECTION
+    CORRECTION;
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/partial/AlertType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/partial/AlertType.java
@@ -1,6 +1,10 @@
 package com.github.onsdigital.zebedee.content.partial;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum AlertType {
-    alert,
-    correction,
+    @SerializedName("alert")
+    ALERT,
+    @SerializedName("correction")
+    CORRECTION
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
@@ -55,7 +55,7 @@ class PageTypeResolver implements JsonDeserializer<Page> {
         String type = jsonType.getAsString();
 
         try {
-            PageType contentType = PageType.valueOf(type);
+            PageType contentType = PageType.valueOf(type.toUpperCase());
 
             // FIXME CMD feature
             if (!datasetImportEnabled && isDatasetImportPageType.test(contentType)) {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.content.util;
 import com.github.onsdigital.zebedee.content.page.base.Page;
 import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration;
+import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -23,7 +24,6 @@ import java.util.stream.Collectors;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.error;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.info;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.warn;
-import static com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration.get;
 
 /**
  * Created by bren on 09/06/15.
@@ -35,7 +35,6 @@ class PageTypeResolver implements JsonDeserializer<Page> {
     private static PageTypeResolver instance = null;
 
     private boolean datasetImportEnabled;
-    private Set<PageType> datasetImportPageTypes;
     private Predicate<PageType> isDatasetImportPageType;
 
     private PageTypeResolver(boolean datasetImportEnabled, Predicate<PageType> isDatasetImportPageType) {
@@ -52,10 +51,8 @@ class PageTypeResolver implements JsonDeserializer<Page> {
             return null;
         }
 
-        String type = jsonType.getAsString();
-
         try {
-            PageType contentType = PageType.valueOf(type.toUpperCase());
+            PageType contentType = new Gson().fromJson(jsonType, PageType.class);
 
             // FIXME CMD feature
             if (!datasetImportEnabled && isDatasetImportPageType.test(contentType)) {
@@ -66,7 +63,7 @@ class PageTypeResolver implements JsonDeserializer<Page> {
 
             Class<Page> pageClass = contentClasses.get(contentType);
             if (pageClass == null) {
-                throw new RuntimeException("Could find content object for " + type);
+                throw new RuntimeException("Could find content object for " + jsonType.getAsString());
             }
             Page content = context.deserialize(json, pageClass);
             return content;

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandler.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/ReadRequestHandler.java
@@ -226,7 +226,7 @@ public class ReadRequestHandler {
         Collection<ContentNode> nodeList = nodes.values();
         for (Iterator<ContentNode> iterator = nodeList.iterator(); iterator.hasNext(); ) {
             ContentNode next = iterator.next();
-            if (PageType.taxonomy_landing_page.equals(next.getType()) == false) {
+            if (PageType.TAXONOMY_LANDING_PAGE.equals(next.getType()) == false) {
                 continue;
             }
             next.setChildren(getTaxonomy(collectionId, sessionId, next.getUri().toString(), depth));

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/ResolveDatasets.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/api/endpoint/ResolveDatasets.java
@@ -100,7 +100,7 @@ public class ResolveDatasets {
         Content c = handler.findContent(request, extractFilter(request));
 
         Page p = (Page) c;
-        if (p.getType() != PageType.product_page) {
+        if (p.getType() != PageType.PRODUCT_PAGE) {
             throw new BadRequestException("invalid page type for getDatasetSummaries datasets");
         }
         return (ProductPage) p;

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/configuration/ReaderConfiguration.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/configuration/ReaderConfiguration.java
@@ -8,8 +8,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.github.onsdigital.zebedee.content.page.base.PageType.api_dataset;
-import static com.github.onsdigital.zebedee.content.page.base.PageType.api_dataset_landing_page;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.API_DATASET;
+import static com.github.onsdigital.zebedee.content.page.base.PageType.API_DATASET_LANDING_PAGE;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.error;
 import static com.github.onsdigital.zebedee.logging.ReaderLogger.info;
 import static com.github.onsdigital.zebedee.util.VariableUtils.getVariableValue;
@@ -129,7 +129,7 @@ public class ReaderConfiguration {
             this.serviceAuthToken = validateCMDConfig(SERVICE_AUTH_TOKEN_KEY);
             this.datasetAPIHost = validateCMDConfig(DATASET_API_URL_KEY);
             this.datasetAPIAuthToken = validateCMDConfig(DATASET_API_AUTH_TOKEN_KEY);
-            this.datasetImportPageTypes = new HashSet<>(Arrays.asList(api_dataset, api_dataset_landing_page));
+            this.datasetImportPageTypes = new HashSet<>(Arrays.asList(API_DATASET, API_DATASET_LANDING_PAGE));
             info().data(ENABLE_DATASET_IMPORT, true).log("CMD feature flag enabled for zebedee reader");
         } else {
             this.serviceAuthToken = "";

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderResponseResponseUtils.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderResponseResponseUtils.java
@@ -33,7 +33,7 @@ public class ReaderResponseResponseUtils {
 
         if (content instanceof Page) {
             Page page = (Page) content;
-            response.setHeader("ONS-Page-Type", page.getType().toString());
+            response.setHeader("ONS-Page-Type", page.getType().getSerializedName());
         }
 
         IOUtils.copy(new StringReader(ContentUtil.serialise(content)), response.getOutputStream());

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderResponseResponseUtils.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderResponseResponseUtils.java
@@ -33,7 +33,7 @@ public class ReaderResponseResponseUtils {
 
         if (content instanceof Page) {
             Page page = (Page) content;
-            response.setHeader("ONS-Page-Type", page.getType().getSerializedName());
+            response.setHeader("ONS-Page-Type", page.getType().getLabel());
         }
 
         IOUtils.copy(new StringReader(ContentUtil.serialise(content)), response.getOutputStream());

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -284,7 +284,7 @@ public class Indexer {
 
     private void indexSingleContent(String indexName, Page page) throws IOException {
         List<String> terms = resolveSearchTerms(page.getUri().toString());
-        searchUtils.createDocument(indexName, page.getType().getSerializedName(), page.getUri().toString(), serialise(toSearchDocument(page, terms)));
+        searchUtils.createDocument(indexName, page.getType().getLabel(), page.getUri().toString(), serialise(toSearchDocument(page, terms)));
     }
 
     private SearchDocument toSearchDocument(Page page, List<String> searchTerms) {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -284,7 +284,7 @@ public class Indexer {
 
     private void indexSingleContent(String indexName, Page page) throws IOException {
         List<String> terms = resolveSearchTerms(page.getUri().toString());
-        searchUtils.createDocument(indexName, page.getType().toString(), page.getUri().toString(), serialise(toSearchDocument(page, terms)));
+        searchUtils.createDocument(indexName, page.getType().getSerializedName(), page.getUri().toString(), serialise(toSearchDocument(page, terms)));
     }
 
     private SearchDocument toSearchDocument(Page page, List<String> searchTerms) {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -186,7 +186,7 @@ public class Indexer {
                 //TODO: optimize resolving latest flag, only update elastic search for existing releases rather than reindexing
                 //Load old releases as well to get latest flag re-calculated
                 index(getSearchAlias(), new FileScanner().scan(URIUtils.removeLastSegment(uri)));
-            } else if (page.getType() == PageType.timeseries) {
+            } else if (page.getType() == PageType.TIMESERIES) {
                 index(getSearchAlias(), new FileScanner().scan(uri));
             } else {
                 indexSingleContent(getSearchAlias(), page);
@@ -351,9 +351,9 @@ public class Indexer {
 
     private boolean isPeriodic(PageType type) {
         switch (type) {
-            case bulletin:
-            case article:
-            case compendium_landing_page:
+            case BULLETIN:
+            case ARTICLE:
+            case COMPENDIUM_LANDING_PAGE:
                 return true;
             default:
                 return false;

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/CollectionReaderTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/CollectionReaderTest.java
@@ -49,7 +49,7 @@ public class CollectionReaderTest {
     public void testGetAvailableContent() throws ZebedeeException, IOException {
         Page content = collectionReader.getContent("employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/articles/labourdisputes/2015-07-16");
         assertNotNull(content);
-        assertEquals(content.getType(), PageType.article);
+        assertEquals(content.getType(), PageType.ARTICLE);
         assertTrue(content instanceof Article);
     }
 
@@ -59,7 +59,7 @@ public class CollectionReaderTest {
         collectionReader.setLanguage(ContentLanguage.cy);
         Page content = collectionReader.getContent("employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/articles/labourdisputes/2015-07-16");
         assertNotNull(content);
-        assertEquals(content.getType(), PageType.article);
+        assertEquals(content.getType(), PageType.ARTICLE);
         assertTrue(content instanceof Article);
         assertEquals("prif bwyntiau", content.getDescription().getTitle());
     }
@@ -69,7 +69,7 @@ public class CollectionReaderTest {
         collectionReader.setLanguage(ContentLanguage.cy);
         Page content = collectionReader.getContent("employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02/");
         assertNotNull(content);
-        assertEquals(content.getType(), PageType.dataset_landing_page);
+        assertEquals(content.getType(), PageType.DATASET_LANDING_PAGE);
         assertTrue(content instanceof DatasetLandingPage);
     }
 
@@ -135,7 +135,7 @@ public class CollectionReaderTest {
         assertTrue(children.size() == 1);
         Map.Entry<URI, ContentNode> contentNode = children.entrySet().iterator().next();
         assertEquals("Labour disputes by sector: LABD02", contentNode.getValue().getDescription().getTitle());
-        assertEquals(PageType.dataset_landing_page, contentNode.getValue().getType());//type is null for directories with no data.json
+        assertEquals(PageType.DATASET_LANDING_PAGE, contentNode.getValue().getType());//type is null for directories with no data.json
         assertEquals("/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02", contentNode.getKey().toString());
     }
 

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ContentReaderTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ContentReaderTest.java
@@ -59,7 +59,7 @@ public class ContentReaderTest {
     public void testGetAvailableContent() throws ZebedeeException, IOException {
         Page content = contentReader.getContent("about/accessibility");
         assertNotNull(content);
-        assertEquals(content.getType(), PageType.static_page);
+        assertEquals(content.getType(), PageType.STATIC_PAGE);
         assertEquals("Accessibility", content.getDescription().getTitle());
         assertTrue(content instanceof StaticPage);
         StaticPage staticPage = (StaticPage) content;
@@ -70,7 +70,7 @@ public class ContentReaderTest {
     public void testGetHome() throws ZebedeeException, IOException {
         Page content = contentReader.getContent("/");
         assertNotNull(content);
-        assertEquals(content.getType(), PageType.home_page);
+        assertEquals(content.getType(), PageType.HOME_PAGE);
         assertEquals("Home", content.getDescription().getTitle());
     }
 

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ZebedeeReaderTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ZebedeeReaderTest.java
@@ -136,7 +136,7 @@ public class ZebedeeReaderTest {
         assertNotNull(content);
         assertTrue(content instanceof Page);
         Page page = (Page) content;
-        assertEquals(page.getType(), PageType.article);
+        assertEquals(page.getType(), PageType.ARTICLE);
         assertTrue(content instanceof Article);
     }
 
@@ -181,7 +181,7 @@ public class ZebedeeReaderTest {
         Content content = readPublishedContent(path);
         assertTrue(content instanceof Page);
         Page page = (Page) content;
-        assertEquals(page.getType(), PageType.static_page);
+        assertEquals(page.getType(), PageType.STATIC_PAGE);
         assertEquals("Accessibility", page.getDescription().getTitle());
         assertTrue(page instanceof StaticPage);
         StaticPage staticPage = (StaticPage) content;


### PR DESCRIPTION
### What

Enums values are not currently following naming convention: they should be uppercase characters separated by underscores. Presumably this is so that it serialises to the value we expect (lowercase). 

Rename the enum values to follow conventions and add the `@SerializedName` annotation so that they serialise to the required (lowercase) string.

Also took the opportunity to make `ContentDetail` use a `PageType` enum rather than its string representation. This makes the class more robust by only accepting valid types and helps ensuring this is not a breaking change. 

### How to review

Check changes make sense. 
Test creating/reading content still works (check page type and alert types)
Test elastic search interaction still works

### Who can review

Anyone
