### PR TITLE
Prevent Duplicate API Datasets from Being Added When a Collection is Approved More Than Once

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -23,6 +23,7 @@ public class ReleasePopulator {
     public static Release populate(Release release, Iterable<ContentDetail> collectionContent) throws IOException, ZebedeeException {
 
         release.setRelatedDatasets(new ArrayList<>());
+        release.setRelatedAPIDatasets(new ArrayList<>());
         release.setRelatedDocuments(new ArrayList<>());
         release.setRelatedMethodology(new ArrayList<>());
         release.setRelatedMethodologyArticle(new ArrayList<>());


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
There is currently a bug that is causing Cantabular (aka API) Datasets, in scheduled releases, to be duplicated if the collection gets approved more than once (e.g. if it gets approved then unlocked then approved again).

The bug has been fixed by making sure that a new empty ArrayList is created, to contain the API Datasets, each time a collection is approved.

NB. More details are given in the bug ticket here: https://trello.com/c/zR2O91nG/1368-duplication-of-related-api-datasets-on-a-release-when-multiple-collection-approvals-are-made 

# How to review
<!--- Describe in detail how you tested your changes. -->
The unit tests can be run using this command: make test

The component tests can be run using this command: go test -component

The linter can be run using this command: make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
