### PR TITLE
Return 204 on deletion of flexible dataset

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -170,7 +170,7 @@ public class Collections {
                             updateDatasetInCollection(collection, resourceID, request, user);
                             break;
 
-                        case 8: // /collections/{collection_id}/datasets/{dataset_id}/editions/{}/versions/{}
+                        case 8: // /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version}
 
                             String edition = pathSegments.get(5);
                             String version = pathSegments.get(7);
@@ -250,7 +250,7 @@ public class Collections {
                     case 4: // /collections/{collection_id}/datasets/{dataset_id}
                         removeDatasetFromCollection(collection, resourceID);
                         break;
-                    case 8: // /collections/{collection_id}/datasets/{dataset_id}/editions/{}/versions/{}
+                    case 8: // /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version}
                         String edition = pathSegments.get(5);
                         String version = pathSegments.get(7);
                         removeDatasetVersionFromCollection(collection, resourceID, edition, version);
@@ -285,7 +285,7 @@ public class Collections {
                 .data("edition", edition)
                 .data("version", version)
                 .data("user", user)
-                .log("PUT called on /collections/{}/datasets/{}/editions/{}/versions/{} endpoint");
+                .log("PUT called on /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version} endpoint");
 
         try (InputStream body = request.getInputStream()) {
 
@@ -302,7 +302,7 @@ public class Collections {
         info().data("collectionId", collection.getId())
                 .data("datasetId", datasetID)
                 .data("user", user)
-                .log("PUT called on /collections/{}/datasets/{} endpoint");
+                .log("PUT called on /collections/{collection_id}/datasets/{dataset_id} endpoint");
 
         try (InputStream body = request.getInputStream()) {
 
@@ -319,7 +319,7 @@ public class Collections {
         info().data("collectionId", collection.getId())
                 .data("interactiveId", interactiveID)
                 .data("user", user)
-                .log("PUT called on /collections/{}/interactives/{} endpoint");
+                .log("PUT called on /collections/{collection_id}/interactives/{interactive_id} endpoint");
 
         try (InputStream body = request.getInputStream()) {
 
@@ -336,7 +336,7 @@ public class Collections {
                 .data("datasetId", datasetID)
                 .data("edition", edition)
                 .data("version", version)
-                .log("DELETE called on /collections/{collection_id}/datasets/{}/editions/{}/versions/{} endpoint");
+                .log("DELETE called on /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version} endpoint");
 
         datasetService.removeDatasetVersionFromCollection(collection, datasetID, edition, version);
     }
@@ -345,7 +345,7 @@ public class Collections {
 
         info().data("collectionId", collection.getId())
                 .data("datasetId", datasetID)
-                .log("DELETE called on /collections/{collection_id}/datasets/{} endpoint");
+                .log("DELETE called on /collections/{collection_id}/datasets/{dataset_id} endpoint");
 
         datasetService.removeDatasetFromCollection(collection, datasetID);
     }
@@ -354,7 +354,7 @@ public class Collections {
 
         info().data("collectionId", collection.getId())
                 .data("interactiveId", interactiveID)
-                .log("DELETE called on /collections/{collection_id}/interactiveID/{} endpoint");
+                .log("DELETE called on /collections/{collection_id}/interactives/{interactive_id} endpoint");
 
         interactivesService.removeInteractiveFromCollection(collection, interactiveID);
     }
@@ -362,7 +362,7 @@ public class Collections {
     private boolean isValidPath(HttpServletResponse response, Path path, List<String> segments) {
 
         // /collections/{collection_id}/datasets/{dataset_id}
-        // /collections/{collection_id}/datasets/{dataset_id}/editions/{}/versions/{}
+        // /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version}
         if (segments.size() < 4) {
             info().data("path", path).log("Endpoint for collections not found");
             response.setStatus(HttpStatus.SC_NOT_FOUND);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -249,28 +249,26 @@ public class Collections {
                 switch (pathSegments.size()) {
                     case 4: // /collections/{collection_id}/datasets/{dataset_id}
                         removeDatasetFromCollection(collection, resourceID);
+                        response.setStatus(HttpStatus.SC_NO_CONTENT);
                         break;
                     case 8: // /collections/{collection_id}/datasets/{dataset_id}/editions/{edition}/versions/{version}
                         String edition = pathSegments.get(5);
                         String version = pathSegments.get(7);
                         removeDatasetVersionFromCollection(collection, resourceID, edition, version);
+                        response.setStatus(HttpStatus.SC_NO_CONTENT);
                         break;
                     default:
                         response.setStatus(HttpStatus.SC_NOT_FOUND);
-                        return;
                 }
                 break;
             case "interactives":
                 switch (pathSegments.size()) {
                     case 4: // /collections/{collection_id}/interactives/{interactive_id}
-
                         removeInteractiveFromCollection(collection, resourceID);
                         response.setStatus(HttpStatus.SC_NO_CONTENT);
                         break;
-
                     default:
                         response.setStatus(HttpStatus.SC_NOT_FOUND);
-                        return;
                 }
                 break;
             default:

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -351,8 +351,10 @@ public class CollectionsTest {
     @Test
     public void testPutInteractiveInvalidPathSize() throws Exception {
 
-        // Given a PUT request with a bad json input
-        String url = String.format("/collections/%s/interactives/%s/more", collectionID, resourceID);
+        // Given a PUT request with an invalid interactives URL
+        String url = String.format("/collections/%s/interactives/%s/editions/%s/versions/%s",
+                collectionID, resourceID, edition, version);
+        when(request.getPathInfo()).thenReturn(url);
         when(request.getPathInfo()).thenReturn(url);
         when(session.getEmail()).thenReturn(user);
 
@@ -434,9 +436,9 @@ public class CollectionsTest {
     @Test
     public void testDeleteInteractiveInvalidPathSize() throws Exception {
 
-        // Given a DELETE request with a valid URL
-        String url = String.format("/collections/%s/interactives/%s/more",
-                collectionID, resourceID, edition);
+        // Given a DELETE request with an invalid interactives URL
+        String url = String.format("/collections/%s/interactives/%s/editions/%s/versions/%s",
+                collectionID, resourceID, edition, version);
         when(request.getPathInfo()).thenReturn(url);
 
         shouldAuthorise(request, true);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -77,7 +77,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPut_Forbidden() throws Exception {
+    public void testPut_Forbidden() throws Exception {
 
         // Given a PUT request with a valid URL
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
@@ -93,7 +93,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDelete_Forbidden() throws Exception {
+    public void testDelete_Forbidden() throws Exception {
 
         // Given a delete request with a valid URL
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
@@ -109,7 +109,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPut_CollectionNotFound() throws Exception {
+    public void testPut_CollectionNotFound() throws Exception {
 
         // Given a collection ID that does not exist
         when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(null);
@@ -126,7 +126,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDelete_CollectionNotFound() throws Exception {
+    public void testDelete_CollectionNotFound() throws Exception {
 
         // Given a collection ID that does not exist
         when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(null);
@@ -143,7 +143,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPut_SessionNotFound() throws Exception {
+    public void testPut_SessionNotFound() throws Exception {
         // Given a session that does not exist
         when(mockZebedeeCmsService.getSession()).thenReturn(null);
 
@@ -155,7 +155,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDelete_SessionNotFound() throws Exception {
+    public void testDelete_SessionNotFound() throws Exception {
 
         // Given a session that does not exist
         when(mockZebedeeCmsService.getSession()).thenReturn(null);
@@ -168,7 +168,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPut_ReturnBadRequest_URLSegments() throws Exception {
+    public void testPutReturnBadRequestURLSegments() throws Exception {
 
         shouldAuthorise(request, true);
 
@@ -179,12 +179,17 @@ public class CollectionsTest {
         // When the put method is called
         collections.put(request, response);
 
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+        // The interactives service is not called
+        verifyNoInteractions(mockInteractivesService);
+
         // Then a HTTP 404 is set on the response.
         verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
-    public void TestDelete_ReturnBadRequest_URLSegments() throws Exception {
+    public void testDeleteReturnBadRequestURLSegments() throws Exception {
 
         shouldAuthorise(request, true);
 
@@ -196,12 +201,17 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+        // The interactives service is not called
+        verifyNoInteractions(mockInteractivesService);
+
         // Then a HTTP 404 is set on the response.
         verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
-    public void TestPut_ReturnBadRequest_NotValidEndpoint() throws Exception {
+    public void testPut_ReturnBadRequest_NotValidEndpoint() throws Exception {
 
         shouldAuthorise(request, true);
 
@@ -217,7 +227,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDelete_ReturnBadRequest_NotValidEndpoint() throws Exception {
+    public void testDeleteReturnBadRequestNotValidEndpoint() throws Exception {
 
         shouldAuthorise(request, true);
 
@@ -228,12 +238,17 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+        // The interactives service is not called
+        verifyNoInteractions(mockInteractivesService);
+
         // Then a HTTP 404 is set on the response.
         verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
-    public void TestPutDataset_EmptyJSON() throws Exception {
+    public void testPutDataset_EmptyJSON() throws Exception {
 
         // Given a PUT request with a bad json input
         String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
@@ -252,7 +267,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPutInteractive_EmptyJSON() throws Exception {
+    public void testPutInteractive_EmptyJSON() throws Exception {
 
         // Given a PUT request with a bad json input
         String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
@@ -271,7 +286,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPutDataset() throws Exception {
+    public void testPutDataset() throws Exception {
 
         // Given a PUT request with a valid URL for a dataset
         String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
@@ -291,7 +306,30 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPutInteractive() throws Exception {
+    public void testPutDatasetInvalidPathSize() throws Exception {
+
+        // Given a PUT request with a valid URL for a dataset
+        String url = String.format("/collections/%s/datasets/%s/more", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        String json = "{ \"state\": \"inProgress\"}";
+        mockRequestBody(json);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+
+        // Then a HTTP 404 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testPutInteractive() throws Exception {
 
         // Given a PUT request with a bad json input
         String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
@@ -311,7 +349,30 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestPutDatasetVersion() throws Exception {
+    public void testPutInteractiveInvalidPathSize() throws Exception {
+
+        // Given a PUT request with a bad json input
+        String url = String.format("/collections/%s/interactives/%s/more", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(session.getEmail()).thenReturn(user);
+
+        String json = "{ \"state\": \"inProgress\"}";
+        mockRequestBody(json);
+
+        shouldAuthorise(request, true);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // The dataset service is not called
+        verifyNoInteractions(mockInteractivesService);
+
+        // Then a HTTP 404 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testPutDatasetVersion() throws Exception {
 
         // Given a PUT request with a valid URL for a dataset
         String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
@@ -333,7 +394,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void TestDeleteDataset() throws Exception {
+    public void testDeleteDataset() throws Exception {
 
         // Given a DELETE request with a valid URL
         String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
@@ -346,10 +407,13 @@ public class CollectionsTest {
 
         // The dataset service is called with the values extracted from the request URL.
         verify(mockDatasetService, times(1)).removeDatasetFromCollection(mockCollection, resourceID);
+
+        // Then a HTTP 204 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
     }
 
     @Test
-    public void TestDeleteInteractive() throws Exception {
+    public void testDeleteInteractive() throws Exception {
 
         // Given a DELETE request with a valid URL
         String url = String.format("/collections/%s/interactives/%s", collectionID, resourceID);
@@ -362,10 +426,30 @@ public class CollectionsTest {
 
         // The dataset service is called with the values extracted from the request URL.
         verify(mockInteractivesService, times(1)).removeInteractiveFromCollection(mockCollection, resourceID);
+
+        // Then a HTTP 204 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
     }
 
     @Test
-    public void TestDeleteDatasetVersion() throws Exception {
+    public void testDeleteInteractiveInvalidPathSize() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/interactives/%s/more",
+                collectionID, resourceID, edition);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // Then a HTTP 404 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void testDeleteDatasetVersion() throws Exception {
 
         // Given a DELETE request with a valid URL
         String url = String.format("/collections/%s/datasets/%s/editions/%s/versions/%s",
@@ -380,6 +464,29 @@ public class CollectionsTest {
         // The dataset service is called with the values extracted from the request URL.
         verify(mockDatasetService, times(1)).removeDatasetVersionFromCollection(
                 mockCollection, resourceID, edition, version);
+
+        // Then a HTTP 204 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testDeleteDatasetVersionInvalidPathSize() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/datasets/%s/editions/%s/versions",
+                collectionID, resourceID, edition);
+        when(request.getPathInfo()).thenReturn(url);
+
+        shouldAuthorise(request, true);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+
+        // Then a HTTP 404 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
     }
 
     // mock the authorisation for the given request to authorise the request is the authorise param is true.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class CollectionsTest {
@@ -407,11 +408,14 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockDatasetService, times(1)).removeDatasetFromCollection(mockCollection, resourceID);
-
         // Then a HTTP 204 is set on the response
         verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
+
+        // The dataset service is called with the values extracted from the request URL.
+        verify(mockDatasetService, times(1)).removeDatasetFromCollection(mockCollection, resourceID);
+        verifyNoMoreInteractions(mockDatasetService);
+        // No calls to the interactives service
+        verifyNoInteractions(mockInteractivesService);
     }
 
     @Test
@@ -426,11 +430,14 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
-        // The dataset service is called with the values extracted from the request URL.
-        verify(mockInteractivesService, times(1)).removeInteractiveFromCollection(mockCollection, resourceID);
-
         // Then a HTTP 204 is set on the response
         verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
+
+        // The interactives service is called with the values extracted from the request URL.
+        verify(mockInteractivesService, times(1)).removeInteractiveFromCollection(mockCollection, resourceID);
+        verifyNoMoreInteractions(mockInteractivesService);
+        // No calls to the dataset service
+        verifyNoInteractions(mockDatasetService);
     }
 
     @Test
@@ -448,6 +455,11 @@ public class CollectionsTest {
 
         // Then a HTTP 404 is set on the response
         verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+        // No calls to the interactives service
+        verifyNoInteractions(mockInteractivesService);
     }
 
     @Test
@@ -463,12 +475,16 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
+        // Then a HTTP 204 is set on the response
+        verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
+
         // The dataset service is called with the values extracted from the request URL.
         verify(mockDatasetService, times(1)).removeDatasetVersionFromCollection(
                 mockCollection, resourceID, edition, version);
 
-        // Then a HTTP 204 is set on the response
-        verify(response).setStatus(HttpStatus.SC_NO_CONTENT);
+        verifyNoMoreInteractions(mockDatasetService);
+        // No calls to the interactives service
+        verifyNoInteractions(mockInteractivesService);
     }
 
     @Test
@@ -484,11 +500,13 @@ public class CollectionsTest {
         // When the delete method is called
         collections.delete(request, response);
 
-        // The dataset service is not called
-        verifyNoInteractions(mockDatasetService);
-
         // Then a HTTP 404 is set on the response
         verify(response).setStatus(HttpStatus.SC_NOT_FOUND);
+
+        // The dataset service is not called
+        verifyNoInteractions(mockDatasetService);
+        // No calls to the interactives service
+        verifyNoInteractions(mockInteractivesService);
     }
 
     // mock the authorisation for the given request to authorise the request is the authorise param is true.


### PR DESCRIPTION
### What

There is an issue in Florence while parsing the response of the DELETE request for flexible datasets (CMD or Cantabular). It results in an error displayed to the user despite the files having been removed successfully. The DELETE endpoint should return 204 (No content) as it is not returning anything and prevent Florence from trying to parse the body response.

Also amend some log messages and refactor the `isValidPath` private method to simplify the logic.

### How to review

Check changes make sense and tests pass

### Who can review

Anyone