### PR TITLE
Remove uris from kafka service log

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/KafkaServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/KafkaServiceImpl.java
@@ -23,7 +23,6 @@ public class KafkaServiceImpl implements KafkaService {
     public void produceContentUpdated(String collectionId, List<String> uris, String dataType, String jobID,
             String searchIndex, String traceId) throws IOException {
         info().collectionID(collectionId)
-                .data("uris", uris)
                 .data("DataType", dataType)
                 .log("generating content-updated kafka events for published collection");
 


### PR DESCRIPTION
### What

Remove uris from the kafka service log - they sometimes produce log lines that are 450k long. 
I left the log as a whole in because it still seems useful to have it there and without uris should be less problematic. 

### How to review

Check is sensible

### Who can review

Not me. 