### PR TITLE
fixed URI builder in pooled http client

### DIFF
--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/verification/http/PooledHttpClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/verification/http/PooledHttpClient.java
@@ -164,7 +164,8 @@ public class PooledHttpClient {
 
     private URIBuilder newUriBuilder(String path) {
         URIBuilder uriBuilder = new URIBuilder(HOST);
-        uriBuilder.setPath((uriBuilder.getPath() + "/" + path).replaceAll("//+", "/"));
+        String uri = StringUtils.defaultIfEmpty(uriBuilder.getPath(), "");
+        uriBuilder.setPath((uri + "/" + path).replaceAll("//+", "/"));
         return uriBuilder;
     }
 


### PR DESCRIPTION
### Fix mathjax equation request builder.

We recently upgraded our version of `org.apache.httpcomponents.httpclient` from `4.5.1` to `4.5.13`. The default `URIBuilder.path` value in the old version returned `""` whereas the latest version returns `null`. This results in the `PooledHttpClient.uriBuilder` building requests with an incorrect URI:

After upgrading the URI builder is returning:
```
http://{host}:{port}/null/
```
instead of 
```
http://{host}:{port}/
```
Which results in a request to an invalid/unknown endpoint in our Mathjax server. I've updated our code to default a `null` path  value to `""` instead of null to maintain the original functionality.