### PR TITLE
Upgrade restolino to v0.6.0 (config max threads)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <restolino.version>0.4.2</restolino.version>
+        <restolino.version>0.6.0</restolino.version>
         <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
         <spring.version>5.3.20</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,15 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>30.1.1-jre</version>
+                <version>32.1.1-jre</version>
             </dependency>
 
+            <!-- override the snappy version used by kafka client -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.1</version>
+            </dependency>
 
             <!-- File upload -->
             <dependency>
@@ -265,7 +271,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
             </dependency>
 
             <dependency>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -138,6 +138,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>


### PR DESCRIPTION
### What

Upgrade restolino to v0.6.0 to enable configurable jetty max threads.

- Defaults to the current value of 200 max threads so no change if un-configured (eg. in prod)
- Upgrades dependencies for security (jetty, junit, gson, slf4j)
- [Only other change between v0.4.2 and v0.6.0](https://github.com/ONSdigital/restolino/compare/v0.4.2...v0.6.0) is a change to the restolino files handler which is only used by babbage (for /web static files) and is unused in zebedee so has no impact. 

### How to review

Ensure tests pass and changes make sense

### Who can review

Anyone but me