### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <restolino.version>v0.4.2</restolino.version>
+        <restolino.version>0.4.2</restolino.version>
         <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
         <spring.version>5.3.20</spring.version>
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-cryptolite-java</artifactId>
-                <version>v1.5.0</version>
+                <version>1.5.0</version>
             </dependency>
 
             <!-- Any sub modules depending on Zebedee reader and content wrappers should depend on project version as all modules are released together under same version-->
@@ -263,7 +263,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-jwt-verifier-java</artifactId>
-                <version>v0.5.0</version>
+                <version>0.5.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
         <spring.version>5.3.20</spring.version>
-        <dp.logging.version>v2.0.0-beta</dp.logging.version>
+        <dp.logging.version>2.0.0-beta.3</dp.logging.version>
     </properties>
 
     <dependencyManagement>
@@ -105,12 +105,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${fasterxml.jackson.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-smile</artifactId>
                 <version>${fasterxml.jackson.version}</version>
@@ -125,12 +119,6 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-cbor</artifactId>
-                <version>${fasterxml.jackson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
 
@@ -263,7 +251,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-image-api-client-java</artifactId>
-                <version>0.1.0</version>
+                <version>0.1.1</version>
             </dependency>
 
             <dependency>
@@ -293,7 +281,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-dataset-api-java-client</artifactId>
-                <version>v1.1.0</version>
+                <version>1.2.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
         <restolino.version>v0.4.2</restolino.version>
-        <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.13.4</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
         <spring.version>5.3.20</spring.version>
         <dp.logging.version>v2.0.0-beta</dp.logging.version>
@@ -113,6 +113,18 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-smile</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
 
@@ -394,11 +406,6 @@
                             <artifactId>elasticsearch</artifactId>
                             <version>2.1.1</version>
                         </exlude>
-                        <exlude>
-                            <groupId>org.yaml</groupId>
-                            <artifactId>snakeyaml</artifactId>
-                            <version>1.15</version>
-                        </exlude>
                         <!-- End Trello #1717 -->
 
                         <!-- https://trello.com/c/xSwdnxm8 -->
@@ -413,11 +420,6 @@
                             <groupId>org.apache.lucene</groupId>
                             <artifactId>lucene-queryparser</artifactId>
                             <version>5.3.1</version>
-                        </exlude>
-                        <exlude>
-                            <groupId>com.fasterxml.jackson.dataformat</groupId>
-                            <artifactId>jackson-dataformat-cbor</artifactId>
-                            <version>2.6.2</version>
                         </exlude>
 
                     </excludeCoordinates>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -263,7 +263,7 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-interactives-api-client-java</artifactId>
-            <version>0.2.5</version>
+            <version>0.2.6</version>
         </dependency>
     </dependencies>
 

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-static-files-api-client-java</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
         </dependency>
 
         <dependency>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -107,11 +107,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
         </dependency>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -180,7 +180,6 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-jwt-verifier-java</artifactId>
-            <version>0.5.0</version>
         </dependency>
 
         <!-- Kafka -->
@@ -214,13 +213,26 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+        </dependency>
+
+        <!-- API Clients -->
+        <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-dataset-api-java-client</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi</artifactId>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-static-files-api-client-java</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-interactives-api-client-java</artifactId>
+            <version>0.2.6</version>
         </dependency>
 
         <!-- Test -->
@@ -254,17 +266,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-static-files-api-client-java</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-interactives-api-client-java</artifactId>
-            <version>0.2.6</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -1,9 +1,7 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.onsdigital</groupId>
     <artifactId>zebedee-reader</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>Zebedee Reader</name>
 
     <parent>


### PR DESCRIPTION
### What

- Bump `jackson` to latest version, removing vulnerability
- Add overrides for `jackson-dataformat-yaml` and `jackson-dataformat-cbor` to use latest version - transitive dependencies of `elasticsearch:2.1.1` 
- Remove audit exclusions no longer needed
- Remove unnecessary overrides of `jackson-annotations` and `jackson-databind`
- Bump `dp-image-api-client-java`, `dp-dataset-api-java-client`, `dp-interactives-api-client-java` and `dp-static-files-api-client-java` to latest version (which use latest `jackson`)
- Tidy pom: remove unnecessary properties, place api client dependencies together, and remove `v` version prefix

### How to review

Ensure changes make sense and tests and audit pass

### Who can review

Anyone