### PR TITLE
Extend to include management of interactives in collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,6 @@
                             <artifactId>xmlbeans</artifactId>
                             <version>2.6.0</version>
                         </exlude>
-                        <!-- End -->
 
                         <!-- https://trello.com/c/xDqibumj -->
                         <exlude>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -270,6 +270,12 @@
             <artifactId>dp-static-files-api-client-java</artifactId>
             <version>1.1.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-interactives-api-client-java</artifactId>
+            <version>0.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/Zebedee.java
@@ -18,6 +18,7 @@ import com.github.onsdigital.zebedee.notification.StartUpNotifier;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ImageService;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.service.KafkaService;
 import com.github.onsdigital.zebedee.service.ServiceStore;
 import com.github.onsdigital.zebedee.service.ServiceStoreImpl;
@@ -84,6 +85,7 @@ public class Zebedee {
     private final Sessions sessions;
     private final DataIndex dataIndex;
     private final DatasetService datasetService;
+    private final InteractivesService interactivesService;
     private final ImageService imageService;
     private final KafkaService kafkaService;
     private final StaticFilesService staticFilesService;
@@ -110,6 +112,7 @@ public class Zebedee {
         this.usersService = cfg.getUsersService();
         this.verificationAgent = cfg.getVerificationAgent(isVerificationEnabled(), this);
         this.datasetService = cfg.getDatasetService();
+        this.interactivesService = cfg.getInteractivesService();
         this.imageService = cfg.getImageService();
         this.kafkaService = cfg.getKafkaService();
         this.staticFilesService = cfg.getStaticFilesService();
@@ -366,6 +369,10 @@ public class Zebedee {
 
     public DatasetService getDatasetService() {
         return datasetService;
+    }
+
+    public InteractivesService getInteractivesService() {
+        return interactivesService;
     }
 
     public ImageService getImageService() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -3,9 +3,9 @@ package com.github.onsdigital.zebedee;
 import com.github.onsdigital.JWTVerifier;
 import com.github.onsdigital.JWTVerifierImpl;
 import com.github.onsdigital.dp.files.api.APIClient;
-import com.github.onsdigital.dp.files.api.Client;
 import com.github.onsdigital.dp.image.api.client.ImageAPIClient;
 import com.github.onsdigital.dp.image.api.client.ImageClient;
+import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
 import com.github.onsdigital.slack.Profile;
 import com.github.onsdigital.slack.client.SlackClient;
 import com.github.onsdigital.slack.client.SlackClientImpl;
@@ -35,6 +35,8 @@ import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
 import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ImageService;
 import com.github.onsdigital.zebedee.service.ImageServiceImpl;
+import com.github.onsdigital.zebedee.service.InteractivesService;
+import com.github.onsdigital.zebedee.service.InteractivesServiceImpl;
 import com.github.onsdigital.zebedee.service.KafkaService;
 import com.github.onsdigital.zebedee.service.KafkaServiceImpl;
 import com.github.onsdigital.zebedee.service.NoOpKafkaService;
@@ -92,6 +94,7 @@ import static com.github.onsdigital.zebedee.configuration.Configuration.getDatas
 import static com.github.onsdigital.zebedee.configuration.Configuration.getIdentityAPIURL;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getImageAPIURL;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getInitialRetryInterval;
+import static com.github.onsdigital.zebedee.configuration.Configuration.getInteractivesAPIURL;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getKafkaContentPublishedTopic;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getKafkaURL;
 import static com.github.onsdigital.zebedee.configuration.Configuration.getKeyringInitVector;
@@ -132,6 +135,7 @@ public class ZebedeeConfiguration {
     private Sessions sessions;
     private DataIndex dataIndex;
     private DatasetService datasetService;
+    private InteractivesService interactivesService;
     private ImageService imageService;
     private KafkaService kafkaService;
     private StaticFilesService staticFilesService;
@@ -197,8 +201,11 @@ public class ZebedeeConfiguration {
             this.permissionsService = new PermissionsServiceImpl(permissionsStore);
         }
 
+        InteractivesAPIClient interactivesClient = new InteractivesAPIClient(getInteractivesAPIURL(), getServiceAuthToken());
+        interactivesService = new InteractivesServiceImpl(interactivesClient);
+
         VersionsService versionsService = new VersionsServiceImpl();
-        this.collections = new Collections(collectionsPath, permissionsService, versionsService, published);
+        this.collections = new Collections(collectionsPath, permissionsService, versionsService, interactivesService, published);
 
         // TODO: Remove after migration to JWT sessions is complete
         if (cmsFeatureFlags().isJwtSessionsEnabled()) {
@@ -435,6 +442,10 @@ public class ZebedeeConfiguration {
 
     public DatasetService getDatasetService() {
         return datasetService;
+    }
+
+    public InteractivesService getInteractivesService() {
+        return interactivesService;
     }
 
     public ImageService getImageService() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -124,6 +124,8 @@ public class CollectionDetails {
             result.datasetVersions = collection.getDescription().getDatasetVersions();
         }
 
+        result.interactives = collection.getDescription().getInteractives();
+
         return result;
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
@@ -19,6 +19,7 @@ public class CMSFeatureFlags {
     private static final String ENABLE_JWT_SESSIONS = "ENABLE_JWT_SESSIONS";
     public static final String ENABLE_KAFKA = "ENABLE_KAFKA";
     public static final String ENABLE_STATIC_FILES_PUBLISHING = "ENABLE_STATIC_FILES_PUBLISHING";
+    public static final String ENABLE_INTERACTIVES_PUBLISHING = "ENABLE_INTERACTIVES_PUBLISHING";
 
     /**
      * Singleton instance
@@ -33,6 +34,8 @@ public class CMSFeatureFlags {
     private final boolean isJwtSessionsEnabled;
     private final boolean isKafkaEnabled;
     private final boolean isStaticFilesPublishingEnabled;
+    private final boolean isInteractivesPublishingEnabled;
+
 
     /**
      * Construct a new feature flags instance.
@@ -47,6 +50,7 @@ public class CMSFeatureFlags {
         this.isJwtSessionsEnabled = Boolean.valueOf(getConfigValue(ENABLE_JWT_SESSIONS));
         this.isKafkaEnabled = Boolean.valueOf(getConfigValue(ENABLE_KAFKA));
         this.isStaticFilesPublishingEnabled = Boolean.valueOf(getConfigValue(ENABLE_STATIC_FILES_PUBLISHING));
+        this.isInteractivesPublishingEnabled = Boolean.valueOf(getConfigValue(ENABLE_INTERACTIVES_PUBLISHING));
 
         info().data(ENABLE_DATASET_IMPORT, isDatasetImportEnabled)
                 .data(ENABLE_VERIFY_PUBLISH_CONTENT, isVerifyPublishEnabled)
@@ -57,6 +61,7 @@ public class CMSFeatureFlags {
                 .data(ENABLE_JWT_SESSIONS, isJwtSessionsEnabled)
                 .data(ENABLE_KAFKA, isKafkaEnabled)
                 .data(ENABLE_STATIC_FILES_PUBLISHING, isStaticFilesPublishingEnabled)
+                .data(ENABLE_INTERACTIVES_PUBLISHING, isInteractivesPublishingEnabled)
                 .log("CMS feature flags configurations");
     }
 
@@ -116,6 +121,9 @@ public class CMSFeatureFlags {
         return isStaticFilesPublishingEnabled;
     }
 
+    public boolean isInteractivesPublishingEnabled() {
+        return isInteractivesPublishingEnabled;
+    }
 
     public static String getConfigValue(String name) {
         String value = System.getProperty(name);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -11,9 +11,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
@@ -34,6 +32,7 @@ public class Configuration {
     private static final String MATHJAX_SERVICE_URL = "http://localhost:8888";
     private static final String DATASET_API_URL = "http://localhost:22000";
     private static final String IMAGE_API_URL = "http://localhost:24700";
+    private static final String INTERACTIVES_API_URL = "http://localhost:27500";
     private static final String STATIC_FILES_API_URL = "http://localhost:26900";
     private static final String IDENTITY_API_URL = "http://localhost:25600";
     private static final String KAFKA_ADDR = "localhost:9092";
@@ -145,6 +144,10 @@ public class Configuration {
 
     public static String getImageAPIURL() {
         return StringUtils.defaultIfBlank(getValue("IMAGE_API_URL"), IMAGE_API_URL);
+    }
+
+    public static String getInteractivesAPIURL() {
+        return StringUtils.defaultIfBlank(getValue("INTERACTIVES_API_URL"), INTERACTIVES_API_URL);
     }
 
     public static String getStaticFilesAPIURL() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
@@ -30,6 +30,9 @@ public class CollectionDescription extends CollectionBase {
     private Map<String, String> publishTransactionIds;
     private Map<String, Events> eventsByUri;
     private Set<CollectionDataset> datasets;
+
+    private Set<CollectionInteractive> interactives;
+
     private Set<CollectionDatasetVersion> datasetVersions;
 
     private ApprovalStatus approvalStatus = ApprovalStatus.NOT_STARTED;
@@ -53,6 +56,7 @@ public class CollectionDescription extends CollectionBase {
         this.eventsByUri = new HashMap<>();
         this.datasets = new HashSet<>();
         this.datasetVersions = new HashSet<>();
+        this.interactives = new HashSet<>();
     }
 
     /**
@@ -72,6 +76,7 @@ public class CollectionDescription extends CollectionBase {
         this.eventsByUri = new HashMap<>();
         this.datasets = new HashSet<>();
         this.datasetVersions = new HashSet<>();
+        this.interactives = new HashSet<>();
     }
 
 
@@ -139,6 +144,41 @@ public class CollectionDescription extends CollectionBase {
 
     public void setApprovalStatus(ApprovalStatus approvalStatus) {
         this.approvalStatus = approvalStatus;
+    }
+
+    public Set<CollectionInteractive> getInteractives() {
+
+        if (this.interactives == null) {
+            this.interactives = new HashSet<>();
+        }
+
+        return Collections.unmodifiableSet(this.interactives);
+    }
+
+    public Optional<CollectionInteractive> getInteractive(String interactiveID) {
+
+        if (this.interactives == null) {
+            return Optional.empty();
+        }
+
+        return this.interactives.stream()
+                .filter(i -> i.getId().equals(interactiveID)).findFirst();
+    }
+
+    public void addInteractive(CollectionInteractive interactive) {
+
+        if (this.interactives == null) {
+            this.interactives = new HashSet<>();
+        }
+
+        this.interactives.add(interactive);
+    }
+
+    public void removeInteractive(CollectionInteractive interactive) {
+
+        if (this.interactives == null) return;
+
+        this.interactives.remove(interactive);
     }
 
     /**
@@ -321,6 +361,10 @@ public class CollectionDescription extends CollectionBase {
 
     public void setDatasets(final Set<CollectionDataset> datasets) {
         this.datasets = datasets;
+    }
+
+    public void setInteractives(final Set<CollectionInteractive> interactives) {
+        this.interactives = interactives;
     }
 
     public void setDatasetVersions(final Set<CollectionDatasetVersion> datasetVersions) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDetail.java
@@ -14,6 +14,7 @@ public class CollectionDetail extends CollectionBase {
     public List<PendingDelete> pendingDeletes;
     public Events events;
     public Set<CollectionDataset> datasets;
+    public Set<CollectionInteractive> interactives;
     public Set<CollectionDatasetVersion> datasetVersions;
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInteractive.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInteractive.java
@@ -1,0 +1,68 @@
+package com.github.onsdigital.zebedee.json;
+
+/**
+ * Represents a dataset that has been added to a collection.
+ */
+public class CollectionInteractive {
+
+    private String id;
+    private String title;
+    private ContentStatus state;
+    private String uri;
+    private String lastEditedBy;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public ContentStatus getState() {
+        return state;
+    }
+
+    public void setState(ContentStatus state) {
+        this.state = state;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public void setLastEditedBy(String user) {
+        this.lastEditedBy = user;
+    }
+
+    public String getLastEditedBy() {
+        return lastEditedBy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CollectionInteractive that = (CollectionInteractive) o;
+
+        return getId() != null ? getId().equals(that.getId()) : that.getId() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getId() != null ? getId().hashCode() : 0;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1392,12 +1392,11 @@ public class Collection {
      * Return true if this collection has had all of its content reviewed.
      */
     public boolean isAllContentReviewed(boolean datasetImportEnabled) throws IOException {
+
+        boolean isContentReviewed = inProgressUris().isEmpty() && completeUris().isEmpty();
+
         // FIXME CMD feature flag
         if (datasetImportEnabled) {
-            boolean allInteractivesReviewed = description.getInteractives()
-                    .stream()
-                    .allMatch(i -> i.getState().equals(ContentStatus.Reviewed));
-
             boolean allDatasetsReviewed = description.getDatasets()
                     .stream()
                     .allMatch(ds -> ds.getState().equals(ContentStatus.Reviewed));
@@ -1406,14 +1405,18 @@ public class Collection {
                     .stream()
                     .allMatch(ds -> ds.getState().equals(ContentStatus.Reviewed));
 
-            return (inProgressUris().isEmpty()
-                    && completeUris().isEmpty()
-                    && allDatasetsReviewed
-                    && allDatasetVersionsReviewed
-                    && allInteractivesReviewed);
+            isContentReviewed &= allDatasetsReviewed && allDatasetVersionsReviewed;
         }
 
-        return inProgressUris().isEmpty() && completeUris().isEmpty();
+        if (cmsFeatureFlags().isInteractivesPublishingEnabled()) {
+            boolean allInteractivesReviewed = description.getInteractives()
+                    .stream()
+                    .allMatch(i -> i.getState().equals(ContentStatus.Reviewed));
+
+            isContentReviewed &= allInteractivesReviewed;
+        }
+
+        return isContentReviewed;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -1394,6 +1394,10 @@ public class Collection {
     public boolean isAllContentReviewed(boolean datasetImportEnabled) throws IOException {
         // FIXME CMD feature flag
         if (datasetImportEnabled) {
+            boolean allInteractivesReviewed = description.getInteractives()
+                    .stream()
+                    .allMatch(i -> i.getState().equals(ContentStatus.Reviewed));
+
             boolean allDatasetsReviewed = description.getDatasets()
                     .stream()
                     .allMatch(ds -> ds.getState().equals(ContentStatus.Reviewed));
@@ -1405,10 +1409,24 @@ public class Collection {
             return (inProgressUris().isEmpty()
                     && completeUris().isEmpty()
                     && allDatasetsReviewed
-                    && allDatasetVersionsReviewed);
+                    && allDatasetVersionsReviewed
+                    && allInteractivesReviewed);
         }
 
         return inProgressUris().isEmpty() && completeUris().isEmpty();
+    }
+
+    /**
+     * Return a list of ContentDetail items for each interactive in the collection.
+     */
+    public List<ContentDetail> getInteractiveDetails() {
+
+        return description.getInteractives().stream().map(ds -> {
+
+            String url = URI.create(ds.getUri()).getPath();
+            return new ContentDetail(ds.getTitle(), url, PageType.INTERACTIVE);
+
+        }).collect(Collectors.toList());
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -27,6 +27,7 @@ import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 import com.github.onsdigital.zebedee.util.versioning.VersionNotFoundException;
@@ -77,6 +78,7 @@ public class Collections {
 
     private final Path path;
     private PermissionsService permissionsService;
+    private InteractivesService interactivesService;
     private Content published;
     private Supplier<Zebedee> zebedeeSupplier = () -> Root.zebedee;
     private ZebedeeCmsService zebedeeCmsService = ZebedeeCmsService.getInstance();
@@ -87,11 +89,15 @@ public class Collections {
     private Comparator<String> strComparator = Comparator.comparing(String::toString);
     private VersionsService versionsService;
 
-    public Collections(Path path, PermissionsService permissionsService,
-                       VersionsService versionsService, Content published) {
+    public Collections(Path path,
+                       PermissionsService permissionsService,
+                       VersionsService versionsService,
+                       InteractivesService interactivesService,
+                       Content published) {
         this.path = path;
         this.permissionsService = permissionsService;
         this.versionsService = versionsService;
+        this.interactivesService = interactivesService;
         this.published = published;
         this.collectionReaderWriterFactory = new CollectionReaderWriterFactory();
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventLog.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventLog.java
@@ -7,6 +7,7 @@ import java.util.List;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.ADD_DATASET_DETAILS;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.ADD_DATASET_VERSION_DETAILS;
+import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.ADD_INTERACTIVE_DETAILS;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.APPROVAL_COMPLETED;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.APPROVAL_STARTED;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.APPROVAL_STATE_SET;
@@ -54,6 +55,10 @@ public class ApprovalEventLog {
 
     public void addDatasetDetails() {
         addEvent(ADD_DATASET_DETAILS);
+    }
+
+    public void addInteractiveDetails() {
+        addEvent(ADD_INTERACTIVE_DETAILS);
     }
 
     public void addDatasetVersionDetails() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventType.java
@@ -6,6 +6,8 @@ public enum ApprovalEventType {
 
     RESOLVED_DETAILS("resolvedDetails"),
 
+    ADD_INTERACTIVE_DETAILS("addInteractiveDetails"),
+
     ADD_DATASET_DETAILS("addDatasetDetails"),
 
     ADD_DATASET_VERSION_DETAILS("addDatasetDetails"),

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -123,6 +123,11 @@ public class ApproveTask implements Callable<Boolean> {
                     collectionReader.getReviewed());
             eventLog.resolvedDetails();
 
+            if (cmsFeatureFlags().isInteractivesPublishingEnabled()) {
+                collectionContent.addAll(collection.getInteractiveDetails());
+                eventLog.addInteractiveDetails();
+            }
+
             if (cmsFeatureFlags().isEnableDatasetImport()) {
                 collectionContent.addAll(collection.getDatasetDetails());
                 eventLog.addDatasetDetails();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentStatusUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentStatusUtils.java
@@ -1,0 +1,88 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.json.ContentStatus;
+
+import java.util.Objects;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+
+public class ContentStatusUtils {
+
+    private ContentStatusUtils() {}
+
+    public static ContentStatus updatedStateInCollection(ContentStatus currentState, ContentStatus newState, String lastEditedBy, String user) throws ForbiddenException, BadRequestException {
+
+        Objects.requireNonNull(newState);
+
+        if (currentState == null && newState.equals(ContentStatus.Reviewed)) {
+            info().data("last edited by", lastEditedBy).data("user", user)
+                    .log("Attempt to review a resource that hasn't been submitted for review");
+
+            throw new BadRequestException("Cannot be reviewed without being submitted for review first");
+        }
+
+        // Updating from scratch to 'in progress' or 'complete' state so don't need to perform following checks
+        if (currentState == null && (newState.equals(ContentStatus.InProgress) || newState.equals(ContentStatus.Complete))) {
+            info().data("user", user)
+                    .data("last edited by", lastEditedBy)
+                    .data("current state", currentState)
+                    .data("new state", newState)
+                    .log("Updating resource state for first time");
+
+            return newState;
+        }
+
+        // The same user can't review edits they've submitted for review
+        if (!currentState.equals(ContentStatus.Reviewed) && newState.equals(ContentStatus.Reviewed) && lastEditedBy.equalsIgnoreCase(user)) {
+            info().data("user", user)
+                    .data("last edited by", lastEditedBy)
+                    .data("current state", currentState)
+                    .data("new state", newState)
+                    .log("User attempting to review their own resource");
+
+            throw new ForbiddenException("User " + user + "doesn't have permission to review a resource they completed");
+        }
+
+        // Any further updates made by the user who submitted the dataset should keep the dataset in the awaiting review state
+        if (currentState.equals(ContentStatus.Complete) && lastEditedBy.equalsIgnoreCase(user)) {
+
+            info().data("user", user)
+                    .data("last edited by", lastEditedBy)
+                    .data("current state", currentState)
+                    .data("new state", newState)
+                    .log("User making more updates to a resource whilst it is awaiting review");
+            return ContentStatus.Complete;
+        }
+
+        // Any updates to a dataset awaiting review by a different user means it moves back to an in progress state
+        if (currentState.equals(ContentStatus.Complete) && !newState.equals(ContentStatus.Reviewed) && !lastEditedBy.equalsIgnoreCase(user)) {
+
+            info().data("user", user)
+                    .data("last edited by", lastEditedBy)
+                    .data("current state", currentState)
+                    .data("new state", newState)
+                    .log("A different user making updates to a resource whilst it is awaiting review");
+            return ContentStatus.InProgress;
+        }
+
+        // Once reviewed any updates can be made to a dataset without the state changing
+        if (currentState.equals(ContentStatus.Reviewed)) {
+
+            info().data("user", user)
+                    .data("last edited by", lastEditedBy)
+                    .data("current state", currentState)
+                    .data("new state", newState)
+                    .log("Making updates to a review resource");
+            return ContentStatus.Reviewed;
+        }
+
+        info().data("user", user)
+                .data("last edited by", lastEditedBy)
+                .data("current state", currentState)
+                .data("new state", newState)
+                .log("Updating resource state");
+        return newState;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesService.java
@@ -1,0 +1,21 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionInteractive;
+import com.github.onsdigital.zebedee.model.Collection;
+import dp.api.dataset.exception.DatasetAPIException;
+
+import java.io.IOException;
+
+/**
+ * Provides high level dataset functionality
+ */
+public interface InteractivesService {
+
+    /**
+     * Update a dataset for the given ID to the collection for the given collectionID.
+     */
+    CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException, RuntimeException;
+    void removeInteractiveFromCollection(Collection collection, String interactiveID) throws IOException, RuntimeException;
+    void publishCollection(Collection collection) throws RuntimeException;
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
@@ -1,0 +1,119 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
+import com.github.onsdigital.dp.interactives.api.models.Interactive;
+import com.github.onsdigital.dp.interactives.api.models.InteractiveMetadata;
+import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionInteractive;
+import com.github.onsdigital.zebedee.json.ContentStatus;
+import com.github.onsdigital.zebedee.model.Collection;
+import dp.api.dataset.exception.DatasetAPIException;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.util.Optional;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+
+/**
+ * Dataset related services
+ */
+public class InteractivesServiceImpl implements InteractivesService {
+
+    private InteractivesAPIClient interactivesClient;
+
+    public InteractivesServiceImpl(InteractivesAPIClient interactivesClient) {
+        this.interactivesClient = interactivesClient;
+    }
+
+    /**
+     * Add the dataset for the given datasetID to the collection for the collectionID.
+     */
+    @Override
+    public CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException, RuntimeException {
+
+        CollectionInteractive collectionInteractive;
+
+        Optional<CollectionInteractive> existingInteractive = collection.getDescription().getInteractive(id);
+        if (existingInteractive.isPresent()) {
+            collectionInteractive = existingInteractive.get();
+        } else {
+            collectionInteractive = new CollectionInteractive();
+            collectionInteractive.setId(id);
+        }
+
+        if (updatedInteractive != null && updatedInteractive.getState() != null) {
+            collectionInteractive.setState(ContentStatusUtils.updatedStateInCollection(collectionInteractive.getState(), updatedInteractive.getState(), collectionInteractive.getLastEditedBy(), user));
+        } else {
+            collectionInteractive.setState(ContentStatus.InProgress);
+        }
+
+        collectionInteractive.setLastEditedBy(user);
+
+        Interactive interactive = interactivesClient.getInteractive(id);
+        if (ObjectUtils.allNotNull(interactive, interactive.getMetadata())) {
+            InteractiveMetadata metadata = interactive.getMetadata();
+            boolean notAssociatedYet = StringUtils.isBlank(metadata.getCollectionId());
+            
+            if (!notAssociatedYet) {
+                boolean associatedToAnotherCollection = !metadata.getCollectionId().equals(collection.getId());
+                if (associatedToAnotherCollection) {
+                    throw new ConflictException("cannot add interactive " + id
+                            + " to collection " + collection.getId()
+                            + " it is already in collection " + metadata.getCollectionId());
+                }
+            }
+
+            if (StringUtils.isBlank(interactive.getURL())) {
+                info().data("collectionId", collection.getDescription().getId())
+                        .data("interactiveId", id)
+                        .log("The interactive URL has not been set");
+                throw new InvalidObjectException("The interactive URL has not been set on the dataset response");
+            }
+
+            if (notAssociatedYet) {
+                interactivesClient.linkInteractiveToCollection(id, collection.getId());
+            }
+
+            collectionInteractive.setUri(interactive.getURL());
+            collectionInteractive.setTitle(metadata.getTitle());
+            collection.getDescription().addInteractive(collectionInteractive);
+            collection.save();
+        }
+
+        return collectionInteractive;
+    }
+
+    @Override
+    public void removeInteractiveFromCollection(Collection collection, String interactiveID) throws IOException, RuntimeException {
+
+        // if its not in the collection then just return.
+        Optional<CollectionInteractive> existingInteractive = collection.getDescription().getInteractive(interactiveID);
+        if (!existingInteractive.isPresent()) {
+            return;
+        }
+
+        try {
+            interactivesClient.deleteInteractive(interactiveID);
+        } catch (Exception e) {
+            throw e;
+        }
+
+        collection.getDescription().removeInteractive(existingInteractive.get());
+        collection.save();
+    }
+
+    @Override
+    public void publishCollection(Collection collection) throws RuntimeException {
+        String collectionId = collection.getDescription().getId();
+
+        if (collectionId == null || collectionId.isEmpty()) {
+            throw new IllegalArgumentException("a collectionId must be set in the collection being published");
+        }
+
+        interactivesClient.publishCollection(collectionId);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ZebedeeDatasetService.java
@@ -1,8 +1,6 @@
 package com.github.onsdigital.zebedee.service;
 
-import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
-import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
@@ -16,7 +14,6 @@ import dp.api.dataset.model.State;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
@@ -30,80 +27,6 @@ public class ZebedeeDatasetService implements DatasetService {
 
     public ZebedeeDatasetService(DatasetClient datasetClient) {
         this.datasetClient = datasetClient;
-    }
-
-    private ContentStatus updatedStateInCollection(ContentStatus currentState, ContentStatus newState, String lastEditedBy, String user) throws ForbiddenException, BadRequestException {
-
-        Objects.requireNonNull(newState);
-
-        if (currentState == null && newState.equals(ContentStatus.Reviewed)) {
-            info().data("last edited by", lastEditedBy).data("user", user)
-                    .log("Attempt to review a dataset that hasn't been submitted for review");
-
-            throw new BadRequestException("Cannot be reviewed without being submitted for review first");
-        }
-
-        // Updating from scratch to 'in progress' or 'complete' state so don't need to perform following checks
-        if (currentState == null && (newState.equals(ContentStatus.InProgress) || newState.equals(ContentStatus.Complete))) {
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("Updating dataset state for first time");
-
-            return newState;
-        }
-
-        // The same user can't review edits they've submitted for review
-        if (!currentState.equals(ContentStatus.Reviewed) && newState.equals(ContentStatus.Reviewed) && lastEditedBy.equalsIgnoreCase(user)) {
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("User attempting to review their own dataset");
-
-            throw new ForbiddenException("User " + user + "doesn't have permission to review a dataset they completed");
-        }
-
-        // Any further updates made by the user who submitted the dataset should keep the dataset in the awaiting review state
-        if (currentState.equals(ContentStatus.Complete) && lastEditedBy.equalsIgnoreCase(user)) {
-
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("User making more updates to a dataset whilst it is awaiting review");
-            return ContentStatus.Complete;
-        }
-
-        // Any updates to a dataset awaiting review by a different user means it moves back to an in progress state
-        if (currentState.equals(ContentStatus.Complete) && !newState.equals(ContentStatus.Reviewed) && !lastEditedBy.equalsIgnoreCase(user)) {
-
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("A different user making updates to a dataset whilst it is awaiting review");
-            return ContentStatus.InProgress;
-        }
-
-        // Once reviewed any updates can be made to a dataset without the state changing
-        if (currentState.equals(ContentStatus.Reviewed)) {
-
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("Making updates to a review dataset");
-            return ContentStatus.Reviewed;
-        }
-
-        info().data("user", user)
-                .data("last edited by", lastEditedBy)
-                .data("current state", currentState)
-                .data("new state", newState)
-                .log("Updating dataset state");
-        return newState;
     }
 
     /**
@@ -160,7 +83,7 @@ public class ZebedeeDatasetService implements DatasetService {
         }
 
         if (updatedDataset != null && updatedDataset.getState() != null) {
-            collectionDataset.setState(updatedStateInCollection(collectionDataset.getState(), updatedDataset.getState(), collectionDataset.getLastEditedBy(), user));
+            collectionDataset.setState(ContentStatusUtils.updatedStateInCollection(collectionDataset.getState(), updatedDataset.getState(), collectionDataset.getLastEditedBy(), user));
         } else {
             collectionDataset.setState(ContentStatus.InProgress);
         }
@@ -228,7 +151,7 @@ public class ZebedeeDatasetService implements DatasetService {
         }
 
         if (updatedVersion != null && updatedVersion.getState() != null) {
-            collectionDatasetVersion.setState(updatedStateInCollection(collectionDatasetVersion.getState(), updatedVersion.getState(), collectionDatasetVersion.getLastEditedBy(), user));
+            collectionDatasetVersion.setState(ContentStatusUtils.updatedStateInCollection(collectionDatasetVersion.getState(), updatedVersion.getState(), collectionDatasetVersion.getLastEditedBy(), user));
         } else {
             collectionDatasetVersion.setState(ContentStatus.InProgress);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ZebedeeCmsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ZebedeeCmsService.java
@@ -21,6 +21,7 @@ import com.github.onsdigital.zebedee.reader.FileSystemContentReader;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.service.ImageService;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.service.KafkaService;
 import com.github.onsdigital.zebedee.service.StaticFilesService;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -135,6 +136,10 @@ public class ZebedeeCmsService {
 
     public DatasetService getDatasetService() {
         return Root.zebedee.getDatasetService();
+    }
+
+    public InteractivesService getInteractivesService() {
+        return Root.zebedee.getInteractivesService();
     }
 
     public ImageService getImageService() {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -3,8 +3,10 @@ package com.github.onsdigital.zebedee.api;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
+import com.github.onsdigital.zebedee.json.CollectionInteractive;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.DatasetService;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.util.ZebedeeCmsService;
 import org.apache.http.HttpStatus;
@@ -29,6 +31,7 @@ public class CollectionsTest {
 
     private ZebedeeCmsService mockZebedeeCmsService = mock(ZebedeeCmsService.class);
     private DatasetService mockDatasetService = mock(DatasetService.class);
+    private InteractivesService mockInteractivesService = mock(InteractivesService.class);
     private ServletInputStream mockServletInputStream = mock(ServletInputStream.class);
 
     private com.github.onsdigital.zebedee.model.Collection mockCollection =
@@ -38,9 +41,9 @@ public class CollectionsTest {
     private HttpServletResponse response = mock(HttpServletResponse.class);
     private Session session = mock(Session.class);
 
-    private Collections collections = new Collections(mockZebedeeCmsService, mockDatasetService, true);
+    private Collections collections = new Collections(mockZebedeeCmsService, mockDatasetService, mockInteractivesService, true);
     private String collectionID = "123";
-    private String datasetID = "345";
+    private String resourceID = "345";
     private String edition = "2014";
     private String version = "1";
     private String user = "test@email.com";
@@ -52,100 +55,54 @@ public class CollectionsTest {
     }
 
     @Test
-    public void testPutDataset_DatasetImportDisabled() throws Exception {
-        collections = new Collections(mockZebedeeCmsService, mockDatasetService, false);
+    public void testPut_DatasetImportDisabled() throws Exception {
+        collections = new Collections(mockZebedeeCmsService, mockDatasetService, mockInteractivesService, false);
 
         // When the put method is called
         collections.put(request, response);
 
         verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
-        verifyNoInteractions(mockZebedeeCmsService, mockDatasetService);
+        verifyNoInteractions(mockZebedeeCmsService, mockDatasetService, mockInteractivesService);
     }
 
     @Test
-    public void testDeleteDataset_DatasetImportDisabled() throws Exception {
-        collections = new Collections(mockZebedeeCmsService, mockDatasetService, false);
+    public void testDelete_DatasetImportDisabled() throws Exception {
+        collections = new Collections(mockZebedeeCmsService, mockDatasetService, mockInteractivesService, false);
 
         // When the put method is called
         collections.delete(request, response);
 
         verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
-        verifyNoInteractions(mockZebedeeCmsService, mockDatasetService);
-    }
-
-    @Test
-    public void TestPutDataset_EmptyJSON() throws Exception {
-
-        // Given a PUT request with a bad json input
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
-        when(request.getPathInfo()).thenReturn(url);
-        when(session.getEmail()).thenReturn(user);
-
-        String json = "";
-        mockRequestBody(json);
-
-        shouldAuthorise(request, true);
-
-        // When the put method is called
-        collections.put(request, response);
-
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).updateDatasetInCollection(mockCollection, datasetID, null, user);
-    }
-
-    @Test
-    public void TestPutDataset() throws Exception {
-
-        // Given a PUT request with a valid URL for a dataset
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
-        when(request.getPathInfo()).thenReturn(url);
-        when(session.getEmail()).thenReturn(user);
-
-        String json = "{ \"state\": \"inProgress\"}";
-        mockRequestBody(json);
-
-        shouldAuthorise(request, true);
-
-        // When the put method is called
-        collections.put(request, response);
-
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).updateDatasetInCollection(mockCollection, datasetID, new CollectionDataset(), user);
-    }
-
-    @Test
-    public void TestPutDatasetVersion() throws Exception {
-
-        // Given a PUT request with a valid URL for a dataset
-        String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
-                collectionID, datasetID, edition, version);
-        when(request.getPathInfo()).thenReturn(url);
-        when(session.getEmail()).thenReturn(user);
-
-        String json = "{ \"state\": \"inProgress\"}";
-        mockRequestBody(json);
-
-        shouldAuthorise(request, true);
-
-        // When the put method is called
-        collections.put(request, response);
-
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).updateDatasetVersionInCollection(
-                mockCollection, datasetID, edition, version, new CollectionDatasetVersion(), user);
+        verifyNoInteractions(mockZebedeeCmsService, mockDatasetService, mockInteractivesService);
     }
 
     @Test
     public void TestPut_Forbidden() throws Exception {
 
         // Given a PUT request with a valid URL
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
+        String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
 
         shouldAuthorise(request, false);
 
         // When the put method is called
         collections.put(request, response);
+
+        // a HTTP 403 is set on the response
+        verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void TestDelete_Forbidden() throws Exception {
+
+        // Given a delete request with a valid URL
+        String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, false);
+
+        // When the delete method is called
+        collections.delete(request, response);
 
         // a HTTP 403 is set on the response
         verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
@@ -157,7 +114,7 @@ public class CollectionsTest {
         // Given a collection ID that does not exist
         when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(null);
 
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
+        String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
         shouldAuthorise(request, true);
 
@@ -169,7 +126,24 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPutDataset_SessionNotFound() throws Exception {
+    public void TestDelete_CollectionNotFound() throws Exception {
+
+        // Given a collection ID that does not exist
+        when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(null);
+
+        String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // The expected response code is set on the response
+        verify(response, times(1)).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestPut_SessionNotFound() throws Exception {
         // Given a session that does not exist
         when(mockZebedeeCmsService.getSession()).thenReturn(null);
 
@@ -178,121 +152,6 @@ public class CollectionsTest {
 
         // The dataset service is called with the values extracted from the request URL.
         verify(response, times(1)).setStatus(HttpStatus.SC_FORBIDDEN);
-    }
-
-    @Test
-    public void TestPut_ReturnBadRequest_URLSegments() throws Exception {
-
-        shouldAuthorise(request, true);
-
-        // Given a PUT request with a URL that contains less than the expected 4 segments
-        String url = "/collections/123/datasets";
-        when(request.getPathInfo()).thenReturn(url);
-
-        // When the put method is called
-        collections.put(request, response);
-
-        // Then a HTTP 404 is set on the response.
-        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void TestPut_ReturnBadRequest_NotDatasetsEndpoint() throws Exception {
-
-        shouldAuthorise(request, true);
-
-        // Given a PUT request with a URL that contains something other than /collections/{}/datasets/{}
-        String url = "/collections/123/wut/345";
-        when(request.getPathInfo()).thenReturn(url);
-
-        // When the put method is called
-        collections.put(request, response);
-
-        // Then a HTTP 404 is set on the response.
-        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void TestDelete_ReturnBadRequest_URLSegments() throws Exception {
-
-        shouldAuthorise(request, true);
-
-        // Given a PUT request with a URL that contains less than the expected number of segments
-        String url = "/collections/123/datasets";
-
-        when(request.getPathInfo()).thenReturn(url);
-
-        // When the delete method is called
-        collections.delete(request, response);
-
-        // Then a HTTP 404 is set on the response.
-        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void TestDelete_ReturnBadRequest_NotDatasetsEndpoint() throws Exception {
-
-        shouldAuthorise(request, true);
-
-        // Given a PUT request with a URL that contains something other than /collections/{}/datasets/{}
-        String url = "/collections/123/wut/345";
-        when(request.getPathInfo()).thenReturn(url);
-
-        // When the delete method is called
-        collections.delete(request, response);
-
-        // Then a HTTP 404 is set on the response.
-        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void TestDeleteDataset() throws Exception {
-
-        // Given a DELETE request with a valid URL
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
-        when(request.getPathInfo()).thenReturn(url);
-
-        shouldAuthorise(request, true);
-
-        // When the delete method is called
-        collections.delete(request, response);
-
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).removeDatasetFromCollection(mockCollection, datasetID);
-    }
-
-    @Test
-    public void TestDeleteDatasetVersion() throws Exception {
-
-        // Given a DELETE request with a valid URL
-        String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
-                collectionID, datasetID, edition, version);
-        when(request.getPathInfo()).thenReturn(url);
-
-        shouldAuthorise(request, true);
-
-        // When the delete method is called
-        collections.delete(request, response);
-
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).removeDatasetVersionFromCollection(
-                mockCollection, datasetID, edition, version);
-    }
-
-    @Test
-    public void TestDelete_Forbidden() throws Exception {
-
-        // Given a delete request with a valid URL
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
-        when(request.getPathInfo()).thenReturn(url);
-
-        shouldAuthorise(request, false);
-
-        // When the delete method is called
-        collections.delete(request, response);
-
-        // a HTTP 403 is set on the response
-        verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
     }
 
     @Test
@@ -309,20 +168,218 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDelete_CollectionNotFound() throws Exception {
+    public void TestPut_ReturnBadRequest_URLSegments() throws Exception {
 
-        // Given a collection ID that does not exist
-        when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(null);
+        shouldAuthorise(request, true);
 
-        String url = String.format("/collections/%s/datasets/%s", collectionID, datasetID);
+        // Given a PUT request with a URL that contains less than the expected 4 segments
+        String url = "/collections/123/anything";
         when(request.getPathInfo()).thenReturn(url);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestDelete_ReturnBadRequest_URLSegments() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains less than the expected number of segments
+        String url = "/collections/123/anything";
+
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestPut_ReturnBadRequest_NotValidEndpoint() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains something other than /collections/{}/{datasets|interactives}/{}
+        String url = "/collections/123/anything/345";
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestDelete_ReturnBadRequest_NotValidEndpoint() throws Exception {
+
+        shouldAuthorise(request, true);
+
+        // Given a PUT request with a URL that contains something other than /collections/{}/{datasets|interactives}/{}
+        String url = "/collections/123/anything/345";
+        when(request.getPathInfo()).thenReturn(url);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // Then a HTTP 404 is set on the response.
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void TestPutDataset_EmptyJSON() throws Exception {
+
+        // Given a PUT request with a bad json input
+        String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        mockRequestBody("");
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).updateDatasetInCollection(mockCollection, resourceID, null, user);
+    }
+
+    @Test
+    public void TestPutInteractive_EmptyJSON() throws Exception {
+
+        // Given a PUT request with a bad json input
+        String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        mockRequestBody("");
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockInteractivesService, times(1)).updateInteractiveInCollection(mockCollection, resourceID, null, user);
+    }
+
+    @Test
+    public void TestPutDataset() throws Exception {
+
+        // Given a PUT request with a valid URL for a dataset
+        String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        String json = "{ \"state\": \"inProgress\"}";
+        mockRequestBody(json);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).updateDatasetInCollection(mockCollection, resourceID, new CollectionDataset(), user);
+    }
+
+    @Test
+    public void TestPutInteractive() throws Exception {
+
+        // Given a PUT request with a bad json input
+        String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        String json = "{ \"state\": \"inProgress\"}";
+        mockRequestBody(json);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockInteractivesService, times(1)).updateInteractiveInCollection(mockCollection, resourceID, new CollectionInteractive(), user);
+    }
+
+    @Test
+    public void TestPutDatasetVersion() throws Exception {
+
+        // Given a PUT request with a valid URL for a dataset
+        String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
+                collectionID, resourceID, edition, version);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        String json = "{ \"state\": \"inProgress\"}";
+        mockRequestBody(json);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).updateDatasetVersionInCollection(
+                mockCollection, resourceID, edition, version, new CollectionDatasetVersion(), user);
+    }
+
+    @Test
+    public void TestDeleteDataset() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+
         shouldAuthorise(request, true);
 
         // When the delete method is called
         collections.delete(request, response);
 
-        // The expected response code is set on the response
-        verify(response, times(1)).setStatus(HttpStatus.SC_NOT_FOUND);
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).removeDatasetFromCollection(mockCollection, resourceID);
+    }
+
+    @Test
+    public void TestDeleteInteractive() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockInteractivesService, times(1)).removeInteractiveFromCollection(mockCollection, resourceID);
+    }
+
+    @Test
+    public void TestDeleteDatasetVersion() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
+                collectionID, resourceID, edition, version);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).removeDatasetVersionFromCollection(
+                mockCollection, resourceID, edition, version);
     }
 
     // mock the authorisation for the given request to authorise the request is the authorise param is true.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -12,6 +12,7 @@ import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactoryImpl;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
 import com.github.onsdigital.zebedee.reader.api.endpoint.Data;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.session.service.Sessions;
 import com.github.onsdigital.zebedee.user.service.UsersService;
@@ -63,6 +64,8 @@ public class ContentTest {
     UsersService mockUsersService;
     @Mock
     Notifier mockNotifier;
+    @Mock
+    InteractivesService interactivesService;
     Path tempBasePath;
 
     CollectionDescription collectionDescription;
@@ -85,7 +88,7 @@ public class ContentTest {
         versionsService = new VersionsServiceImpl();
 
         content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
-        collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
+        collections = new Collections(tempBasePath, mockPermissionsService, versionsService, interactivesService, content);
 
         when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
         when(mockPermissionsService.canView(any(), any())).thenReturn(true);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/CollectionDescriptionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/CollectionDescriptionTest.java
@@ -50,6 +50,46 @@ public class CollectionDescriptionTest {
     }
 
     @Test
+    public void testAddInteractive() throws Exception {
+
+        // Given a collection description and a CollectionDataset
+        CollectionDescription collection = new CollectionDescription();
+
+        CollectionInteractive interactive = new CollectionInteractive();
+        String id = "123";
+        interactive.setId(id);
+
+        // When a dataset is added
+        collection.addInteractive(interactive);
+
+        // Then the dataset is in the collection description
+        Optional<CollectionInteractive> optional = collection.getInteractive(id);
+        assertTrue(optional.isPresent());
+        assertTrue(collection.getInteractives().contains(interactive));
+    }
+
+    @Test
+    public void testRemoveInteractive() throws Exception {
+
+        // Given a collection description with a dataset
+        CollectionDescription collection = new CollectionDescription();
+
+        CollectionInteractive interactive = new CollectionInteractive();
+        String id = "123";
+        interactive.setId(id);
+
+        collection.addInteractive(interactive);
+
+        // When a dataset is removed
+        collection.removeInteractive(interactive);
+
+        // Then the dataset is in the collection description
+        Optional<CollectionInteractive> option = collection.getInteractive(id);
+        assertFalse(option.isPresent());
+        assertFalse(collection.getDatasets().contains(interactive));
+    }
+
+    @Test
     public void testAddDatasetVersion() throws Exception {
 
         // Given a collection description and a CollectionDatasetVersion

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -5,6 +5,7 @@ import com.github.davidcarboni.cryptolite.Random;
 import com.github.davidcarboni.restolino.json.Serialiser;
 import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.ZebedeeTestBaseFixture;
+import com.github.onsdigital.zebedee.configuration.CMSFeatureFlags;
 import com.github.onsdigital.zebedee.content.page.base.PageDescription;
 import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.content.page.release.Release;
@@ -1711,6 +1712,9 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
 
     @Test
     public void isAllContentReviewed_shouldReturnFalseWhenInteractiveNotReviewed() throws IOException, ZebedeeException {
+        System.setProperty(CMSFeatureFlags.ENABLE_INTERACTIVES_PUBLISHING, "true");
+        CMSFeatureFlags.reset();
+
         // Given a collection with an interactive that has not been set to reviewed.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
         Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -19,6 +19,7 @@ import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionInteractive;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.ContentDetail;
 import com.github.onsdigital.zebedee.json.ContentStatus;
@@ -1709,6 +1710,23 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
+    public void isAllContentReviewed_shouldReturnFalseWhenInteractiveNotReviewed() throws IOException, ZebedeeException {
+        // Given a collection with an interactive that has not been set to reviewed.
+        Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
+
+        CollectionInteractive interactive = new CollectionInteractive();
+        interactive.setState(ContentStatus.Complete);
+        collection.getDescription().addInteractive(interactive);
+
+        // When isAllContentReviewed() is called
+        boolean allContentReviewed = collection.isAllContentReviewed(true);
+
+        // Then the result is false
+        assertFalse(allContentReviewed);
+    }
+
+    @Test
     public void isAllContentReviewed_shouldReturnFalseWhenDatasetVersionNotReviewed() throws IOException, ZebedeeException {
             // Given a collection with a dataset version that has not been set to reviewed.
             Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
@@ -1744,7 +1762,25 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void isAllContentReviewed_shouldReturnTrueWhenDatasetVersionISReviewed() throws IOException, ZebedeeException {
+    public void isAllContentReviewed_shouldReturnTrueWhenInteractiveIsReviewed() throws IOException, ZebedeeException {
+
+        // Given a collection with an interactive that has been set to reviewed.
+        Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
+
+        CollectionInteractive interactive = new CollectionInteractive();
+        interactive.setState(ContentStatus.Reviewed);
+        collection.getDescription().addInteractive(interactive);
+
+        // When isAllContentReviewed() is called
+        boolean allContentReviewed = collection.isAllContentReviewed(false);
+
+        // Then the result is true
+        assertTrue(allContentReviewed);
+    }
+
+    @Test
+    public void isAllContentReviewed_shouldReturnTrueWhenDatasetVersionIsReviewed() throws IOException, ZebedeeException {
 
         // Given a collection with a dataset version that has been set to reviewed.
         Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
@@ -1782,6 +1818,29 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertEquals("/datasets/123", datasetDetail.uri);
         assertEquals(PageType.API_DATASET_LANDING_PAGE, datasetDetail.getType());
         assertEquals(dataset.getTitle(), datasetDetail.description.title);
+    }
+
+    @Test
+    public void getInteractiveDetails() throws IOException, ZebedeeException {
+
+        // Given a collection with a dataset.
+        Path collectionPath = Files.createTempDirectory(Random.id()); // create a temp directory to generate content into
+        Collection collection = CollectionTest.createCollection(collectionPath, "isAllContentReviewed");
+
+        CollectionInteractive interactive = new CollectionInteractive();
+        interactive.setUri("http://localhost:1234/interactives/123");
+        interactive.setTitle("title");
+        collection.getDescription().addInteractive(interactive);
+
+        // When getDatasetDetails() is called
+        List<ContentDetail> interactiveContent = collection.getInteractiveDetails();
+
+        // Then the expected values have been set
+        ContentDetail interactiveDetail = interactiveContent.get(0);
+
+        assertEquals("/interactives/123", interactiveDetail.uri);
+        assertEquals(PageType.INTERACTIVE, interactiveDetail.getType());
+        assertEquals(interactive.getTitle(), interactiveDetail.description.title);
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -21,6 +21,7 @@ import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.ZebedeeReader;
+import com.github.onsdigital.zebedee.service.InteractivesService;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.user.model.User;
 import com.github.onsdigital.zebedee.user.service.UsersService;
@@ -71,7 +72,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -104,6 +104,9 @@ public class CollectionsTest {
 
     @Mock
     private UsersService usersServiceMock;
+
+    @Mock
+    InteractivesService interactivesService;
 
     @Mock
     private Collection collectionMock;
@@ -160,7 +163,7 @@ public class CollectionsTest {
         collectionsPath = rootDir.newFolder("collections").toPath();
 
         // Test target.
-        collections = new Collections(collectionsPath, permissionsServiceMock, versionsService, publishedContentMock);
+        collections = new Collections(collectionsPath, permissionsServiceMock, versionsService, interactivesService, publishedContentMock);
 
         zebedeeSupplier = () -> zebedeeMock;
         publishingNotificationConsumer = (c, e) -> publishNotification.sendNotification(e);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/InteractivesServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/InteractivesServiceImplTest.java
@@ -1,0 +1,162 @@
+package com.github.onsdigital.zebedee.service;
+
+import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
+import com.github.onsdigital.dp.interactives.api.models.Interactive;
+import com.github.onsdigital.dp.interactives.api.models.InteractiveMetadata;
+import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.json.CollectionInteractive;
+import com.github.onsdigital.zebedee.json.ContentStatus;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InvalidObjectException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InteractivesServiceImplTest extends TestCase {
+
+    String id    = "12345";
+    String colId = "9876";
+    CollectionInteractive interactive = createColInteractive();
+    Interactive ix = createInteractive();
+
+    @Mock
+    Collection mockCollection;
+    @Mock
+    CollectionDescription mockCollectionDescription;
+    @Mock
+    InteractivesAPIClient mockApiClient;
+
+    @Test
+    public void testUpdateInteractiveSuccess() throws Exception {
+        
+        InteractiveMetadata md = new InteractiveMetadata();
+        ix.setURL("madeUpURL");
+        ix.setMetadata(md);
+        interactive.setId(colId);
+
+        when(mockCollectionDescription.getInteractive(id)).thenReturn(Optional.of(interactive));
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+        when(mockCollection.getId()).thenReturn(colId);
+        when(mockApiClient.getInteractive(id)).thenReturn(ix);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.updateInteractiveInCollection(mockCollection, id, interactive, "user");
+
+        // collection is linked/added and saved
+        verify(mockApiClient, times(1)).linkInteractiveToCollection(id, colId);
+        verify(mockCollectionDescription, times(1)).addInteractive(interactive);
+        verify(mockCollection, times(1)).save();
+    }
+
+    @Test(expected = InvalidObjectException.class)
+    public void testUpdateInteractiveWhenUnlinkedAndNoUrlThenThrowException() throws Exception {
+        
+        InteractiveMetadata md = new InteractiveMetadata();
+        md.setCollectionId("");
+        ix.setMetadata(md);
+
+        when(mockCollectionDescription.getInteractive(id)).thenReturn(Optional.of(interactive));
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+        when(mockApiClient.getInteractive(id)).thenReturn(ix);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.updateInteractiveInCollection(mockCollection, id, interactive, "user");
+    }
+
+    @Test(expected = ConflictException.class)
+    public void testUpdateInteractiveWhenWrongAssociationThenThrowException() throws Exception {
+        
+        when(mockCollectionDescription.getInteractive(id)).thenReturn(Optional.of(interactive));
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+        when(mockApiClient.getInteractive(id)).thenReturn(ix);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.updateInteractiveInCollection(mockCollection, id, interactive, "user");
+    }
+
+    @Test
+    public void testRemoveInteractiveWhenInteractiveNotFoundThenShouldNotInvoke() throws Exception {
+
+        when(mockCollectionDescription.getInteractive(id)).thenReturn(Optional.empty());
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.removeInteractiveFromCollection(mockCollection, id);
+
+        verify(mockApiClient, times(0)).deleteInteractive(id);
+    }
+
+    @Test
+    public void testRemoveInteractive() throws Exception {
+
+        when(mockCollectionDescription.getInteractive(id)).thenReturn(Optional.of(interactive));
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.removeInteractiveFromCollection(mockCollection, id);
+
+        verify(mockApiClient, times(1)).deleteInteractive(id);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWhenCollectionIdIsBlankIllegalArgumentIsThrown() throws Exception {
+
+        when(mockCollectionDescription.getId()).thenReturn("");
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.publishCollection(mockCollection);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWhenCollectionIdIsNullIllegalArgumentIsThrown() throws Exception {
+
+        when(mockCollectionDescription.getId()).thenReturn(null);
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.publishCollection(mockCollection);
+    }
+
+    @Test
+    public void testPublishCollectionWithCorrectCollectionID() {
+        String collectionID = "123456789";
+        when(mockCollectionDescription.getId()).thenReturn(collectionID);
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        InteractivesService service = new InteractivesServiceImpl(mockApiClient);
+        service.publishCollection(mockCollection);
+
+        verify(mockApiClient, times(1)).publishCollection(collectionID);
+    }
+
+    private CollectionInteractive createColInteractive()
+    {
+        CollectionInteractive ix = new CollectionInteractive();
+        ix.setId(id);
+        ix.setState(ContentStatus.Reviewed);
+        return ix;
+    }
+
+    private Interactive createInteractive()
+    {
+        Interactive ix = new Interactive();
+        ix.setId(id);
+        InteractiveMetadata md = new InteractiveMetadata();
+        md.setTitle("Title");
+        md.setCollectionId(colId);
+        ix.setMetadata(md);
+        return ix;
+    }
+}

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageType.java
@@ -73,6 +73,9 @@ public enum PageType {
     @SerializedName("static_adhoc")
     STATIC_ADHOC("Static adhoc page"),
 
+    @SerializedName("interactive")
+    INTERACTIVE("Interactive page"),
+
     @SerializedName("dataset")
     DATASET("Dataset page"),
 

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/search/indexing/Indexer.java
@@ -182,6 +182,10 @@ public class Indexer {
             if (page == null) {
                 throw new NotFoundException("Content not found for re-indexing, uri: " + uri);
             }
+            if (page.getType() == PageType.INTERACTIVE) {
+                return; //TODO implement expected behaviour here
+            }
+
             if (isPeriodic(page.getType())) {
                 //TODO: optimize resolving latest flag, only update elastic search for existing releases rather than reindexing
                 //Load old releases as well to get latest flag re-calculated


### PR DESCRIPTION
### What

Note: a squash/force to tidy and this PR also includes contributions from @nimitsarup 😊 

An `interactive` is a new type of "page" and this PR is to allow zebedee to handle the new type within a collections workflow similar to filterable datasets - from adding to a collection to publishing (this will hook into publish task and call interactives api to publish too).

Just for clarity - if you look in florence develop right now there is an `interactives` menu item - this will be dropped soon and the only entrypoint will be via a collection.

The florence UI (tbc) for interactives will make the relevant zebedee call for updating state - e.g.:

```
curl --location --request PUT 'http://localhost:8082/collections/collection2/interactives/28417c90-a3a2-40bc-bb16-2d408bbae58c' \
--header 'X-Florence-Token:' \
--header 'Content-Type: application/json' \
--data-raw '{
    "state": "Reviewed"
}'
```

Example of json collection:

```
"interactives": [
  {
    "id": "28417c90-a3a2-40bc-bb16-2d408bbae58c",
    "title": "title1",
    "state": "InProgress",
    "uri": "/interactives/lable-uPOPNJXf/embed",
    "lastEditedBy": "mryan321@gmail.com"
  },
  {
    "id": "40de0587-d6cf-4f3e-9827-4cc68a416ab7",
    "title": "title",
    "state": "InProgress",
    "uri": "/interactives/label-5vgbc4j9/embed",
    "lastEditedBy": "mryan321@gmail.com"
  }
]
```

### How to review

Sanity check - maybe pull and experiment

### Who can review

Ideally anyone with knowledge of zebedee
