### PR TITLE
Fix setting collection viewer teams (JWT enabled)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <restolino.version>v0.4.2</restolino.version>
         <fasterxml.jackson.version>2.13.0</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
-        <spring.version>5.3.13</spring.version>
+        <spring.version>5.3.19</spring.version>
         <dp.logging.version>v2.0.0-beta</dp.logging.version>
     </properties>
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -441,7 +441,8 @@ public class Collection {
             for (String teamName : teamNames) {
                 Team team = teams.findTeam(teamName);
                 if (team == null) {
-                    throw new NotFoundException("team assigned to collection expected but does not exist");
+                    info().data("team", teamName).log("team assigned to collection expected but does not exist, skipping...");
+                    continue;
                 }
 
                 teamIds.add(team.getId());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -73,6 +73,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import static com.github.onsdigital.zebedee.configuration.CMSFeatureFlags.cmsFeatureFlags;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
@@ -424,24 +425,28 @@ public class Collection {
 
     private static Set<String> setViewerTeams(CollectionDescription desc, Zebedee zebedee, Session session)
             throws IOException, ZebedeeException {
-        Set<String> teamIds = new HashSet<>();
-        List<String> teamNames = desc.getTeams();
+        Set<String> teamIds;
 
-        if (teamNames == null) {
-            teamNames = new ArrayList<>();
-        }
+        if (cmsFeatureFlags().isJwtSessionsEnabled()) {
+            teamIds = new HashSet<>(desc.getTeams());
+        } else {
+            teamIds = new HashSet<>();
+            List<String> teamNames = desc.getTeams();
 
-        // TODO: Remove the following transitional code once Florence is updated to send the team IDs rather than the team names.
-        TeamsService teams = zebedee.getTeamsService();
-        for (String teamName : teamNames) {
-            Team team = teams.findTeam(teamName);
-            if (team == null) {
-                throw new NotFoundException("team assigned to collection expected but does not exist");
+            if (teamNames == null) {
+                teamNames = new ArrayList<>();
             }
 
-            teamIds.add(team.getId());
+            TeamsService teams = zebedee.getTeamsService();
+            for (String teamName : teamNames) {
+                Team team = teams.findTeam(teamName);
+                if (team == null) {
+                    throw new NotFoundException("team assigned to collection expected but does not exist");
+                }
+
+                teamIds.add(team.getId());
+            }
         }
-        // end of transitional code
 
         PermissionsService permissions = zebedee.getPermissionsService();
         permissions.setViewerTeams(session, desc.getId(), teamIds);


### PR DESCRIPTION
### What

A piece of technical debt involving a hack in zebedee that maps the team
names back to team IDs (because Florence is sending the names when it
shouldn't be) is causing creation of collections to fail with a 500 then
409. This is because the logic used to map the name to the ID is no
longer possible with the JWT sessions enabled and group management moved
to the dp-identity-api. Since Florence actually as the team ID to hand
the cleaner solution is to simply have florence provide the team IDs
rather than names in the first place. This change lays the ground work
for that change.

### How to review

Ensure that the team IDs submitted in the teams array will be stored as is when the JWT sessions are enabled, but that the old logic will still function the same way.

### Who can review

!me
