### PR TITLE
Feature/update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 9200
 ENTRYPOINT java -Xmx2048m \
           -Drestolino.classes=target/classes \
           -Drestolino.packageprefix=com.github.onsdigital.zebedee.api \
-          -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+          -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
           -Dotel.propagators=tracecontext,baggage \
           -Dotel.service.name=zebedee \
           -Dotel.javaagent.enabled=false \

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -8,7 +8,7 @@ ADD dependency target/dependency
 CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"    \
     -Drestolino.packageprefix=com.github.onsdigital.zebedee.api \
     -Drestolino.classes=target/classes                          \
-    -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+    -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
     -Dotel.propagators=tracecontext,baggage \
     -Dotel.service.name=zebedee \
     -Dotel.javaagent.enabled=false \

--- a/pom.xml
+++ b/pom.xml
@@ -23,17 +23,23 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <restolino.version>0.6.0</restolino.version>
-        <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
+        <restolino.version>0.7.1</restolino.version>
+        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
-        <spring.version>5.3.20</spring.version>
-        <dp.logging.version>2.0.0-beta.8</dp.logging.version>
-        <batik.version>1.16</batik.version>
-        <logback.version>1.2.11</logback.version>
+        <spring.version>5.3.31</spring.version>
+        <dp.logging.version>v2.0.0-beta.11</dp.logging.version>
+        <batik.version>1.17</batik.version>
+        <logback.version>1.3.14</logback.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Keep logging at the beginning of the file so that org.slf4j dependency is imported at its latest version required by logging to work -->
+            <dependency>
+                <groupId>com.github.onsdigital</groupId>
+                <artifactId>dp-logging</artifactId>
+                <version>${dp.logging.version}</version>
+            </dependency>
 
             <!-- Main -->
             <dependency>
@@ -46,7 +52,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-cryptolite-java</artifactId>
-                <version>1.5.0</version>
+                <version>1.5.1</version>
             </dependency>
 
             <!-- Any sub modules depending on Zebedee reader and content wrappers should depend on project version as all modules are released together under same version-->
@@ -59,26 +65,26 @@
             <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
-                <version>0.9.10</version>
+                <version>0.10.2</version>
             </dependency>
 
             <!-- commons -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.15.1</version>
             </dependency>
 
             <!--Gson-->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.9</version>
+                <version>2.10.1</version>
             </dependency>
 
             <!--SVG conversion-->
@@ -123,14 +129,14 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.1-jre</version>
+                <version>32.1.3-jre</version>
             </dependency>
 
             <!-- override the snappy version used by kafka client -->
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.5</version>
             </dependency>
 
             <!-- File upload -->
@@ -142,7 +148,7 @@
             <dependency>
                 <groupId>com.github.davidcarboni</groupId>
                 <artifactId>encrypted-file-upload</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.2</version>
                 <exclusions>
                     <!-- Brings in an older version of davidcarboni/cryptolite which conflicts
                          with the onsdigital fork. This stops the old version being imported. -->
@@ -156,7 +162,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.10.13</version>
+                <version>2.12.6</version>
             </dependency>
 
             <dependency>
@@ -185,28 +191,21 @@
                 <version>2.3</version>
             </dependency>
 
-            <!-- Logging -->
-            <dependency>
-                <groupId>com.github.onsdigital</groupId>
-                <artifactId>dp-logging</artifactId>
-                <version>${dp.logging.version}</version>
-            </dependency>
-
             <!-- Http -->
             <dependency>
                 <groupId>com.github.davidcarboni</groupId>
                 <artifactId>httpino</artifactId>
-                <version>0.0.7</version>
+                <version>0.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.14</version>
             </dependency>
 
             <dependency>
@@ -217,7 +216,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>2.1.1</version>
+                <version>2.4.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
@@ -231,11 +230,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>2.1.1</version>
@@ -243,12 +237,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.15</version>
+                <version>4.4.16</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.16.0</version>
             </dependency>
 
             <dependency>
@@ -266,19 +260,19 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-jwt-verifier-java</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.1</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.0</version>
+                <version>1.11.3</version>
             </dependency>
 
             <dependency>
@@ -290,9 +284,10 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>1.28.4</version>
+                <version>1.28.5</version>
             </dependency>
 
