### PR TITLE
fix server error when getTeams returns null

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -412,9 +412,8 @@ public class Collection {
             scheduler.cancel(collection);
         }
 
-        Set<String> teamIds = setViewerTeams(collectionDescription, zebedee, session);
-
         if (collectionDescription.getTeams() != null) {
+            Set<String> teamIds = setViewerTeams(collectionDescription, zebedee, session);
             updatedCollection.getDescription().setTeams(collectionDescription.getTeams());
         }
 


### PR DESCRIPTION
### What

when editing a collection (e.g. publishDate), zebedee 500's
this is a NullPointerException caused by getTeams returning null
this PR should avoid that

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
