### PR TITLE
Modify collection file schema with new url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -247,6 +247,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <scope>test</scope>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -111,7 +111,7 @@ public class Collections {
 
             return result;
         } catch (IOException e) {
-            error().data("user", session.getEmail()).logException(e,GET_COLLECTIONS_ERROR);
+            error().data("user", session.getEmail()).logException(e, GET_COLLECTIONS_ERROR);
             throw new UnexpectedErrorException(GET_COLLECTIONS_ERROR, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -10,7 +10,6 @@ import com.github.onsdigital.zebedee.model.ZebedeeCollectionReaderFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
-import com.github.onsdigital.zebedee.reader.CollectionReaderFactory;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.reader.api.endpoint.Data;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -52,25 +51,18 @@ public class ContentTest {
     
     @Mock
     private Zebedee mockZebedee;
-
     @Mock
     private Sessions mockSessions;
-
     @Mock
     private Session mockSession;
-
     @Mock
     private CollectionKeyring mockCollectionKeyring;
-    
     @Mock
     private PermissionsService mockPermissionsService;
-
     @Mock
     UsersService mockUsersService;
-
     @Mock
     Notifier mockNotifier;
-    
     Path tempBasePath;
 
     CollectionDescription collectionDescription;
@@ -113,7 +105,7 @@ public class ContentTest {
     }
 
     @Test
-    public void WriteVersionFileV1() throws Exception {
+    public void writeVersionFileV1() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         String collectionId = "aktesting";
         request.setPathInfo("/content/" + collectionId);
@@ -129,61 +121,13 @@ public class ContentTest {
             boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
             Assert.assertTrue(result);
         } catch (Exception e) {
-            Assert.fail(e.getMessage() + e.toString());
-            e.printStackTrace();
-            throw e;
-        }
-
-        byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
-        Assert.assertEquals(expectedContentV1, new String(bytes));
-
-        // read the version content via the content API.
-       MockHttpServletResponse response = new MockHttpServletResponse();
-        MockHttpServletRequest dataRequest = new MockHttpServletRequest();
-        dataRequest.setRequestURI("/data/" + collectionId);
-
-        String dataURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022";
-        dataRequest.addParameter("uri", dataURL);
-
-        ZebedeeCollectionReaderFactory factory = new ZebedeeCollectionReaderFactory(mockZebedee);
-        ZebedeeReader.setCollectionReaderFactory(factory);
-
-        try {
-            Data dataAPI = new Data();
-            dataAPI.read(dataRequest, response);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage() + e.toString());
-            throw e;
-        }
-
-        Assert.assertEquals(200, response.getStatus());
-        JSONAssert.assertEquals(expectedContentV1, response.getContentAsString(), false);
-    }
-
-    @Test
-    public void WriteVersionFileV2() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        String collectionId = "aktesting";
-        request.setPathInfo("/content/" + collectionId);
-        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
-        request.addParameter("uri", datasetURL);
-        request.setContent(getV2RequestContent());
-
-        Path versionFile = createCollectionAndPaths(collectionId);
-
-        try {
-            Content contentApi = new Content();
-            boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
-            Assert.assertTrue(result);
-        } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(e.getMessage() + e.toString());
             throw e;
         }
 
         byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
-        Assert.assertEquals(expectedContentV2, new String(bytes));
+        Assert.assertEquals(EXPECTED_CONTENT_V1, new String(bytes));
 
         // read the version content via the content API.
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -206,7 +150,55 @@ public class ContentTest {
         }
 
         Assert.assertEquals(200, response.getStatus());
-        JSONAssert.assertEquals(expectedContentV2, response.getContentAsString(), false);
+        JSONAssert.assertEquals(EXPECTED_CONTENT_V1, response.getContentAsString(), false);
+    }
+
+    @Test
+    public void writeVersionFileV2() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String collectionId = "aktesting";
+        request.setPathInfo("/content/" + collectionId);
+        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
+        request.addParameter("uri", datasetURL);
+        request.setContent(getV2RequestContent());
+
+        Path versionFile = createCollectionAndPaths(collectionId);
+
+        try {
+            Content contentApi = new Content();
+            boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
+            Assert.assertTrue(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() + e.toString());
+            throw e;
+        }
+
+        byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
+        Assert.assertEquals(EXPECTED_CONTENT_V2, new String(bytes));
+
+        // read the version content via the content API.
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest dataRequest = new MockHttpServletRequest();
+        dataRequest.setRequestURI("/data/" + collectionId);
+
+        String dataURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022";
+        dataRequest.addParameter("uri", dataURL);
+
+        ZebedeeCollectionReaderFactory factory = new ZebedeeCollectionReaderFactory(mockZebedee);
+        ZebedeeReader.setCollectionReaderFactory(factory);
+
+        try {
+            Data dataAPI = new Data();
+            dataAPI.read(dataRequest, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() + e.toString());
+            throw e;
+        }
+
+        Assert.assertEquals(200, response.getStatus());
+        JSONAssert.assertEquals(EXPECTED_CONTENT_V2, response.getContentAsString(), false);
     }
 
     private Path createCollectionAndPaths(String collectionId) throws IOException, ZebedeeException {
@@ -219,10 +211,10 @@ public class ContentTest {
     }
 
     private byte[] getV1RequestContent() {
-        return expectedContentV1.getBytes();
+        return EXPECTED_CONTENT_V1.getBytes();
     }
 
-    private static final String expectedContentV1 =
+    private static final String EXPECTED_CONTENT_V1 =
             "{\"downloads\":" +
                     "[{\"file\":\"ac2be72c.xls\"}]," +
                     "\"type\":\"dataset\"," +
@@ -247,10 +239,10 @@ public class ContentTest {
                     "}";
 
     private byte[] getV2RequestContent() {
-        return expectedContentV2.getBytes();
+        return EXPECTED_CONTENT_V2.getBytes();
     }
 
-    private static final String expectedContentV2 =
+    private static final String EXPECTED_CONTENT_V2 =
             "{\"downloads\":[{\"url\":\"some/path/some/file.csv\",\"version\":\"v2\"}]," +
                     "\"type\":\"dataset\"," +
                     "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022\"," +

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -1,13 +1,17 @@
 package com.github.onsdigital.zebedee.api;
 
 import com.github.onsdigital.zebedee.Zebedee;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
+import com.github.onsdigital.zebedee.model.ZebedeeCollectionReaderFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.reader.CollectionReaderFactory;
+import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.reader.api.endpoint.Data;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
@@ -17,15 +21,18 @@ import com.github.onsdigital.zebedee.util.slack.Notifier;
 import com.github.onsdigital.zebedee.util.versioning.VersionsServiceImpl;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,40 +67,40 @@ public class ContentTest {
     @Mock
     Notifier mockNotifier;
 
-    @Test
-    public void WriteVersionFileV1() throws Exception {
-        Path tempBasePath = Files.createTempDirectory("tempZebedee");
+    @Mock
+    CollectionReaderFactory collectionReaderFactory;
+
+    Path tempBasePath;
+
+    CollectionDescription collectionDescription;
+    private EncryptionKeyFactory encryptionKeyFactory;
+    private SecretKey secretKey;
+    private VersionsServiceImpl versionsService;
+    private com.github.onsdigital.zebedee.model.Content content;
+    private Collections collections;
+
+    @Before
+    public void setUp() throws Exception {
+        tempBasePath = Files.createTempDirectory("tempZebedee");
 
         System.setProperty("ENABLE_DATASET_IMPORT", "false");
         System.setProperty("zebedee_root", tempBasePath.toString());
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        String collectionId = "aktesting";
-        request.setPathInfo("/content/" + collectionId);
-        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
-        request.addParameter("uri", datasetURL);
-        request.setContent(getV1RequestContent());
+        collectionDescription = new CollectionDescription("AK Testing");
+        encryptionKeyFactory = new EncryptionKeyFactoryImpl();
+        secretKey = KeyGenerator.getInstance("AES").generateKey();
+        versionsService = new VersionsServiceImpl();
 
-        CollectionDescription collectionDescription = new CollectionDescription("AK Testing");
-        collectionDescription.setEncrypted(false);
-        EncryptionKeyFactory encryptionKeyFactory = new EncryptionKeyFactoryImpl();
-
-        SecretKey secretKey = KeyGenerator.getInstance("AES").generateKey();
-
-        VersionsServiceImpl versionsService = new VersionsServiceImpl();
-        com.github.onsdigital.zebedee.model.Content content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
-
-        Collections collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
+        content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
+        collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
 
         when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
+        when(mockPermissionsService.canView(any(), any())).thenReturn(true);
 
         when(mockSessions.get()).thenReturn(mockSession);
 
-        when(mockCollections.getPath()).thenReturn(tempBasePath);
-
         when(mockCollectionKeyring.get(any(), any())).thenReturn(secretKey);
 
-        when(mockNotifier.sendCollectionWarning(any(), any(), any())).thenReturn(true);
         when(mockZebedee.getCollections()).thenReturn(collections);
         when(mockZebedee.getSessions()).thenReturn(mockSessions);
         when(mockZebedee.getEncryptionKeyFactory()).thenReturn(encryptionKeyFactory);
@@ -102,16 +109,19 @@ public class ContentTest {
         when(mockZebedee.getCollectionKeyring()).thenReturn(mockCollectionKeyring);
         when(mockZebedee.getSlackNotifier()).thenReturn(mockNotifier);
         Root.zebedee = mockZebedee;
+    }
 
-        Collection.create(collectionDescription, mockZebedee, mockSession);
+    @Test
+    public void WriteVersionFileV1() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String collectionId = "aktesting";
+        request.setPathInfo("/content/" + collectionId);
+        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
+        request.addParameter("uri", datasetURL);
+        request.setContent(getV1RequestContent());
 
-        Path pathToCreate = Paths.get(tempBasePath.toString(), collectionId, "inprogress","peoplepopulationandcommunity", "birthsdeathsandmarriages", "livebirths", "datasets", "babynamesenglandandwalesbabynamesstatisticsboys", "2022");
-        Path datasetPath = Files.createDirectories(pathToCreate);
-        Path versionFile = Paths.get(datasetPath.toString(), "data.json");
-        Files.createFile(versionFile);
+        Path versionFile = createCollectionAndPaths(collectionId);
 
-
-        
         // Create the version content via the content API.
         try {
             Content contentApi = new Content();
@@ -124,17 +134,18 @@ public class ContentTest {
         }
 
         byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
-
         Assert.assertEquals(expectedContentV1, new String(bytes));
 
         // read the version content via the content API.
        MockHttpServletResponse response = new MockHttpServletResponse();
         MockHttpServletRequest dataRequest = new MockHttpServletRequest();
-//        dataRequest.setPathInfo("/data/" + collectionId);
         dataRequest.setRequestURI("/data/" + collectionId);
 
         String dataURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022";
         dataRequest.addParameter("uri", dataURL);
+
+        ZebedeeCollectionReaderFactory factory = new ZebedeeCollectionReaderFactory(mockZebedee);
+        ZebedeeReader.setCollectionReaderFactory(factory);
 
         try {
             Data dataAPI = new Data();
@@ -146,7 +157,64 @@ public class ContentTest {
         }
 
         Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals(expectedContentV1, response.getContentAsString());
+        JSONAssert.assertEquals(expectedContentV1, response.getContentAsString(), false);
+    }
+
+    @Test
+    public void WriteVersionFileV2() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String collectionId = "aktesting";
+        request.setPathInfo("/content/" + collectionId);
+        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
+        request.addParameter("uri", datasetURL);
+        request.setContent(getV2RequestContent());
+
+        Path versionFile = createCollectionAndPaths(collectionId);
+
+        try {
+            Content contentApi = new Content();
+            boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
+            Assert.assertTrue(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() + e.toString());
+            throw e;
+        }
+
+        byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
+        Assert.assertEquals(expectedContentV2, new String(bytes));
+
+        // read the version content via the content API.
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest dataRequest = new MockHttpServletRequest();
+        dataRequest.setRequestURI("/data/" + collectionId);
+
+        String dataURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022";
+        dataRequest.addParameter("uri", dataURL);
+
+        ZebedeeCollectionReaderFactory factory = new ZebedeeCollectionReaderFactory(mockZebedee);
+        ZebedeeReader.setCollectionReaderFactory(factory);
+
+        try {
+            Data dataAPI = new Data();
+            dataAPI.read(dataRequest, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() + e.toString());
+            throw e;
+        }
+
+        Assert.assertEquals(200, response.getStatus());
+        JSONAssert.assertEquals(expectedContentV2, response.getContentAsString(), false);
+    }
+
+    private Path createCollectionAndPaths(String collectionId) throws IOException, ZebedeeException {
+        Collection.create(collectionDescription, mockZebedee, mockSession);
+        Path pathToCreate = Paths.get(tempBasePath.toString(), collectionId, "inprogress","peoplepopulationandcommunity", "birthsdeathsandmarriages", "livebirths", "datasets", "babynamesenglandandwalesbabynamesstatisticsboys", "2022");
+        Path datasetPath = Files.createDirectories(pathToCreate);
+        Path versionFile = Paths.get(datasetPath.toString(), "data.json");
+        Files.createFile(versionFile);
+        return versionFile;
     }
 
     private byte[] getV1RequestContent() {
@@ -155,101 +223,9 @@ public class ContentTest {
 
     private static final String expectedContentV1 =
             "{\"downloads\":" +
-                "[{\"file\":\"ac2be72c.xls\"}]," +
-            "\"type\":\"dataset\"," +
-            "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2014\"," +
-            "\"description\":" +
-                "{\"title\":\"Baby Names Statistics Boys\"," +
-                "\"summary\":\"Ranks and counts for boys' baby names in England and Wales and also by region and month.\"," +
-                "\"keywords\":[\"top,ten,boys,girls,most,popular\"]," +
-                "\"metaDescription\":\"Ranks and counts for boys' baby names in England and Wales and also by region and month.\"," +
-                "\"nationalStatistic\":true," +
-                "\"contact\":{\"email\":\"vsob@ons.gov.uk\",\"name\":\"Elizabeth McLaren\",\"telephone\":\"+44 (0)1329 444110\"}," + "\"releaseDate\":\"2015-08-16T23:00:00.000Z\"," +
-                "\"nextRelease\":\"August - September 16 (provisional date)\"," +
-                "\"edition\":\"2014\"," +
-                "\"datasetId\":\"\"," +
-                "\"unit\":\"\",\"preUnit\":\"\"," +
-                "\"source\":\"\"," +
-                "\"versionLabel\":\"Testing\"}," +
-            "\"versions\":[{\"correctionNotice\":\"\"," +
-                "\"updateDate\":\"2022-05-03T11:31:21.283Z\"," +
-                "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2014/previous/v1\"," +
-                "\"label\":\"Testing\"}]" +
-            "}";
-
-    @Test
-    public void WriteVersionFileV2() throws Exception {
-        Path tempBasePath = Files.createTempDirectory("tempZebedee");
-
-        System.setProperty("ENABLE_DATASET_IMPORT", "false");
-        System.setProperty("zebedee_root", tempBasePath.toString());
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        String collectionId = "aktesting";
-        request.setPathInfo("/content/" + collectionId);
-        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
-        request.addParameter("uri", datasetURL);
-        request.setContent(getV2RequestContent());
-
-        CollectionDescription collectionDescription = new CollectionDescription("AK Testing");
-        collectionDescription.setEncrypted(false);
-        EncryptionKeyFactory encryptionKeyFactory = new EncryptionKeyFactoryImpl();
-
-        SecretKey secretKey = KeyGenerator.getInstance("AES").generateKey();
-
-        VersionsServiceImpl versionsService = new VersionsServiceImpl();
-        com.github.onsdigital.zebedee.model.Content content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
-
-        Collections collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
-
-        when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
-
-        when(mockSessions.get()).thenReturn(mockSession);
-
-        when(mockCollections.getPath()).thenReturn(tempBasePath);
-
-        when(mockCollectionKeyring.get(any(), any())).thenReturn(secretKey);
-
-        when(mockNotifier.sendCollectionWarning(any(), any(), any())).thenReturn(true);
-        when(mockZebedee.getCollections()).thenReturn(collections);
-        when(mockZebedee.getSessions()).thenReturn(mockSessions);
-        when(mockZebedee.getEncryptionKeyFactory()).thenReturn(encryptionKeyFactory);
-        when(mockZebedee.getPermissionsService()).thenReturn(mockPermissionsService);
-        when(mockZebedee.getUsersService()).thenReturn(mockUsersService);
-        when(mockZebedee.getCollectionKeyring()).thenReturn(mockCollectionKeyring);
-        when(mockZebedee.getSlackNotifier()).thenReturn(mockNotifier);
-        Root.zebedee = mockZebedee;
-
-        Collection.create(collectionDescription, mockZebedee, mockSession);
-
-        Path pathToCreate = Paths.get(tempBasePath.toString(), collectionId, "inprogress","peoplepopulationandcommunity", "birthsdeathsandmarriages", "livebirths", "datasets", "babynamesenglandandwalesbabynamesstatisticsboys", "2022");
-        Path datasetPath = Files.createDirectories(pathToCreate);
-        Path versionFile = Paths.get(datasetPath.toString(), "data.json");
-        Files.createFile(versionFile);
-
-        try {
-            Content contentApi = new Content();
-            boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
-            Assert.assertTrue(result);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage() + e.toString());
-            e.printStackTrace();
-            throw e;
-        }
-
-        byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
-
-        Assert.assertEquals(expectedContentV1, new String(bytes));
-    }
-
-    private byte[] getV2RequestContent() {
-        return expectedContentV1.getBytes();
-    }
-
-    private static final String expectedContentV2 =
-            "{\"downloads\":[{\"url\":\"some/path/to/ac2be72c.xls\",\"version\":\"v2\"}]," +
+                    "[{\"file\":\"ac2be72c.xls\"}]," +
                     "\"type\":\"dataset\"," +
-                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2014\"," +
+                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022\"," +
                     "\"description\":" +
                     "{\"title\":\"Baby Names Statistics Boys\"," +
                     "\"summary\":\"Ranks and counts for boys' baby names in England and Wales and also by region and month.\"," +
@@ -258,14 +234,41 @@ public class ContentTest {
                     "\"nationalStatistic\":true," +
                     "\"contact\":{\"email\":\"vsob@ons.gov.uk\",\"name\":\"Elizabeth McLaren\",\"telephone\":\"+44 (0)1329 444110\"}," + "\"releaseDate\":\"2015-08-16T23:00:00.000Z\"," +
                     "\"nextRelease\":\"August - September 16 (provisional date)\"," +
-                    "\"edition\":\"2014\"," +
+                    "\"edition\":\"2022\"," +
                     "\"datasetId\":\"\"," +
                     "\"unit\":\"\",\"preUnit\":\"\"," +
                     "\"source\":\"\"," +
                     "\"versionLabel\":\"Testing\"}," +
                     "\"versions\":[{\"correctionNotice\":\"\"," +
                     "\"updateDate\":\"2022-05-03T11:31:21.283Z\"," +
-                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2014/previous/v1\"," +
+                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/previous/v1\"," +
+                    "\"label\":\"Testing\"}]" +
+                    "}";
+
+    private byte[] getV2RequestContent() {
+        return expectedContentV2.getBytes();
+    }
+
+    private static final String expectedContentV2 =
+            "{\"downloads\":[{\"url\":\"some/path/some/file.csv\",\"version\":\"v2\"}]," +
+                    "\"type\":\"dataset\"," +
+                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022\"," +
+                    "\"description\":" +
+                    "{\"title\":\"Baby Names Statistics Boys\"," +
+                    "\"summary\":\"Ranks and counts for boys' baby names in England and Wales and also by region and month.\"," +
+                    "\"keywords\":[\"top,ten,boys,girls,most,popular\"]," +
+                    "\"metaDescription\":\"Ranks and counts for boys' baby names in England and Wales and also by region and month.\"," +
+                    "\"nationalStatistic\":true," +
+                    "\"contact\":{\"email\":\"vsob@ons.gov.uk\",\"name\":\"Elizabeth McLaren\",\"telephone\":\"+44 (0)1329 444110\"}," + "\"releaseDate\":\"2015-08-16T23:00:00.000Z\"," +
+                    "\"nextRelease\":\"August - September 16 (provisional date)\"," +
+                    "\"edition\":\"2022\"," +
+                    "\"datasetId\":\"\"," +
+                    "\"unit\":\"\",\"preUnit\":\"\"," +
+                    "\"source\":\"\"," +
+                    "\"versionLabel\":\"Testing\"}," +
+                    "\"versions\":[{\"correctionNotice\":\"\"," +
+                    "\"updateDate\":\"2022-05-03T11:31:21.283Z\"," +
+                    "\"uri\":\"/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/previous/v1\"," +
                     "\"label\":\"Testing\"}]" +
                     "}";
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -8,6 +8,7 @@ import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.reader.api.endpoint.Data;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.service.UsersService;
@@ -49,8 +50,7 @@ public class ContentTest {
 
     @Mock
     private CollectionKeyring mockCollectionKeyring;
-
-
+    
     @Mock
     private PermissionsService mockPermissionsService;
 
@@ -110,6 +110,9 @@ public class ContentTest {
         Path versionFile = Paths.get(datasetPath.toString(), "data.json");
         Files.createFile(versionFile);
 
+
+        
+        // Create the version content via the content API.
         try {
             Content contentApi = new Content();
             boolean result = contentApi.saveContent(request, new MockHttpServletResponse());
@@ -123,6 +126,27 @@ public class ContentTest {
         byte[] bytes = IOUtils.toByteArray(EncryptionUtils.encryptionInputStream(versionFile, secretKey));
 
         Assert.assertEquals(expectedContentV1, new String(bytes));
+
+        // read the version content via the content API.
+       MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest dataRequest = new MockHttpServletRequest();
+//        dataRequest.setPathInfo("/data/" + collectionId);
+        dataRequest.setRequestURI("/data/" + collectionId);
+
+        String dataURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022";
+        dataRequest.addParameter("uri", dataURL);
+
+        try {
+            Data dataAPI = new Data();
+            dataAPI.read(dataRequest, response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage() + e.toString());
+            throw e;
+        }
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(expectedContentV1, response.getContentAsString());
     }
 
     private byte[] getV1RequestContent() {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -40,6 +40,13 @@ import java.nio.file.Paths;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+/**
+ * An Integration test for the end-to-end of creating a piece of content in Zebedee
+ *
+ * Note: this should probably use FailSafe and be renamed to ContentTestIT but the current
+ * zebedee CI pipeline does not execute the verify maven phase, so would never execute these tests.
+ *
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class ContentTest {
     
@@ -53,9 +60,6 @@ public class ContentTest {
     private Session mockSession;
 
     @Mock
-    private Collections mockCollections;
-
-    @Mock
     private CollectionKeyring mockCollectionKeyring;
     
     @Mock
@@ -66,10 +70,7 @@ public class ContentTest {
 
     @Mock
     Notifier mockNotifier;
-
-    @Mock
-    CollectionReaderFactory collectionReaderFactory;
-
+    
     Path tempBasePath;
 
     CollectionDescription collectionDescription;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -1,0 +1,128 @@
+package com.github.onsdigital.zebedee.api;
+
+import com.github.onsdigital.zebedee.Zebedee;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Collections;
+import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
+import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
+import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.session.model.Session;
+import com.github.onsdigital.zebedee.session.service.Sessions;
+import com.github.onsdigital.zebedee.user.service.UsersService;
+import com.github.onsdigital.zebedee.util.versioning.VersionsServiceImpl;
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.crypto.SecretKey;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentTest {
+    
+    @Mock
+    private Zebedee mockZebedee;
+
+    @Mock
+    private Sessions mockSessions;
+
+    @Mock
+    private Session mockSession;
+
+    @Mock
+    private Collections mockCollections;
+
+    @Mock
+    private CollectionKeyring mockCollectionKeyring;
+
+    @Mock
+    private SecretKey secretKey;
+
+    @Mock
+    private PermissionsService mockPermissionsService;
+
+    @Mock
+    UsersService mockUsersService;
+
+    @Test
+    public void It_Should_Write_Content_To_File() throws Exception {
+        Path tempBasePath = Files.createTempDirectory("tempZebedee");
+
+        System.setProperty("ENABLE_DATASET_IMPORT", "false");
+        System.setProperty("zebedee_root", tempBasePath.toString());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String collectionId = "aktesting";
+        request.setPathInfo("/content/" + collectionId);
+        String datasetURL = "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
+        request.addParameter("uri", datasetURL);
+
+        CollectionDescription collectionDescription = new CollectionDescription("AK Testing");
+        EncryptionKeyFactory encryptionKeyFactory = new EncryptionKeyFactoryImpl();
+
+        VersionsServiceImpl versionsService = new VersionsServiceImpl();
+        com.github.onsdigital.zebedee.model.Content content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
+
+        Collections collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
+
+        when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
+
+        when(mockSessions.get()).thenReturn(mockSession);
+
+        when(mockCollections.getPath()).thenReturn(tempBasePath);
+
+        when(mockZebedee.getCollections()).thenReturn(collections);
+        when(mockZebedee.getSessions()).thenReturn(mockSessions);
+        when(mockZebedee.getEncryptionKeyFactory()).thenReturn(encryptionKeyFactory);
+        when(mockZebedee.getPermissionsService()).thenReturn(mockPermissionsService);
+        when(mockZebedee.getUsersService()).thenReturn(mockUsersService);
+        when(mockZebedee.getCollectionKeyring()).thenReturn(mockCollectionKeyring);
+        Root.zebedee = mockZebedee;
+
+        Collection collection = Collection.create(collectionDescription, mockZebedee, mockSession);
+        when(mockCollections.getCollection(collectionId)).thenReturn(collection); // Do we still need to do this given we have a real collection (TRY DELETING THIS LINE)
+        when(mockCollectionKeyring.get(any(), any())).thenReturn(secretKey);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // "/peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json";
+
+//        Path a = Paths.get(tempBasePath.toString(), collectionId, "peoplepopulationandcommunity");
+//        Files.createDirectory(a);
+//        Path b = Paths.get(tempBasePath.toString(), collectionId, "peoplepopulationandcommunity", "birthsdeathsandmarriages");
+//        Files.createDirectory(b);
+        Path c = Paths.get(tempBasePath.toString(), collectionId, "inprogress","peoplepopulationandcommunity", "birthsdeathsandmarriages", "livebirths", "datasets", "babynamesenglandandwalesbabynamesstatisticsboys", "2022");
+//        Files.createDirectory(c);
+
+        Path d = Files.createDirectories(c);
+        Path versionFile = Paths.get(d.toString(), "data.json");
+        Files.createFile(versionFile);
+
+        Version versionApi = new Version();
+        versionApi.create(newVersionRequest, newVersionResponse);
+        Page pageApi = new Page(false);
+        pageApi.createPage(newPageRequest, newPageResponse);
+
+        try {
+            Content contentApi = new Content();
+            boolean result = contentApi.saveContent(request, response);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage() + e.toString());
+            e.printStackTrace();
+            throw e;
+        }
+
+    }
+}

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DownloadSection.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DownloadSection.java
@@ -12,6 +12,8 @@ public class DownloadSection extends Content {
     private List<String> cdids;
     private String file;
     private String fileDescription; //Markdown
+    private String url;
+    private String version;
 
     public String getTitle() {
         return title;

--- a/zebedee.yaml
+++ b/zebedee.yaml
@@ -1,0 +1,190 @@
+openapi: 3.0.3
+info:
+  title: Zebedee
+  description: Zebedee CMS API
+  version: 1.0.0
+servers:
+  - url: 'https'
+paths:
+  /login:
+    post:
+      summary: Authenticate a User
+      requestBody:
+        description: The details of the user authenticating
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                  example: florence@magicroundabout.ons.gov.uk
+                  description: The email address of the user authenticating
+                password:
+                  type: string
+                  example: p@ssword123!
+                  description: The password of the user authenticating
+              required:
+                - email
+                - password
+      responses:
+        200:
+          description: Returns the quoted authentication token
+          content:
+            text/plain:
+              example: "123456789poiuytrewqasdfghjkzxcvbnm"
+  /content/{collection_id}:
+    post:
+      summary: Handle the upload of files (multi-part) and CMS (Collection/Versions/Page) data (JSON)
+      description: TODO - implemented in com.github.onsdigital.zebedee.api.Content
+      parameters:
+        - name: collection_id
+          required: true
+          description: the ID of the collection the content file or data is associated with
+          example: aktesting-123456789
+          in: path
+          schema:
+            type: string
+        - name: uri
+          required: true
+          example:
+            - /peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/data.json
+          description: the file path to be created/overwritten
+          in: query
+          schema:
+            type: string
+        - name: overwriteExisting
+          required: false
+          example: true
+          description: Whether the file should overwritten if it exists (if false and file exists and error will be returned) Default - true
+          in: query
+          schema:
+            type: boolean
+        - name: recursive
+          required: false
+          example: false
+          description: TODO Default - false
+          in: query
+          schema:
+            type: boolean
+        - name: validateJson
+          required: false
+          example: true
+          description: TODO Default - true
+          in: query
+          schema:
+            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/json:
+            examples:
+              any:
+                description: any JSON encode of classes defined in zebedee-reader within the com.github.onsdigital.zebebee.content packages
+          multipart/mixed:
+            examples:
+              TODO:
+                description: Uploading of CSV/Excel file (This function is deprecated - use Static File dp-upload-service)
+      responses:
+        200:
+          description: Whether the content is store based on the boolean in the response body
+        409:
+          description: if overwriteExisting = false and file already exists
+  /data/{collection_id}:
+    get:
+      summary: returns the content of a Zebedee CMS data file based on the URI provided
+      description: TODO.... Implemented in zebedee-reader at com.github.onsdigital.zebedee.reader.api.endpoint.Data
+      parameters:
+        - name: collection_id
+          required: true
+          description: the ID of the collection the content file or data is associated with
+          example: aktesting-123456789
+          in: path
+          schema:
+            type: string
+        - name: uri
+          required: true
+          example:
+            - /peoplepopulationandcommunity/birthsdeathsandmarriages/livebirths/datasets/babynamesenglandandwalesbabynamesstatisticsboys/2022/
+          description: the file path to be created/overwritten
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: any JSON encode of classes defined in zebedee-reader within the com.github.onsdigital.zebebee.content packages, based on the `type` field in the content
+  /collection:
+    post:
+      summary: Create a collection
+      parameters:
+        - name: X-Florence-Token
+          in: header
+          required: true
+          description: Auth Token for the currently used auth system
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  description: The name of the collection
+                  example: 2021 Annual Births Analysis
+                type:
+                  type: string
+                  description: the type of collection either manual or scheduled
+                  example: manual
+                TODO:
+                  description: There are more properties that we have not discovered/used TODO please continues documenting
+              required:
+                - name
+                - type
+      responses:
+        200:
+          description: Whether the content is store based on the boolean in the response body
+  /publish/{collection_id}:
+    post:
+      summary: Publish a collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: The ID of the collection to be published
+          schema:
+            type: string
+        - name: X-Florence-Token
+          in: header
+          required: true
+          description: Auth Token for the currently used auth system
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns a boolean based on the success of publication
+          content:
+            text/plain:
+              example: true
+  /approve/{collection_id}:
+    post:
+      summary: Approve a collection
+      parameters:
+        - name: collection_id
+          in: path
+          required: true
+          description: The ID of the collection to be approved
+          schema:
+            type: string
+        - name: X-Florence-Token
+          in: header
+          required: true
+          description: Auth Token for the currently used auth system
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns a boolean based on the success of approval
+          content:
+            text/plain:
+              example: true


### PR DESCRIPTION
### What

Changed the DownloadSection model (used Collection and Dataset etc. model objects) to add a version and url fields to the model. This will be used by Florence to store references to files uploaded to dp-static-files.

### How to review

The essential tests are in the file ContentTest.java - these act as a partial wrapper test to verify the correct functioning of both the existing format for dowloads and the new format (with URL but without filename)

### Who can review

People familiar with the use of Zebedee to store file & page content from Florence in the corresponding json files.