### PR TITLE
Add getters and setters

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DownloadSection.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/statistics/dataset/DownloadSection.java
@@ -46,4 +46,20 @@ public class DownloadSection extends Content {
     public void setFileDescription(String fileDescription) {
         this.fileDescription = fileDescription;
     }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
 }


### PR DESCRIPTION
### What

Add missing getters and setters. 

`url` and `version` were [added recently](https://github.com/ONSdigital/zebedee/pull/621) as private fields of this class without any accessor. Although they are effectively used via reflection, we should provide a way of accessing them and be consistent with the rest of the class.

### How to review

Sense check

### Who can review

Anyone
