### PR TITLE
Move populateQuietly to Collection object

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -453,7 +453,7 @@ public class Collection {
         return this.description;
     }
 
-    public Release populateRelease(CollectionReader reader, CollectionWriter collectionWriter, Iterable<ContentDetail> collectionContent) throws IOException, ZebedeeException {
+    private Release populateRelease(CollectionReader reader, CollectionWriter collectionWriter, Iterable<ContentDetail> collectionContent) throws IOException, ZebedeeException {
 
         if (StringUtils.isEmpty(this.getDescription().getReleaseUri())) {
             throw new BadRequestException("This collection is not associated with a release.");
@@ -466,16 +466,27 @@ public class Collection {
         ) {
             Release release = (Release) ContentUtil.deserialiseContent(dataStream);
             if (release == null) {
-                throw new BadRequestException("This collection is not associated with a release.");
+                throw new BadRequestException("Couldn't read release content: " + uri);
             }
             info().data("collectionId", this.getDescription().getId()).data("title", release.getDescription().getTitle())
-                    .log("Release identified for collection");
+                    .log("Release identified for collection, populating the page links");
 
             release = ReleasePopulator.populate(release, collectionContent);
             collectionWriter.getReviewed().writeObject(release, uri);
 
             return release;
         }
+    }
+
+    public Release populateReleaseQuietly(CollectionReader reader, CollectionWriter writer, Iterable<ContentDetail> collectionContent) throws IOException {
+        Release release = null;
+        try {
+            release = populateRelease(reader, writer, collectionContent);
+        } catch (ZebedeeException e) {
+            error().data("collectionId", this.getDescription().getId())
+                    .logException(e, "Failed to populate release page for collection");
+        }
+        return release;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -465,12 +465,11 @@ public class Collection {
                 InputStream dataStream = resource.getData()
         ) {
             Release release = (Release) ContentUtil.deserialiseContent(dataStream);
-            info().data("collectionId", this.getDescription().getId()).data("title", release.getDescription().getTitle())
-                    .log("Release identified for collection");
-
             if (release == null) {
                 throw new BadRequestException("This collection is not associated with a release.");
             }
+            info().data("collectionId", this.getDescription().getId()).data("title", release.getDescription().getTitle())
+                    .log("Release identified for collection");
 
             release = ReleasePopulator.populate(release, collectionContent);
             collectionWriter.getReviewed().writeObject(release, uri);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -290,7 +290,7 @@ public class ApproveTask implements Callable<Boolean> {
 
     public void populateReleasePage(Iterable<ContentDetail> collectionContent) throws IOException {
         // If the collection is associated with a release then populate the release page.
-        ReleasePopulator.populateQuietly(collection, collectionReader, collectionWriter, collectionContent);
+        collection.populateReleaseQuietly(collectionReader, collectionWriter, collectionContent);
     }
 
     public void generatePdfFiles(List<ContentDetail> collectionContent) throws ZebedeeException {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -16,7 +16,6 @@ import com.github.onsdigital.zebedee.logging.CMSLogEvent;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.CollectionWriter;
 import com.github.onsdigital.zebedee.model.approval.tasks.CollectionPdfGenerator;
-import com.github.onsdigital.zebedee.model.approval.tasks.ReleasePopulator;
 import com.github.onsdigital.zebedee.model.approval.tasks.timeseries.TimeSeriesCompressionTask;
 import com.github.onsdigital.zebedee.model.content.CompoundContentReader;
 import com.github.onsdigital.zebedee.model.publishing.PublishNotification;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -115,20 +115,4 @@ public class ReleasePopulator {
         return link;
     }
 
-    public static void populateQuietly(Collection collection,
-                                       CollectionReader collectionReader,
-                                       CollectionWriter collectionWriter,
-                                       Iterable<ContentDetail> collectionContent) throws IOException {
-        if (collection.isRelease()) {
-            info().data("collectionId", collection.getDescription().getId())
-                    .log("Release identified for collection, populating the page links");
-
-            try {
-                collection.populateRelease(collectionReader, collectionWriter, collectionContent);
-            } catch (ZebedeeException e) {
-                error().data("collectionId", collection.getDescription().getId())
-                        .logException(e, "Failed to populate release page for collection");
-            }
-        }
-    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -4,15 +4,11 @@ import com.github.onsdigital.zebedee.content.page.release.Release;
 import com.github.onsdigital.zebedee.content.partial.Link;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ContentDetail;
-import com.github.onsdigital.zebedee.model.Collection;
-import com.github.onsdigital.zebedee.model.CollectionWriter;
-import com.github.onsdigital.zebedee.reader.CollectionReader;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 
 public class ReleasePopulator {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1288,8 +1288,8 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertEquals(URI.create(uri), result.getUri());
     }
 
-    @Test(expected = BadRequestException.class)
-    public void populateReleaseShouldThrowExceptionWhenCollectionNotAssociatedToRelease() throws ZebedeeException, IOException {
+    @Test
+    public void populateReleaseQuietlyShouldReturnNullWhenCollectionNotAssociatedToRelease() throws ZebedeeException, IOException {
         // Given a collection that is NOT associated with a release
         String releaseUri = "";
         collection.getDescription().setReleaseUri(releaseUri);
@@ -1302,14 +1302,17 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
                 collection.getDescription().getId());
         Iterable<ContentDetail> collectionContent = Collections.emptyList();
 
-        collection.populateRelease(
+        Release result = collection.populateReleaseQuietly(
                 collectionReader,
                 collectionWriter,
                 collectionContent);
+
+        // Then the returned release object is null
+        assertNull(result);
     }
 
-    @Test(expected = BadRequestException.class)
-    public void populateReleaseShouldThrowExceptionWhenReleaseJsonInvalid() throws ZebedeeException, IOException {
+    @Test
+    public void populateReleaseQuietlyShouldReturnNullWhenReleaseJsonInvalid() throws ZebedeeException, IOException {
         // Given a collection that is associated with a release and has an article
         String uri = String.format("/releases/%s", Random.id());
         Release release = createRelease(uri, new DateTime().plusWeeks(4).toDate());
@@ -1338,14 +1341,17 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         Iterable<ContentDetail> collectionContent = ContentDetailUtil.resolveDetails(collection.getReviewed(),
                 collectionReader.getReviewed());
 
-        collection.populateRelease(
+        Release result = collection.populateReleaseQuietly(
                 collectionReader,
                 collectionWriter,
                 collectionContent);
+
+        // Then the returned release object is null
+        assertNull(result);
     }
 
     @Test
-    public void populateReleaseShouldAddLinksToReleasePageForCollectionContent() throws ZebedeeException, IOException {
+    public void populateReleaseQuietlyShouldAddLinksToReleasePageForCollectionContent() throws ZebedeeException, IOException {
         // Given a collection that is associated with a release and has an article
         String uri = String.format("/releases/%s", Random.id());
         Release release = createRelease(uri, new DateTime().plusWeeks(4).toDate());
@@ -1376,7 +1382,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         Iterable<ContentDetail> collectionContent = ContentDetailUtil.resolveDetails(collection.getReviewed(),
                 collectionReader.getReviewed());
 
-        Release result = collection.populateRelease(
+        Release result = collection.populateReleaseQuietly(
                 collectionReader,
                 collectionWriter,
                 collectionContent);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -1287,6 +1288,62 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertEquals(URI.create(uri), result.getUri());
     }
 
+    @Test(expected = BadRequestException.class)
+    public void populateReleaseShouldThrowExceptionWhenCollectionNotAssociatedToRelease() throws ZebedeeException, IOException {
+        // Given a collection that is NOT associated with a release
+        String releaseUri = "";
+        collection.getDescription().setReleaseUri(releaseUri);
+
+        // When we attempt to populate the release from the collection.
+
+        FakeCollectionReader collectionReader = new FakeCollectionReader(zebedee.getCollections().getPath().toString(),
+                collection.getDescription().getId());
+        FakeCollectionWriter collectionWriter = new FakeCollectionWriter(zebedee.getCollections().getPath().toString(),
+                collection.getDescription().getId());
+        Iterable<ContentDetail> collectionContent = Collections.emptyList();
+
+        collection.populateRelease(
+                collectionReader,
+                collectionWriter,
+                collectionContent);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void populateReleaseShouldThrowExceptionWhenReleaseJsonInvalid() throws ZebedeeException, IOException {
+        // Given a collection that is associated with a release and has an article
+        String uri = String.format("/releases/%s", Random.id());
+        Release release = createRelease(uri, new DateTime().plusWeeks(4).toDate());
+
+        CollectionDescription description = new CollectionDescription();
+        description.setId(Random.id());
+        description.setName(description.getId());
+
+        collection.getDescription().setReleaseUri(uri);
+        collection.associateWithRelease(publisher1Session, release, collectionWriter);
+
+        String releaseJsonUri = uri + "/data.json";
+
+        collection.complete(publisher1Session, releaseJsonUri, recursive);
+        collection.review(publisher2Session, releaseJsonUri, recursive);
+
+        FileUtils.write(collection.getReviewed().getPath().resolve(releaseJsonUri.substring(1)).toFile(),
+                Serialiser.serialise(new Object()), Charset.defaultCharset());
+
+
+        // When we attempt to populate the release from the collection.
+        FakeCollectionReader collectionReader = new FakeCollectionReader(zebedee.getCollections().getPath().toString(),
+                collection.getDescription().getId());
+        FakeCollectionWriter collectionWriter = new FakeCollectionWriter(zebedee.getCollections().getPath().toString(),
+                collection.getDescription().getId());
+        Iterable<ContentDetail> collectionContent = ContentDetailUtil.resolveDetails(collection.getReviewed(),
+                collectionReader.getReviewed());
+
+        collection.populateRelease(
+                collectionReader,
+                collectionWriter,
+                collectionContent);
+    }
+
     @Test
     public void populateReleaseShouldAddLinksToReleasePageForCollectionContent() throws ZebedeeException, IOException {
         // Given a collection that is associated with a release and has an article
@@ -1307,7 +1364,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
         ContentDetail articleDetail = new ContentDetail("My article", "/some/uri", PageType.ARTICLE);
         FileUtils.write(collection.getReviewed().getPath().resolve("some/uri/data.json").toFile(),
-                Serialiser.serialise(articleDetail));
+                Serialiser.serialise(articleDetail), Charset.defaultCharset());
 
 
         // When we attempt to populate the release from the collection.
@@ -1325,6 +1382,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
                 collectionContent);
 
         // Then the release is now in progress for the collection and the published flag is set to true
+        assertNotNull(result);
         assertEquals(1, result.getRelatedDocuments().size());
         assertEquals("My article", result.getRelatedDocuments().get(0).getTitle());
         assertEquals("/some/uri", result.getRelatedDocuments().get(0).getUri().toString());


### PR DESCRIPTION
### What

- Move the static `populateQuietly` method from `ReleasePopulator` to an instance method in `Collection`
Living unnecessarily in the `ReleasePopulator`, it has now been moved to `Collection`
and made the existing `populate` method private as not used anywhere else.
There is no need to keep both but left the non-quiet version just in case it
could be useful in the future and also to help with code review

- Extend unit tests to cover exceptional cases
- Change use of deprecated `FileUtils.write` method to include Charset

### How to review

Check changes make sense

### Who can review

Anyone
