### PR TITLE
Fix content indexing

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -275,7 +275,7 @@ public class Indexer {
     private IndexRequestBuilder prepareIndexRequest(String indexName, Document document) throws ZebedeeException, IOException {
         Page page = getPage(document.getUri());
         if (page != null && page.getType() != null) {
-            IndexRequestBuilder indexRequestBuilder = searchUtils.prepareIndex(indexName, page.getType().name(), page.getUri().toString());
+            IndexRequestBuilder indexRequestBuilder = searchUtils.prepareIndex(indexName, page.getType().getLabel(), page.getUri().toString());
             indexRequestBuilder.setSource(serialise(toSearchDocument(page, document.getSearchTerms())));
             return indexRequestBuilder;
         }


### PR DESCRIPTION
### What

As a result of https://github.com/ONSdigital/zebedee/pull/573, elastic search is now using the wrong indexes.
It should be using the label (serialised value) of the type rather than the enum name. All other instances were updated but this was missed 

https://trello.com/c/0NdPJkkW/782-zebedee-search-mapping-not-matching-elastic-search-templates


### How to review

Check the code makes sense

### Who can review

Anyone
