### PR TITLE
Ensure PDF is generated for both languages

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/CollectionDetails.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.api;
 
 import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.zebedee.content.base.ContentLanguage;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDetail;
 import com.github.onsdigital.zebedee.json.ContentDetail;
@@ -135,16 +136,11 @@ public class CollectionDetails {
     ) {
 
         for (ContentDetail contentDetail : detailsToAddEventsFor) {
-            String language = contentDetail.description.language;
-            if (language == null) {
-                language = "";
-            } else {
-                language = "_" + contentDetail.description.language;
-            }
             if (collection.getDescription().getEventsByUri() != null) {
+                ContentLanguage language = contentDetail.getDescription().getLanguage();
                 Events eventsForFile = collection.getDescription()
                         .getEventsByUri()
-                        .get(contentDetail.uri + "/data" + language + ".json");
+                        .get(contentDetail.uri + "/" + language.getDataFileName());
                 contentDetail.events = eventsForFile;
             } else {
                 contentDetail.events = new Events();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetail.java
@@ -205,8 +205,33 @@ public class ContentDetail {
     public void setDeleteMarker(boolean hasDeleteMarker) {
         this.deleteMarker = hasDeleteMarker;
     }
-    
+
     public PageType getType() {
         return type;
     }
+
+    public String getContentPath() {
+        return contentPath;
+    }
+
+    public void setContentPath(String contentPath) {
+        this.contentPath = contentPath;
+    }
+
+    public ContentDetailDescription getDescription() {
+        return description;
+    }
+
+    public void setDescription(ContentDetailDescription description) {
+        this.description = description;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
 }
+

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetailDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentDetailDescription.java
@@ -1,12 +1,14 @@
 package com.github.onsdigital.zebedee.json;
 
+import com.github.onsdigital.zebedee.content.base.ContentLanguage;
+
 /**
  * ContentDetail sub class that holds the title of the page.
  */
 public class ContentDetailDescription {
     public String title;
     public String edition;
-    public String language;
+    private ContentLanguage language;
 
     public ContentDetailDescription(String title) {
         this.title = title;
@@ -42,11 +44,11 @@ public class ContentDetailDescription {
         return this;
     }
 
-    public String getLanguage() {
+    public ContentLanguage getLanguage() {
         return language;
     }
 
-    public ContentDetailDescription setLanguage(String language) {
+    public ContentDetailDescription setLanguage(ContentLanguage language) {
         this.language = language;
         return this;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Content.java
@@ -358,8 +358,10 @@ public class Content {
             for (Path entry : stream) {
                 if (!Files.isDirectory(entry)) {
                     Path relative = this.path.relativize(entry);
-                    if (!relative.toString().toLowerCase().endsWith(".ds_store")) // issue when in development on Mac's
+                    if (!relative.toString().toLowerCase().endsWith(".ds_store")) {
+                        // issue when in development on Mac's
                         result.add(relative);
+                    }
                 }
             }
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/ContentDetailUtil.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.util;
 
+import com.github.onsdigital.zebedee.content.base.ContentLanguage;
 import com.github.onsdigital.zebedee.content.page.base.Page;
 import com.github.onsdigital.zebedee.content.page.statistics.document.figure.chart.Chart;
 import com.github.onsdigital.zebedee.content.page.statistics.document.figure.image.Image;
@@ -48,9 +49,10 @@ public class ContentDetailUtil {
 
                 if (page != null) { //Contents without type is null when deserialised. There should not be no such data
                     ContentDetail contentDetail = new ContentDetail(page.getDescription().getTitle(), page.getUri().toString(), page.getType());
-                    contentDetail.contentPath = page.getUri().toString();
-                    contentDetail.description.edition = page.getDescription().getEdition();
-                    contentDetail.description.language = page.getDescription().getLanguage();
+                    contentDetail.setContentPath(page.getUri().toString());
+                    contentDetail.getDescription().setEdition(page.getDescription().getEdition());
+                    ContentLanguage lang = ContentLanguage.getById(page.getDescription().getLanguage()).orElse(ContentLanguage.ENGLISH);
+                    contentDetail.getDescription().setLanguage(lang);
                     details.add(contentDetail);
                 }
             }

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/base/ContentLanguage.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/base/ContentLanguage.java
@@ -1,5 +1,6 @@
 package com.github.onsdigital.zebedee.content.base;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public enum ContentLanguage {
@@ -7,8 +8,8 @@ public enum ContentLanguage {
 
     private final static String DATA_FILE_NAME = "data%s.json";
 
-    public static ContentLanguage getById(final String id) {
-        return Stream.of(ContentLanguage.values()).filter(l -> l.getId().equalsIgnoreCase(id)).findAny().get();
+    public static Optional<ContentLanguage> getById(final String id) {
+        return Stream.of(ContentLanguage.values()).filter(l -> l.getId().equalsIgnoreCase(id)).findAny();
     }
 
     private final String id;

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderRequestUtils.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/util/ReaderRequestUtils.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -28,17 +27,8 @@ public class ReaderRequestUtils {
      */
     public static ContentLanguage getRequestedLanguage(HttpServletRequest request) {
         String lang = request.getParameter("lang");
-        if (lang == null) {
-            return null;
-        }
-
-        try {
-            return ContentLanguage.getById(lang);
-        } catch (NoSuchElementException e) {
-            return null;
-        }
+        return ContentLanguage.getById(lang).orElse(null);
     }
-
 
     /**
      * Extracts the filter requested to be applied to content. Each request should have at most one filter, otherwise first filter found will be applied

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/content/base/ContentLanguageTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/content/base/ContentLanguageTest.java
@@ -2,7 +2,7 @@ package com.github.onsdigital.zebedee.content.base;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -10,17 +10,27 @@ public class ContentLanguageTest {
 
     @Test
     public void testGetByIdEnglish() {
-        assertEquals(ContentLanguage.ENGLISH, ContentLanguage.getById("en"));
+        assertEquals(Optional.of(ContentLanguage.ENGLISH), ContentLanguage.getById("en"));
     }
 
     @Test
     public void testGetByIdWelsh() {
-        assertEquals(ContentLanguage.WELSH, ContentLanguage.getById("cy"));
+        assertEquals(Optional.of(ContentLanguage.WELSH), ContentLanguage.getById("cy"));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testGetByIdUnknown() {
-        ContentLanguage.getById("sc");
+        assertEquals(Optional.empty(), ContentLanguage.getById("sc"));
+    }
+
+    @Test
+    public void testGetByIdEmpty() {
+        assertEquals(Optional.empty(), ContentLanguage.getById(""));
+    }
+
+    @Test
+    public void testGetByIdNull() {
+        assertEquals(Optional.empty(), ContentLanguage.getById(null));
     }
 
     @Test

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/util/ReaderRequestUtilsTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/util/ReaderRequestUtilsTest.java
@@ -1,0 +1,53 @@
+package com.github.onsdigital.zebedee.reader.util;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.github.onsdigital.zebedee.content.base.ContentLanguage;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReaderRequestUtilsTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    public void getRequestedLanguageEnglish() throws Exception {
+        when(request.getParameter("lang")).thenReturn("en");
+        assertThat(ReaderRequestUtils.getRequestedLanguage(request), equalTo(ContentLanguage.ENGLISH));
+    }
+
+    @Test
+    public void getRequestedLanguageWelshh() throws Exception {
+        when(request.getParameter("lang")).thenReturn("cy");
+        assertThat(ReaderRequestUtils.getRequestedLanguage(request), equalTo(ContentLanguage.WELSH));
+    }
+
+    @Test
+    public void getRequestedLanguageInvalid() throws Exception {
+        when(request.getParameter("lang")).thenReturn("sv");
+        assertThat(ReaderRequestUtils.getRequestedLanguage(request), is(nullValue()));
+    }
+
+    @Test
+    public void getRequestedLanguageEmpty() throws Exception {
+        when(request.getParameter("lang")).thenReturn("");
+        assertThat(ReaderRequestUtils.getRequestedLanguage(request), is(nullValue()));
+    }
+
+    @Test
+    public void getRequestedLanguageMissing() throws Exception {
+        when(request.getParameter("lang")).thenReturn(null);
+        assertThat(ReaderRequestUtils.getRequestedLanguage(request), is(nullValue()));
+    }
+}


### PR DESCRIPTION
### What

Fix a bug on the generation of the PDFs where the English version is not created, but the Welsh version is.

It turns out the code finds the json files from disk expecting the English one (data.json) to appear before the Welsh (data_cy.json). Since there is only one entry for that URI independently of the language, the generator tries to create the Welsh version ONLY when it sees it is English (appearing before in the list of files means it goes in the Set first, and then it skips the Welsh addition - the equals method only checks URI). If it found a Welsh content, it assumed there was no English and no further generation was made.

The order can not be guaranteed and it currently fails in our development environment, although works as expected in prod!

We now always check if a json for the other language exists (independently of the language) and generate its PDF if so

See also https://github.com/ONSdigital/zebedee/pull/653

### How to review
- Create a collection in Florence containing a page with both English and Welsh content.
- Approve the collection
- Check that both `page.pdf` and `page_cy.pdf` have been generated in the relevant collection folder. (Before this fix only `page_cy.pdf` was generated but note this is dependant of the environment and it might not be an issue locally - it isn't for mine!)

### Who can review

Anyone