+            <!-- ch.qos.logback:logback-classic supports JDK 8 only on logback version 1.3.x -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
@@ -302,13 +297,13 @@
             <dependency>
                 <groupId>com.carrotsearch</groupId>
                 <artifactId>hppc</artifactId>
-                <version>0.7.1</version>
+                <version>0.9.1</version>
             </dependency>
 
             <dependency>
                 <groupId>software.amazon.opentelemetry</groupId>
                 <artifactId>aws-opentelemetry-agent</artifactId>
-                <version>1.31.0</version>
+                <version>1.32.0</version>
             </dependency>
 
             <!-- Test -->
@@ -362,13 +357,14 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <encoding>${encoding}</encoding>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>audit-dependencies-critical</id>
@@ -397,12 +393,12 @@
                         <exlude>
                             <groupId>io.netty</groupId>
                             <artifactId>netty</artifactId>
-                            <version>3.10.5.Final</version>
+                            <version>3.10.6.Final</version>
                         </exlude>
                         <exlude>
                             <groupId>org.elasticsearch</groupId>
                             <artifactId>elasticsearch</artifactId>
-                            <version>2.1.1</version>
+                            <version>2.4.6</version>
                         </exlude>
                         <!-- End Trello #1717 -->
 
@@ -417,53 +413,16 @@
                         <exlude>
                             <groupId>org.apache.lucene</groupId>
                             <artifactId>lucene-queryparser</artifactId>
-                            <version>5.3.1</version>
+                            <version>5.5.4</version>
                         </exlude>
 
                         <!-- https://trello.com/c/wotCeMmc -->
                         <exlude>
                             <groupId>org.yaml</groupId>
                             <artifactId>snakeyaml</artifactId>
-                            <version>1.33</version>
+                            <version>1.15</version>
                         </exlude>
 
-                        <exlude>
-                            <groupId>org.xerial.snappy</groupId>
-                            <artifactId>snappy-java</artifactId>
-                            <version>1.1.10.1</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.xmlgraphics</groupId>
-                            <artifactId>batik-transcoder</artifactId>
-                            <version>${batik.version}</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.avro</groupId>
-                            <artifactId>avro</artifactId>
-                            <version>1.11.0</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.xmlgraphics</groupId>
-                            <artifactId>batik-bridge</artifactId>
-                            <version>${batik.version}</version>
-                        </exlude>
-
-                        <!-- exclude [CVE-2023-6378] CWE-502: Deserialization of Untrusted Data (7.5) -->
-                        <exlude>
-                            <groupId>ch.qos.logback</groupId>
-                            <artifactId>logback-classic</artifactId>
-                            <version>${logback.version}</version>
-                        </exlude>
-
-                        <!-- exclude [CVE-2023-6378] CWE-502: Deserialization of Untrusted Data (7.5) -->
-                        <exlude>
-                            <groupId>ch.qos.logback</groupId>
-                            <artifactId>logback-core</artifactId>
-                            <version>${logback.version}</version>
-                        </exlude>
 
                     </excludeCoordinates>
                 </configuration>

--- a/run-reader.sh
+++ b/run-reader.sh
@@ -26,7 +26,7 @@ java $JAVA_OPTS \
  -DSTART_EMBEDDED_SERVER=N \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
  -DFORMAT_LOGGING=$FORMAT_LOGGING \
- -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+ -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
  -Dotel.propagators=tracecontext,baggage \
  -Dotel.javaagent.enabled=false \
  -cp "zebedee-reader/target/classes/:zebedee-reader/target/dependency/*" \

--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,7 @@ java $JAVA_OPTS \
  -Drestolino.classes=$RESTOLINO_CLASSES \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
  -DSTART_EMBEDDED_SERVER=N \
- -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+ -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
  -Dotel.propagators=tracecontext,baggage \
  -Dotel.javaagent.enabled=false \
  -cp "zebedee-cms/target/classes:zebedee-cms/target/dependency/*" \

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -29,6 +29,11 @@
     </repositories>
 
     <dependencies>
+        <!-- Logging -->
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+        </dependency>
 
         <!--Restolino-->
         <dependency>
@@ -74,11 +79,6 @@
             <artifactId>opencsv</artifactId>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-logging</artifactId>
-        </dependency>
 
         <!-- Http -->
         <dependency>
@@ -148,11 +148,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -208,7 +203,14 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-authorisation-java</artifactId>
-            <version>2.2.0</version>
+            <version>2.6.0</version>
+        </dependency>
+
+        <!-- Threads -->
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
         </dependency>
 
         <!-- Spreadsheet generator -->
