### PR TITLE
Refactor Kafka notifications of published collections

### DIFF
--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PostPublisherTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PostPublisherTest.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.model.publishing;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertTrue;
@@ -31,5 +32,34 @@ public class PostPublisherTest {
 
         // Then the result should be false, ie, it should not be indexed.
         assertFalse(isIndexed);
+    }
+
+    @Test
+    public void testConvertUriWithJsonForEvent() {
+
+        //Given {a single uri with data.json ready to be sent to kafka}
+        String testUri = "/testUri0/data.json";
+
+        //When {sending a uris to kafka}
+        String actual = PostPublisher.convertUriForEvent(testUri);
+
+        System.out.println(actual);
+
+        //Then {uri does not have "data.json" string}
+        assertFalse(actual.contains("/testUri0/data.json"));
+        Assert.assertTrue(actual.contains("/testUri0"));
+    }
+
+    @Test
+    public void testConvertUriWithOutJsonForEvent() {
+
+        //Given {a single uri without data.json ready to be sent to kafka}
+        String testUri1 = "/testUri1";
+
+        //When {sending a uri to kafka}
+        String actual = PostPublisher.convertUriForEvent(testUri1);
+
+        //Then {uris returns the original string}
+        Assert.assertTrue(actual.contains("/testUri1"));
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PublisherTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PublisherTest.java
@@ -30,36 +30,6 @@ public class PublisherTest {
         this.publisher = new Publisher();
     }
 
-
-    @Test
-    public void testConvertUriWithJsonForEvent() {
-
-        //Given {a single uri with data.json ready to be sent to kafka}
-        String testUri = "/testUri0/data.json";
-
-        //When {sending a uris to kafka}
-        String actual = publisher.convertUriForEvent(testUri);
-
-        System.out.println(actual);
-
-        //Then {uri does not have "data.json" string}
-        assertFalse(actual.contains("/testUri0/data.json"));
-        assertTrue(actual.contains("/testUri0"));
-    }
-
-    @Test
-    public void testConvertUriWithOutJsonForEvent() {
-
-        //Given {a single uri without data.json ready to be sent to kafka}
-        String testUri1 = "/testUri1";
-
-        //When {sending a uri to kafka}
-        String actual = publisher.convertUriForEvent(testUri1);
-
-        //Then {uris returns the original string}
-        assertTrue(actual.contains("/testUri1"));
-    }
-
     @Test
     public void testisValidCMDDatasetURISuccess() {
 


### PR DESCRIPTION
### What

Move Kafka notifications of published collections from the Publisher to the PostPublisher, so that Zebedee is aware of the published collection (has moved it into its master folder) when the dp-search-data-extractor requests it (dp-search-data-extractor is triggered by the Kafka message)

### How to review

Review code and ensure all tests are passing

### Who can review

Anyone with knowledge of Zebedee
