### PR TITLE
allow removal of published interactive

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.service;
 
 import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
 import com.github.onsdigital.dp.interactives.api.exceptions.NoInteractivesInCollectionException;
+import com.github.onsdigital.dp.interactives.api.exceptions.ForbiddenException;
 import com.github.onsdigital.dp.interactives.api.models.Interactive;
 import com.github.onsdigital.dp.interactives.api.models.InteractiveHTMLFile;
 import com.github.onsdigital.dp.interactives.api.models.InteractiveMetadata;
@@ -119,6 +120,10 @@ public class InteractivesServiceImpl implements InteractivesService {
             warn().data("collectionId", collection.getDescription().getId())
                 .data("interactiveId", interactiveID)
                 .log("Interactives api could not find interactive. Deleting it from collection.");
+        } catch (ForbiddenException e) {
+                    warn().data("collectionId", collection.getDescription().getId())
+                        .data("interactiveId", interactiveID)
+                        .log("Interactives api, cannot delete a published interactive. Removing it from collection.");
         } catch (Exception e) {
             error().data("collectionId", collection.getDescription().getId())
                 .data("interactiveId", interactiveID)

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/InteractivesServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/InteractivesServiceImplTest.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.service;
 
 import com.github.onsdigital.dp.interactives.api.InteractivesAPIClient;
 import com.github.onsdigital.dp.interactives.api.exceptions.NoInteractivesInCollectionException;
+import com.github.onsdigital.dp.interactives.api.exceptions.ForbiddenException;
 import com.github.onsdigital.dp.interactives.api.exceptions.UnauthorizedException;
 import com.github.onsdigital.dp.interactives.api.models.Interactive;
 import com.github.onsdigital.dp.interactives.api.models.InteractiveMetadata;
@@ -111,6 +112,18 @@ public class InteractivesServiceImplTest extends TestCase {
         service.removeInteractiveFromCollection(mockCollection, ID);
 
         // If the collection refers to a non existent interactive, remove it from the collection
+        verify(mockCollectionDescription).removeInteractive(interactive);
+        verify(mockCollection).save();
+    }
+
+    @Test
+    public void testRemovePublishedInteractiveForbiddenException() throws Exception {
+        when(mockCollectionDescription.getInteractive(ID)).thenReturn(Optional.of(interactive));
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+        doThrow(new ForbiddenException("published interactive")).when(mockApiClient).deleteInteractive(ID);
+
+        service.removeInteractiveFromCollection(mockCollection, ID);
+
         verify(mockCollectionDescription).removeInteractive(interactive);
         verify(mockCollection).save();
     }


### PR DESCRIPTION
interactive-api returns a forbidden code if attempting to delete a published interactive
in such a case zebedee must absorb this error code AND at least remove the interactive from a collection