### PR TITLE
Fix calls to deprecated methods when JWT enabled

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -109,8 +109,11 @@ public class CollectionDetails {
         addEventsForDetails(result.reviewed, collection);
 
         Set<Integer> teamIds = zebedeeCmsService.getPermissions().listViewerTeams(session, collection.getDescription().getId());
-        result.teamsDetails = zebedeeCmsService.getZebedee().getTeamsService().resolveTeamDetails(teamIds);
-        result.teamsDetails.forEach(team -> collection.getDescription().getTeams().add(team.getName()));
+
+        if (!cmsFeatureFlags().isJwtSessionsEnabled()) {
+            result.teamsDetails = zebedeeCmsService.getZebedee().getTeamsService().resolveTeamDetails(teamIds);
+            result.teamsDetails.forEach(team -> collection.getDescription().getTeams().add(team.getName()));
+        }
 
         String collectionId = Collections.getCollectionId(request);
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -63,8 +63,6 @@ public class ZebedeeCollectionReader extends CollectionReader {
 
         checkUserAuthorisedToAccessCollection(zebedee, collection.getDescription().getId(), session);
 
-        User user = getUser(zebedee, session);
-
         SecretKey key = getCollectionKey(zebedee, collection, session);
 
         init(collection, key);
@@ -94,14 +92,6 @@ public class ZebedeeCollectionReader extends CollectionReader {
 
         if (session == null) {
             throw new UnauthorizedException(SESSION_NULL_ERR);
-        }
-    }
-
-    private User getUser(Zebedee zebedee, Session session) throws IOException {
-        try {
-            return zebedee.getUsersService().getUserByEmail(session.getEmail());
-        } catch (Exception ex) {
-            throw new IOException(GET_USER_ERR, ex);
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
@@ -55,8 +55,6 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
 
         checkUserAuthorisedToAccessCollection(zebedee, session);
 
-        User user = getUser(zebedee, session);
-
         SecretKey key = getCollectionKey(zebedee, collection, session);
 
         init(collection, key);
@@ -117,21 +115,6 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
         if (!isAuthorised) {
             throw new UnauthorizedException(PERMISSION_DENIED_ERR);
         }
-    }
-
-    private User getUser(Zebedee zebedee, Session session) throws IOException, NotFoundException, BadRequestException {
-        User user = null;
-        try {
-            user = zebedee.getUsersService().getUserByEmail(session.getEmail());
-        } catch (Exception ex) {
-            throw new IOException(GET_USER_ERR, ex);
-        }
-
-        if (user == null) {
-            throw new IOException(USER_NULL_ERR);
-        }
-
-        return user;
     }
 
     private SecretKey getCollectionKey(Zebedee zebedee, Collection collection, Session session)

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -127,8 +127,6 @@ public abstract class ZebedeeTestBaseFixture {
                 .thenReturn(builder.reviewer1);
         when(usersService.getUserByEmail(builder.administrator.getEmail()))
                 .thenReturn(builder.administrator);
-        when(usersService.list())
-                .thenReturn(usersList);
 
         Session session = new Session("1234", builder.publisher1.getEmail());
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
@@ -366,9 +366,6 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         when(collections.getCollection("1234"))
                 .thenReturn(collection);
 
-        when(usersService.getUserByEmail(TEST_EMAIL))
-                .thenReturn(user);
-
         boolean result = endpoint.deleteCollection(mockRequest, mockResponse);
 
         assertTrue(result);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PermissionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/PermissionTest.java
@@ -64,12 +64,6 @@ public class PermissionTest extends ZebedeeAPIBaseTestCase {
         when(sessionsService.get())
                 .thenReturn(mockSession);
 
-        when(usersService.getUserByEmail(TEST_EMAIL))
-                .thenReturn(srcUser);
-
-        when(usersService.getUserByEmail(USER_EMAIL))
-                .thenReturn(targetUser);
-
         Collections.CollectionList collectionList = new Collections.CollectionList();
         collectionList.add(collectionMock);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
@@ -63,9 +63,6 @@ public class CollectionMoveTest extends ZebedeeTestBaseFixture {
         ReflectionTestUtils.setField(zebedee, "permissionsService", permissionsService);
         ReflectionTestUtils.setField(zebedee, "collectionKeyring", keyring);
 
-        when(usersService.getUserByEmail(builder.publisher1Credentials.getEmail()))
-                .thenReturn(user);
-
         when(permissionsService.canView(session, collection.getDescription().getId()))
                 .thenReturn(true);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -194,8 +194,6 @@ public class CollectionsTest {
                 .thenReturn(encryptionKeyFactory);
         when(zebedeeMock.getCollectionKeyring())
                 .thenReturn(collectionKeyring);
-        when(usersServiceMock.getUserByEmail(anyString()))
-                .thenReturn(testUser);
         when(collectionReaderWriterFactoryMock.getWriter(zebedeeMock, collectionMock, sessionMock))
                 .thenReturn(collectionWriterMock);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
@@ -95,9 +95,6 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
         when(permissionsService.canView(userSession, COLLECTION_ID))
                 .thenReturn(true);
 
-        when(usersService.getUserByEmail(userSession.getEmail()))
-                .thenReturn(builder.publisher1);
-
         when(keyring.get(userSession, collection))
                 .thenReturn(key);
 
@@ -285,18 +282,6 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
                 () -> newReader(zebedeeMock, collection, userSession));
 
         assertThat(ex.getMessage(), equalTo(PERMISSION_DENIED_ERR));
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
-    }
-
-    @Test
-    public void testNew_getUserError_shouldThrowException() throws Exception {
-        when(usersService.getUserByEmail(anyString()))
-                .thenThrow(IOException.class);
-
-        IOException ex = assertThrows(IOException.class,
-                () -> newReader(zebedeeMock, collection, userSession));
-
-        assertThat(ex.getMessage(), equalTo(GET_USER_ERR));
         verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
@@ -90,9 +90,6 @@ public class ZebedeeCollectionWriterTest {
         when(permissionsService.canEdit(session))
                 .thenReturn(true);
 
-        when(usersService.getUserByEmail(EMAIL))
-                .thenReturn(user);
-
         when(collectionKeyring.get(session, collection))
                 .thenReturn(key);
 
@@ -168,32 +165,6 @@ public class ZebedeeCollectionWriterTest {
     }
 
     @Test
-    public void testNew_getUserError_shouldThrowException() throws Exception {
-        when(usersService.getUserByEmail(EMAIL))
-                .thenThrow(IOException.class);
-
-        IOException ex = assertThrows(IOException.class,
-                () -> newCollectionWriter(zebedee, collection, session));
-
-        assertThat(ex.getMessage(), equalTo(GET_USER_ERR));
-        verify(permissionsService, times(1)).canEdit(session);
-        verify(usersService, times(1)).getUserByEmail(EMAIL);
-    }
-
-    @Test
-    public void testNew_getUserReturnsNull_shouldThrowException() throws Exception {
-        when(usersService.getUserByEmail(EMAIL))
-                .thenReturn(null);
-
-        IOException ex = assertThrows(IOException.class,
-                () -> newCollectionWriter(zebedee, collection, session));
-
-        assertThat(ex.getMessage(), equalTo(USER_NULL_ERR));
-        verify(permissionsService, times(1)).canEdit(session);
-        verify(usersService, times(1)).getUserByEmail(EMAIL);
-    }
-
-    @Test
     public void testNew_canEditReturnsError_shouldThrowException() throws Exception {
         when(permissionsService.canEdit(session))
                 .thenThrow(IOException.class);
@@ -214,7 +185,6 @@ public class ZebedeeCollectionWriterTest {
                 () -> newCollectionWriter(zebedee, collection, session));
 
         verify(permissionsService, times(1)).canEdit(session);
-        verify(usersService, times(1)).getUserByEmail(EMAIL);
         verify(collectionKeyring, times(1)).get(session, collection);
     }
 
@@ -228,7 +198,6 @@ public class ZebedeeCollectionWriterTest {
 
         assertThat(ex.getMessage(), equalTo(COLLECTION_KEY_NULL_ERR));
         verify(permissionsService, times(1)).canEdit(session);
-        verify(usersService, times(1)).getUserByEmail(EMAIL);
         verify(collectionKeyring, times(1)).get(session, collection);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/scheduled/RunnableSchedulerTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/scheduled/RunnableSchedulerTest.java
@@ -113,17 +113,18 @@ public class RunnableSchedulerTest {
     public void scheduleShouldTakeMillisecondsIntoAccount() throws InterruptedException, ExecutionException {
         // Given a scheduled task that fails with an exception.
         DummyTask task = new DummyTask();
-        Date scheduled = DateTime.now().plusSeconds(10).withMillisOfSecond(567).toDate();
+        DateTime now = DateTime.now();
+        Date scheduled = now.plusSeconds(10).withMillisOfSecond(567).toDate();
+        long expected = scheduled.getTime() - now.getMillis();
+
         ScheduledFuture<?> future = runnableScheduler.schedule(task, scheduled);
 
         assertNotNull(future);
 
         long delayInMs = future.getDelay(TimeUnit.MILLISECONDS);
-
-        long expected = scheduled.getTime() - DateTime.now().getMillis();
         long timeDiff = delayInMs - expected;
         // check delay in ms is as expected within 500ms tolerance
-        assertTrue(timeDiff >= 0 && timeDiff <= 500);
+        assertTrue(timeDiff <= 500);
     }
 }
 


### PR DESCRIPTION
### What

Fix some previously missed calls to methods that are deprecated and will
be removed with JWT sessions are enabled.

### How to review

Ensure that none of the UsersService or TeamsService methods are called when the JWT sessions are enabled.

### Who can review

!me
