### PR TITLE
Temporarily remove error so that read-only mounted volumne can be tested

### DIFF
--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
@@ -340,7 +340,8 @@ public class FileSystemContentReader implements ContentReader {
 
     private void assertExists(Path path) throws ZebedeeException, IOException {
         if (!exists(path) || !isChild(path)) {
-            throw new NotFoundException("Could not find requested content, path:" + path.toUri().toString());
+//            TODO put this error back in when I have confirmed what would happen if it were not there - 14/02/23 - EC
+//            throw new NotFoundException("Could not find requested content, path:" + path.toUri().toString());
         }
     }
 


### PR DESCRIPTION
### What

I have temporarily removed an error so that I can find out what will happen if it does not get triggered when someone tries to write to the read-only mounted volume in the zebedee container in sandbox. This is required for the following ticket:

https://trello.com/c/MXPuJaOJ/1301-check-data-file-path-is-under-content-and-normalise-it

### How to review

n/a

### Who can review

Anyone but me