@@ -278,7 +280,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -294,7 +296,7 @@
             <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
-                <version>1.10.2</version>
+                <version>1.11.3</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/zebedee-reader.nomad
+++ b/zebedee-reader.nomad
@@ -47,7 +47,7 @@ job "zebedee-reader" {
           "-Xmx{{WEB_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.classes=target/classes",
-          "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
+          "-javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
           "-Dotel.javaagent.enabled=false",

--- a/zebedee-reader/Dockerfile
+++ b/zebedee-reader/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 9200
 ENTRYPOINT java -Xmx2048m \
           -Drestolino.classes=target/classes \
           -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \
-          -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+          -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
           -Dotel.propagators=tracecontext,baggage \
           -Dotel.javaagent.enabled=false \
           -Dotel.service.name=zebedee \

--- a/zebedee-reader/Dockerfile.concourse
+++ b/zebedee-reader/Dockerfile.concourse
@@ -6,7 +6,7 @@ ADD dependency target/dependency
 ADD classes target/classes
 
 CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"           \
-    -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+    -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
     -Dotel.propagators=tracecontext,baggage \
     -Dotel.javaagent.enabled=false \
     -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \

--- a/zebedee-reader/Dockerfile.local
+++ b/zebedee-reader/Dockerfile.local
@@ -18,7 +18,7 @@ ENTRYPOINT java $JAVA_OPTS \
      -Dcontent_dir=$CONTENT_DIR \
      -DSTART_EMBEDDED_SERVER=N \
      -Drestolino.packageprefix=$PACKAGE_PREFIX \
-     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
      -Dotel.propagators=tracecontext,baggage \
      -Dotel.javaagent.enabled=false \
      -cp "target/dependency/*:target/classes/" \

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -29,6 +29,12 @@
     </repositories>
 
     <dependencies>
+       <!-- Logging -->
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+        </dependency>
+
         <!--Restolino-->
         <dependency>
             <groupId>com.github.onsdigital</groupId>
@@ -69,12 +75,6 @@
             <artifactId>opencsv</artifactId>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-logging</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -99,11 +99,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
@@ -167,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
@@ -107,7 +107,7 @@ class PageTypeResolver implements JsonDeserializer<Page> {
 
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addUrls(
                     PageTypeResolver.class.getProtectionDomain().getCodeSource().getLocation());
-            configurationBuilder.addClassLoader(PageTypeResolver.class.getClassLoader());
+            configurationBuilder.addClassLoaders(PageTypeResolver.class.getClassLoader());
             Set<Class<? extends Page>> classes = new Reflections(configurationBuilder).getSubTypesOf(Page.class);
 
             for (Class<? extends Page> contentClass : classes) {

--- a/zebedee.nomad
+++ b/zebedee.nomad
@@ -49,7 +49,7 @@ job "zebedee" {
           "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.classes=target/classes",
-          "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
+          "-javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
           "-Dotel.javaagent.enabled=false",


### PR DESCRIPTION
### What

Updated external and internal dependencies to latest minor version.


### How to review
Make sure to use java 1.8 as the current jdk and maven is using it (`mvn --version`)
You have to have experience on how to run zebedee so it can serve content. 
You have to have experience on how to run babage so it can test zebedee reader and zebedee cms. 

run `mvn package`
No errors should appear, the build should run ok and the test cases should run ok

run `mvn versions:display-dependency-updates -DallowMajorUpdates=false`
No libraries should be mentioned here that need updating

create the content folder for zebedee with required content in it
execute ./run-reader.sh - should start zebedee-reader with out errors
execute ./run.sh - should start zebedee cms with out errors
terminate all java running java tasks

Test zebedee servers content to babbage: 

copy content from babage into required location of zebedee, or checkout and build dp-content
run zebedee reader ./run-reader.sh (zebedee)
checkout latest babbage  and execute ./run.sh
checkout compile and run dp-router-api
checkout and compile sixteen to serve stylesheets

go to the content  location : http://localhost:8080/economy/inflationandpriceindices/consumerpriceinflation/2015-04-14  in your browser and you it should display the content without error 500

### Who can review

A member of ONS with skills related to babbage, zebedde, sixteen, dp-content and dp-router-api
