### PR TITLE
Handle 400 errors coming back from brian

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/json/ApiError.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/json/ApiError.java
@@ -1,0 +1,28 @@
+package com.github.onsdigital.zebedee.data.json;
+
+public class ApiError {
+
+    private int code;
+    private String description;
+
+    public ApiError(int code, String description) {
+        setCode(code);
+        setDescription(description);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataLinkBrian.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/data/processing/DataLinkBrian.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.zebedee.content.util.ContentUtil;
 import com.github.onsdigital.zebedee.data.json.ApiError;
 import com.github.onsdigital.zebedee.data.json.TimeSerieses;
 import com.github.onsdigital.zebedee.exceptions.TimeSeriesConversionException;
+import com.github.onsdigital.zebedee.exceptions.UnexpectedErrorException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.reader.Resource;
@@ -75,7 +76,7 @@ public class DataLinkBrian implements DataLink {
         }
     }
 
-    public TimeSerieses getTimeSeries(URI endpointUri, InputStream input, String name) throws IOException, TimeSeriesConversionException {
+    public TimeSerieses getTimeSeries(URI endpointUri, InputStream input, String name) throws IOException, ZebedeeException {
         // Add csdb file as a binary
         HttpPost post = new HttpPost(endpointUri);
         MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create();
@@ -89,39 +90,28 @@ public class DataLinkBrian implements DataLink {
                 CloseableHttpClient client = HttpClients.createDefault();
                 CloseableHttpResponse response = client.execute(post)
         ) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                ApiError apiError = decodeErrorFromResponse(response);
-                error().data("api_error", apiError).data("filename", name).log("error sending time series file to brian");
-                throw new TimeSeriesConversionException("error sending time series file to brian");
+            switch (response.getStatusLine().getStatusCode()) {
+                case HttpStatus.SC_OK:
+                    return decodeBodyFromResponse(response, TimeSerieses.class);
+                case HttpStatus.SC_BAD_REQUEST:
+                    error().data("api_error", decodeBodyFromResponse(response, ApiError.class))
+                            .data("filename", name).log("error sending time series file to brian");
+                    throw new TimeSeriesConversionException("error with time series file sent to brian");
+                default:
+                    error().data("api_error", decodeBodyFromResponse(response, ApiError.class))
+                            .data("filename", name).log("unexpected error sending time series file to brian");
+                    throw new UnexpectedErrorException("unexpected error sending time series file to brian", HttpStatus.SC_SERVICE_UNAVAILABLE);
             }
-
-            TimeSerieses result = null;
-            HttpEntity entity = response.getEntity();
-
-            if (entity != null) {
-                try (InputStream inputStream = entity.getContent()) {
-                    try {
-                        result = ContentUtil.deserialise(inputStream, TimeSerieses.class);
-                    } catch (JsonSyntaxException e) {
-                        // This can happen if an error HTTP code is received and the
-                        // body of the response doesn't contain the expected object:
-                        result = null;
-                    }
-                }
-            } else {
-                EntityUtils.consume(entity);
-            }
-            return result;
         }
     }
 
-    private ApiError decodeErrorFromResponse(CloseableHttpResponse response) throws IOException {
-        ApiError result = null;
+    private <T> T decodeBodyFromResponse(CloseableHttpResponse response, Class<T> type) throws IOException {
+        T result = null;
         HttpEntity entity = response.getEntity();
         if (entity != null) {
             try (InputStream inputStream = entity.getContent()) {
                 try {
-                    result = ContentUtil.deserialise(inputStream, ApiError.class);
+                    result = ContentUtil.deserialise(inputStream, type);
                 } catch (JsonSyntaxException e) {
                     // This can happen if the body of the response doesn't contain the expected object:
                     result = null;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/BadTimeSeriesFileException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/BadTimeSeriesFileException.java
@@ -1,0 +1,15 @@
+package com.github.onsdigital.zebedee.exceptions;
+
+import org.eclipse.jetty.http.HttpStatus;
+
+/**
+ * {@link ZebedeeException} implementation for Errors caused by in invalid time series file sent to brian
+ */
+public class BadTimeSeriesFileException extends ZebedeeException {
+
+    public BadTimeSeriesFileException(String msg) {
+        // 409 status because the client request is fine, it's just the underlying state of the collection is invalid
+        // (ie. the resource is in conflict)
+        super(msg, HttpStatus.CONFLICT_409);
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/TimeSeriesConversionException.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/exceptions/TimeSeriesConversionException.java
@@ -5,9 +5,9 @@ import org.eclipse.jetty.http.HttpStatus;
 /**
  * {@link ZebedeeException} implementation for Errors caused by in invalid time series file sent to brian
  */
-public class BadTimeSeriesFileException extends ZebedeeException {
+public class TimeSeriesConversionException extends ZebedeeException {
 
-    public BadTimeSeriesFileException(String msg) {
+    public TimeSeriesConversionException(String msg) {
         // 409 status because the client request is fine, it's just the underlying state of the collection is invalid
         // (ie. the resource is in conflict)
         super(msg, HttpStatus.CONFLICT_409);


### PR DESCRIPTION
### What

Add explicit error handling for invalid time series files sent to brian. Zebedee will already fail to approve a collection if brian returns a 400, but it will do so with confusing information in the logs (basically a NullException when it tries to read the result). This will error the approval in a more controlled manner with a sensible line in the logs explaining the cause.

### How to review

Review code and check tests pass etc.

### Who can review

Anyone but me