### PR TITLE
Fix deletion of homepage from collection

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
@@ -291,12 +291,7 @@ public class Page {
         }
 
         try {
-            String uriToDelete = uri;
-            // Remove trailing slashes
-            while (uriToDelete.endsWith("/")) {
-                uriToDelete = uriToDelete.substring(0, uriToDelete.length() - 1);
-            }
-            uriToDelete += zebedeeFileSuffix;
+            String uriToDelete = uri.replaceAll("/+$","") + zebedeeFileSuffix;
 
             zebedeeCmsService.getZebedee().getCollections().deleteContent(
                     collection,

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Page.java
@@ -291,9 +291,16 @@ public class Page {
         }
 
         try {
+            String uriToDelete = uri;
+            // Remove trailing slashes
+            while (uriToDelete.endsWith("/")) {
+                uriToDelete = uriToDelete.substring(0, uriToDelete.length() - 1);
+            }
+            uriToDelete += zebedeeFileSuffix;
+
             zebedeeCmsService.getZebedee().getCollections().deleteContent(
                     collection,
-                    uri + zebedeeFileSuffix,
+                    uriToDelete,
                     session);
         } catch (IOException e) {
             error().data("collection_id", collection.getDescription().getId())

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -765,7 +765,7 @@ public class Collections {
                     "This URI cannot be found in the collection");
         }
 
-        boolean deleted = deletcContentFromCollection(collection, session, contentTargetPath, uri);
+        boolean deleted = deleteContentFromCollection(collection, session, contentTargetPath, uri);
         collection.save();
 
         if (deleted) {
@@ -776,9 +776,8 @@ public class Collections {
         return deleted;
     }
 
-    boolean deletcContentFromCollection(Collection collection, Session session, Path contentTargetPath, String uri) throws IOException {
+    boolean deleteContentFromCollection(Collection collection, Session session, Path contentTargetPath, String uri) throws IOException {
         boolean deleted;
-        Path uriPath = Paths.get(uri);
 
         CMSLogEvent event = info().collectionID(collection).uri(contentTargetPath);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PageTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PageTest.java
@@ -49,7 +49,7 @@ public class PageTest extends ZebedeeAPIBaseTestCase {
             mock(com.github.onsdigital.zebedee.model.Collection.class);
     private final CollectionReader collectionReader = mock(CollectionReader.class);
 
-    private static final String uri = "/";
+    private static final String uri = "/releases/adoption";
     private static final ApiDatasetLandingPage page = new ApiDatasetLandingPage();
     private static final byte[] serialisedPageBytes = ContentUtil.serialise(page).getBytes();
 
@@ -247,7 +247,51 @@ public class PageTest extends ZebedeeAPIBaseTestCase {
         assertTrue(pageDeletionHook.wasOnPageUpdatedCalled());
 
         // Then collections.createContent is called
-        verify(collections, times(1)).deleteContent(any(), any(), any());
+        verify(collections, times(1)).deleteContent(collection, uri + "/data.json", mockSession);
+        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_NO_CONTENT);
+    }
+    
+    @Test
+    public void testPage_deletePage_home() throws ZebedeeException, IOException {
+
+        // Given a page instance with mock dependencies
+        when(mockRequest.getParameter("uri")).thenReturn("/");
+        when(collectionReader.getContent(uri)).thenReturn(page);
+        when(zebedeeCmsService.getSession()).thenReturn(mockSession);
+        when(zebedeeCmsService.getCollection(mockRequest)).thenReturn(collection);
+
+        Page page = new Page(zebedeeCmsService, pageCreationHook, pageDeletionHook);
+
+        // When delete is called
+        page.deletePage(mockRequest, mockResponse);
+
+        // Then the page update hook is called
+        assertTrue(pageDeletionHook.wasOnPageUpdatedCalled());
+
+        // Then collections.createContent is called
+        verify(collections, times(1)).deleteContent(collection, "/data.json", mockSession);
+        verify(mockResponse, times(1)).setStatus(HttpStatus.SC_NO_CONTENT);
+    }
+    
+    @Test
+    public void testPage_deletePage_trailingSlashes() throws ZebedeeException, IOException {
+
+        // Given a page instance with mock dependencies
+        when(mockRequest.getParameter("uri")).thenReturn(uri+"///");
+        when(collectionReader.getContent(uri)).thenReturn(page);
+        when(zebedeeCmsService.getSession()).thenReturn(mockSession);
+        when(zebedeeCmsService.getCollection(mockRequest)).thenReturn(collection);
+
+        Page page = new Page(zebedeeCmsService, pageCreationHook, pageDeletionHook);
+
+        // When delete is called
+        page.deletePage(mockRequest, mockResponse);
+
+        // Then the page update hook is called
+        assertTrue(pageDeletionHook.wasOnPageUpdatedCalled());
+
+        // Then collections.createContent is called
+        verify(collections, times(1)).deleteContent(collection, uri + "/data.json", mockSession);
         verify(mockResponse, times(1)).setStatus(HttpStatus.SC_NO_CONTENT);
     }
 


### PR DESCRIPTION
### What

Fix issue when trying to delete homepages from a collection.  The uri to delete becomes `//data.json` which can't be found and the deletion fails. Fixing it by removing all trailing forward slashes from the received uri.

https://trello.com/c/f9XbZerw/374-cant-delete-homepage-from-collection-s2

### How to review

Check code and unit test.
Run florence, create a collection, edit the the homepage, save and delete it. It should disappear from the collection (and the filesystem) even when you go to another collection and come back to it.

### Who can review

Anyone
