### PR TITLE
Add traceid kafka header to contentupdated topic

### DIFF
--- a/zebedee-cms/src/main/avro/message.avsc
+++ b/zebedee-cms/src/main/avro/message.avsc
@@ -6,7 +6,6 @@
    {"name": "data_type", "type": "string", "default": ""},
    {"name": "collection_id", "type": "string", "default": ""},
    {"name": "job_id", "type": "string", "default": ""},
-   {"name": "search_index", "type": "string", "default": ""},
-   {"name": "trace_id", "type": "string", "default": ""}
+   {"name": "search_index", "type": "string", "default": ""}
  ]
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/kafka/KafkaClientImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/kafka/KafkaClientImpl.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
@@ -59,8 +60,10 @@ public class KafkaClientImpl implements KafkaClient {
     @Override
     public Future<RecordMetadata> produceContentUpdated(String uri, String dataType, String collectionID,
             String jobId, String searchIndex, String traceID) {
-        ContentUpdated value = new ContentUpdated(uri, dataType, collectionID, jobId, searchIndex, traceID);
-        return producer.send(new ProducerRecord<>(topic, value));
+        ContentUpdated value = new ContentUpdated(uri, dataType, collectionID, jobId, searchIndex);
+        ProducerRecord<String, ContentUpdated> record = new ProducerRecord<>(topic, value);
+        record.headers().add(new RecordHeader("request-id", traceID.getBytes()));
+        return producer.send(record);
     }
 
 }


### PR DESCRIPTION
### What

This pr attempts to add traceid as kafka header to the ```contentupdated``` topic. This will then be consumed by the dp-search-exporter and dp-search-importer services. 

### How to review

Please check if the changes make sense. 

### Who can review

Anyone except me
