### PR TITLE
Delete interactives from collection even if not found in API

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInteractive.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionInteractive.java
@@ -3,7 +3,7 @@ package com.github.onsdigital.zebedee.json;
 import java.util.Date;
 
 /**
- * Represents a dataset that has been added to a collection.
+ * Represents an interactive that has been added to a collection.
  */
 public class CollectionInteractive {
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesService.java
@@ -3,19 +3,41 @@ package com.github.onsdigital.zebedee.service;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionInteractive;
 import com.github.onsdigital.zebedee.model.Collection;
-import dp.api.dataset.exception.DatasetAPIException;
 
 import java.io.IOException;
 
 /**
- * Provides high level dataset functionality
+ * Provides high level interactives functionality
  */
 public interface InteractivesService {
 
     /**
-     * Update a dataset for the given ID to the collection for the given collectionID.
+     * Update an interactive for the given collection.
+     * 
+     * @param collection         The collection
+     * @param id                 The interactive id
+     * @param updatedInteractive The new interactive object
+     * @param user               The user performing the action
+     * @return The new amended interactive object
+     * @throws ZebedeeException
+     * @throws IOException
      */
-    CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException, RuntimeException;
-    void removeInteractiveFromCollection(Collection collection, String interactiveID) throws IOException, RuntimeException;
-    void publishCollection(Collection collection) throws RuntimeException;
+    CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException;
+
+    /**
+     * Remove an interactive from the given collection
+     * 
+     * @param collection    The collection
+     * @param interactiveID The interactive id
+     * @throws ZebedeeException If an error occurs in the interactives api
+     * @throws IOException      If an error occurs while saving the collection state
+     */
+    void removeInteractiveFromCollection(Collection collection, String id) throws ZebedeeException, IOException;
+
+    /**
+     * Notify the interactives api of a collection publication
+     * 
+     * @param collection The collection
+     */
+    void publishCollection(Collection collection);
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
@@ -1,10 +1,12 @@
 package com.github.onsdigital.zebedee.service;
 
 import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
+import com.github.onsdigital.dp.interactives.api.exceptions.NoInteractivesInCollectionException;
 import com.github.onsdigital.dp.interactives.api.models.Interactive;
 import com.github.onsdigital.dp.interactives.api.models.InteractiveHTMLFile;
 import com.github.onsdigital.dp.interactives.api.models.InteractiveMetadata;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionInteractive;
 import com.github.onsdigital.zebedee.json.CollectionInteractiveFile;
@@ -15,16 +17,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.util.Arrays;
 
 import java.io.IOException;
-import java.io.InvalidObjectException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.warn;
 
 /**
- * Dataset related services
+ * Interactives related services
  */
 public class InteractivesServiceImpl implements InteractivesService {
 
@@ -34,11 +37,8 @@ public class InteractivesServiceImpl implements InteractivesService {
         this.interactivesClient = interactivesClient;
     }
 
-    /**
-     * Add the dataset for the given datasetID to the collection for the collectionID.
-     */
     @Override
-    public CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException, RuntimeException {
+    public CollectionInteractive updateInteractiveInCollection(Collection collection, String id, CollectionInteractive updatedInteractive, String user) throws ZebedeeException, IOException {
 
         CollectionInteractive collectionInteractive;
 
@@ -81,7 +81,7 @@ public class InteractivesServiceImpl implements InteractivesService {
                 info().data("collectionId", collection.getDescription().getId())
                         .data("interactiveId", id)
                         .log("The interactive URL has not been set");
-                throw new InvalidObjectException("The interactive URL has not been set on the dataset response");
+                throw new InternalServerError("The interactive URL has not been set on the interactive response");
             }
 
             if (notAssociatedYet) {
@@ -105,7 +105,7 @@ public class InteractivesServiceImpl implements InteractivesService {
     }
 
     @Override
-    public void removeInteractiveFromCollection(Collection collection, String interactiveID) throws IOException, RuntimeException {
+    public void removeInteractiveFromCollection(Collection collection, String interactiveID) throws ZebedeeException, IOException {
 
         // if its not in the collection then just return.
         Optional<CollectionInteractive> existingInteractive = collection.getDescription().getInteractive(interactiveID);
@@ -115,8 +115,15 @@ public class InteractivesServiceImpl implements InteractivesService {
 
         try {
             interactivesClient.deleteInteractive(interactiveID);
+        } catch (NoInteractivesInCollectionException e) {
+            warn().data("collectionId", collection.getDescription().getId())
+                .data("interactiveId", interactiveID)
+                .log("Interactives api could not find interactive. Deleting it from collection.");
         } catch (Exception e) {
-            throw e;
+            error().data("collectionId", collection.getDescription().getId())
+                .data("interactiveId", interactiveID)
+                .log(e.getMessage());
+            throw new InternalServerError(e.getMessage(), e);
         }
 
         collection.getDescription().removeInteractive(existingInteractive.get());


### PR DESCRIPTION
### What

If an interactive does not exist in database, the API returns `NoInteractivesInCollectionException` and we can't proceed removing it from the collection. 

Handle this exception so that we log a message but continue and delete the link to the interactive from the collection.
This scenario should not happen but it is currently preventing deletion of collections in sandbox where we have been messing with the data.

### How to review

Ensure changes make sense and there is test coverage and tests pass

### Who can review

Anyone, but probably @nimitsarup is the one who knows best this area of zebedee
