### PR TITLE
Changed string given to link to allow most recent version of Cantabular dataset to show

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -121,7 +121,8 @@ public class ReleasePopulator {
     }
 
     private static Link createLink(ContentDetail contentDetail) {
-        Link link = new Link(URI.create(contentDetail.uri));
+        String result = contentDetail.uri.substring(0, contentDetail.uri.indexOf("/versions"));
+        Link link = new Link(URI.create(result));
         link.setTitle(contentDetail.description.title);
         return link;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/ReleasePopulator.java
@@ -89,6 +89,7 @@ public class ReleasePopulator {
     }
 
     private static void addRelatedAPIDataset(Release release, ContentDetail contentDetail) {
+        contentDetail.setUri(contentDetail.uri.substring(0, contentDetail.uri.indexOf("/versions")));
         Link link = createLink(contentDetail);
         if (release.getRelatedAPIDatasets() == null) {
             release.setRelatedAPIDatasets(new ArrayList<>());
@@ -121,8 +122,7 @@ public class ReleasePopulator {
     }
 
     private static Link createLink(ContentDetail contentDetail) {
-        String result = contentDetail.uri.substring(0, contentDetail.uri.indexOf("/versions"));
-        Link link = new Link(URI.create(result));
+        Link link = new Link(URI.create(contentDetail.uri));
         link.setTitle(contentDetail.description.title);
         return link;
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1415,8 +1415,8 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.complete(publisher1Session, releaseJsonUri, recursive);
         collection.review(publisher2Session, releaseJsonUri, recursive);
 
-        ContentDetail cmdDetail = new ContentDetail("My CMD dataset", "/some/uri/versions/test", PageType.API_DATASET_LANDING_PAGE);
-        FileUtils.write(collection.getReviewed().getPath().resolve("/some/uri/versions/test/data.json").toFile(),
+        ContentDetail cmdDetail = new ContentDetail("My CMD dataset", "some/uri/versions/test", PageType.API_DATASET_LANDING_PAGE);
+        FileUtils.write(collection.getReviewed().getPath().resolve("some/uri/versions/test/data.json").toFile(),
                 Serialiser.serialise(cmdDetail), Charset.defaultCharset());
 
         // When we attempt to populate the release from the collection.

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -1415,8 +1415,8 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.complete(publisher1Session, releaseJsonUri, recursive);
         collection.review(publisher2Session, releaseJsonUri, recursive);
 
-        ContentDetail cmdDetail = new ContentDetail("My CMD dataset", "/some/uri", PageType.API_DATASET_LANDING_PAGE);
-        FileUtils.write(collection.getReviewed().getPath().resolve("some/uri/data.json").toFile(),
+        ContentDetail cmdDetail = new ContentDetail("My CMD dataset", "/some/uri/versions/test", PageType.API_DATASET_LANDING_PAGE);
+        FileUtils.write(collection.getReviewed().getPath().resolve("/some/uri/versions/test/data.json").toFile(),
                 Serialiser.serialise(cmdDetail), Charset.defaultCharset());
 
         // When we attempt to populate the release from the collection.
@@ -1436,7 +1436,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertNotNull(result);
         assertEquals(1, result.getRelatedAPIDatasets().size());
         assertEquals(cmdDetail.description.title, result.getRelatedAPIDatasets().get(0).getTitle());
-        assertEquals(cmdDetail.uri, result.getRelatedAPIDatasets().get(0).getUri().toString());
+        assertEquals("/some/uri", result.getRelatedAPIDatasets().get(0).getUri().toString());
     }
 
     @Test


### PR DESCRIPTION
### What

Currently when Zebedee creates a release page it shows a list of Cantabular datasets with links to the first edition of that dataset even if it has been superseded. This code change amends the url which is used to create the link so that it will redirect to the most recent edition of the dataset.

### How to review

LGTM.

### Who can review

Anyone.