### PR TITLE
Fix string team id compare

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/model/Team.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/model/Team.java
@@ -18,6 +18,7 @@ public class Team {
      * {@link Comparator} ordering {@link Team} by {@link Team#id}.
      */
     public static Comparator<Team> teamIDComparator = (t1, t2) -> String.CASE_INSENSITIVE_ORDER.compare(t1.getId(), t2.getId());
+    public static Comparator<Team> numericTeamIDComparator = Comparator.comparingInt(t -> Integer.parseInt(t.getId()));
 
     private String id;
     private String name;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/teams/service/TeamsServiceImpl.java
@@ -12,6 +12,7 @@ import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.teams.model.Team;
 import com.github.onsdigital.zebedee.teams.store.TeamsStore;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getUnauthorizedMessage;
+import static com.github.onsdigital.zebedee.teams.model.Team.numericTeamIDComparator;
 import static com.github.onsdigital.zebedee.teams.model.Team.teamIDComparator;
 
 /**
@@ -106,7 +108,8 @@ public class TeamsServiceImpl implements TeamsService {
             // Order existing teams by their ID.
             List<Team> orderedTeams = listTeams()
                     .parallelStream()
-                    .sorted(teamIDComparator)
+                    .filter(t -> NumberUtils.isParsable(t.getId()))
+                    .sorted(numericTeamIDComparator)
                     .collect(Collectors.toList());
 
             // Reverse the order so the highest number is first (for convenience).


### PR DESCRIPTION
### What

Hotfix to fix issue with creation of new teams having id > "999"

A change to the teams model made the id a string instead of an int, so the new id code was adding to the largest alphabetical id. ie. "999" so was adding all new teams as "1000"

### How to review

Ensure tests pass and code looks good

### Who can review

Anyone but me