### PR TITLE
Review the exceptions for changing content status 

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentStatusUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/ContentStatusUtils.java
@@ -15,23 +15,26 @@ public class ContentStatusUtils {
     public static ContentStatus updatedStateInCollection(ContentStatus currentState, ContentStatus newState, String lastEditedBy, String user) throws ForbiddenException, BadRequestException {
 
         Objects.requireNonNull(newState);
+        
+        if (currentState == null) {
+            switch (newState) {
+            case Reviewed:
+                info().data("last edited by", lastEditedBy)
+                        .data("user", user)
+                        .log("Attempt to review a resource that hasn't been submitted for review");
 
-        if (currentState == null && newState.equals(ContentStatus.Reviewed)) {
-            info().data("last edited by", lastEditedBy).data("user", user)
-                    .log("Attempt to review a resource that hasn't been submitted for review");
+                throw new BadRequestException("Cannot be reviewed without being submitted for review first");
+            case InProgress:
+            case Complete:
+                // Updating from scratch to 'in progress' or 'complete' state so don't need to perform following checks
+                info().data("user", user)
+                        .data("last edited by", lastEditedBy)
+                        .data("current state", currentState)
+                        .data("new state", newState)
+                        .log("Updating resource state for first time");
 
-            throw new BadRequestException("Cannot be reviewed without being submitted for review first");
-        }
-
-        // Updating from scratch to 'in progress' or 'complete' state so don't need to perform following checks
-        if (currentState == null && (newState.equals(ContentStatus.InProgress) || newState.equals(ContentStatus.Complete))) {
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("Updating resource state for first time");
-
-            return newState;
+                return newState;
+            }
         }
 
         // Can't skip the Complete state
@@ -45,37 +48,35 @@ public class ContentStatusUtils {
             throw new ForbiddenException("Can't approve a resource in progress");
         }
 
-        // The same user can't review edits they've submitted for review
-        if (currentState.equals(ContentStatus.Complete) && newState.equals(ContentStatus.Reviewed) && lastEditedBy.equalsIgnoreCase(user)) {
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("User attempting to review their own resource");
+        if (currentState.equals(ContentStatus.Complete)) {
+            if (lastEditedBy.equalsIgnoreCase(user)) {
+                if (newState.equals(ContentStatus.Reviewed)) {
+                    // The same user can't review edits they've submitted for review
+                    info().data("user", user)
+                            .data("last edited by", lastEditedBy)
+                            .data("current state", currentState)
+                            .data("new state", newState)
+                            .log("User attempting to review their own resource");
 
-            throw new ForbiddenException("User " + user + "doesn't have permission to review a resource they completed");
-        }
-
-        // Any further updates made by the user who submitted the dataset should keep the dataset in the awaiting review state
-        if (currentState.equals(ContentStatus.Complete) && lastEditedBy.equalsIgnoreCase(user)) {
-
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("User making more updates to a resource whilst it is awaiting review");
-            return ContentStatus.Complete;
-        }
-
-        // Any updates to a dataset awaiting review by a different user means it moves back to an in progress state
-        if (currentState.equals(ContentStatus.Complete) && !newState.equals(ContentStatus.Reviewed) && !lastEditedBy.equalsIgnoreCase(user)) {
-
-            info().data("user", user)
-                    .data("last edited by", lastEditedBy)
-                    .data("current state", currentState)
-                    .data("new state", newState)
-                    .log("A different user making updates to a resource whilst it is awaiting review");
-            return ContentStatus.InProgress;
+                    throw new ForbiddenException("User " + user + "doesn't have permission to review a resource they completed");
+                } else {
+                    // Any further updates made by the user who submitted the dataset should keep the dataset in the awaiting review state
+                    info().data("user", user)
+                            .data("last edited by", lastEditedBy)
+                            .data("current state", currentState)
+                            .data("new state", newState)
+                            .log("User making more updates to a resource whilst it is awaiting review");
+                    return ContentStatus.Complete;
+                }
+            } else if (newState.equals(ContentStatus.InProgress) || newState.equals(ContentStatus.Complete)) {
+                // Any updates to a dataset awaiting review by a different user means it moves back to an in progress state
+                info().data("user", user)
+                        .data("last edited by", lastEditedBy)
+                        .data("current state", currentState)
+                        .data("new state", newState)
+                        .log("A different user making updates to a resource whilst it is awaiting review");
+                return ContentStatus.InProgress;
+            }
         }
 
         info().data("user", user)

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ContentStatusUtilsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/ContentStatusUtilsTest.java
@@ -1,0 +1,307 @@
+package com.github.onsdigital.zebedee.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.json.ContentStatus;
+
+public class ContentStatusUtilsTest {
+    private static final String ALICE = "alice";
+    private static final String BOB = "bob";
+
+    @Test(expected = NullPointerException.class)
+    public void testUpdatedStateInCollectionNullNewState() throws Exception {
+        ContentStatus currentStatus = null;
+        ContentStatus newStatus = null;
+        String user = ALICE;
+        String lastEditedBy = null;
+
+        ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user);
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInitialToInProgress() throws Exception {
+        ContentStatus currentStatus = null;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = null;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInitialToComplete() throws Exception {
+        ContentStatus currentStatus = null;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = null;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdatedStateInCollectionInitialToReviewed() throws Exception {
+        ContentStatus currentStatus = null;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = null;
+
+        // Can't go straight to reviewed: expect an exception
+        ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user);
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInProgressToInProgressSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInProgressToInProgressDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInProgressToCompleteSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionInProgressToCompleteDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUpdatedStateInCollectionInProgressToReviewedSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Can't review their own resource: expect an exception
+        ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUpdatedStateInCollectionInProgressToReviewedDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.InProgress;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+       // Can't go straight to Reviewed without being Complete: expect an exception
+        ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user);
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToInProgressSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToInProgressDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToCompleteSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToCompleteDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToReviewedSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionReviewedToReviewedDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Reviewed;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionCompleteToInProgressSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Updating a resource whilst awaiting review, keep them in review
+        ContentStatus expectedNewStatus = ContentStatus.Complete;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionCompleteToInProgressDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.InProgress;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUpdatedStateInCollectionCompleteToReviewedSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Can't review their own resource: expect an exception
+        ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user);
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionCompleteToReviewedDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.Reviewed;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionCompleteToCompleteSameUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = ALICE;
+
+        // Should accept the new status
+        ContentStatus expectedNewStatus = newStatus;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+    @Test
+    public void testUpdatedStateInCollectionCompleteToCompleteDifferentUser() throws Exception {
+        ContentStatus currentStatus = ContentStatus.Complete;
+        ContentStatus newStatus = ContentStatus.Complete;
+        String user = ALICE;
+        String lastEditedBy = BOB;
+
+        // Should go back to In Progress
+        ContentStatus expectedNewStatus = ContentStatus.InProgress;
+
+        assertEquals(expectedNewStatus,
+                ContentStatusUtils.updatedStateInCollection(currentStatus, newStatus, lastEditedBy, user));
+    }
+
+}


### PR DESCRIPTION
### What

Review the exceptions for changing content status:
- In progress can't go to reviewed
- Reviewed can go to any status

This will allow Florence to send content back to in progress when a change is made in a reviewed status

Add unit test coverage.

### How to review

Check changes make sense and tests pass

### Who can review

Anyone
