### PR TITLE
Bump tika-core dependency for new sonar vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
                 <version>2.11.0</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.tika</groupId>
-                <artifactId>tika-core</artifactId>
-                <version>1.28.3</version>
-            </dependency>
-
             <!--Gson-->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -293,7 +287,7 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>1.27</version>
+                <version>1.28.3</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,7 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.11.0</version>
             </dependency>
-            <!--
-                can remove tika-core when commons-io bumps:
-                https://ossindex.sonatype.org/vulnerability/CVE-2021-34429?component-type=maven&component-name=org.eclipse.jetty%2Fjetty-http&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1
-            -->
+
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,15 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.11.0</version>
             </dependency>
+            <!--
+                can remove tika-core when commons-io bumps:
+                https://ossindex.sonatype.org/vulnerability/CVE-2021-34429?component-type=maven&component-name=org.eclipse.jetty%2Fjetty-http&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1
+            -->
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-core</artifactId>
+                <version>1.28.3</version>
+            </dependency>
 
             <!--Gson-->
             <dependency>


### PR DESCRIPTION
### What

Added `tika-core` dep for new sonar vuln reported:

```
[ERROR] Failed to execute goal org.sonatype.ossindex.maven:ossindex-maven-plugin:3.1.0:audit (default-cli) on project zebedee-reader: Detected 1 vulnerable components:
[ERROR]   org.apache.tika:tika-core:jar:1.27:compile; https://ossindex.sonatype.org/component/pkg:maven/org.apache.tika/tika-core@1.27?utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1
[ERROR]     * [CVE-2022-30973] We failed to apply the fix for CVE-2022-30126 to the 1.x branch in the 1.28.2 release. In Apache Tika, a regular expression in the StandardsText class, used by the StandardsExtractingContentHandler could lead to a denial of service caused by backtracking on a specially crafted file. This only affects users who are running the StandardsExtractingContentHandler, which is a non-standard handler. This is fixed in 1.28.3. (7.5); https://ossindex.sonatype.org/vulnerability/CVE-2022-30973?component-type=maven&component-name=org.apache.tika%2Ftika-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.1.1
```

### How to review

Check approach is ok

### Who can review

Anyone
