### PR TITLE
Store survey values

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
@@ -83,6 +83,7 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     private String apiDatasetId;
     private String canonicalTopic;
     private List<String> secondaryTopics;
+    private Survey survey;
 
     public PageDescription() {
     }
@@ -470,5 +471,13 @@ public class PageDescription extends Content implements Comparable<PageDescripti
 
     public void setSecondaryTopics(List<String> secondaryTopics) {
         this.secondaryTopics = secondaryTopics;
+    }
+
+    public Survey getSurvey() {
+        return survey;
+    }
+
+    public void setSurvey(Survey survey) {
+        this.survey = survey;
     }
 }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/Survey.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/Survey.java
@@ -1,0 +1,11 @@
+package com.github.onsdigital.zebedee.content.page.base;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enumerates the different types of surveys
+ */
+public enum Survey {
+    @SerializedName("census")
+    CENSUS;
+}


### PR DESCRIPTION
### What

Store survey values. Currently limited to `census` but open to extension via an enum

### How to review

Check changes make sense.

Optionally, it can be tested by posting content with `"survey" : "census"` in the description and then retrieving it, checking that it returns the survey value.

### Who can review

Anyone not me
