### PR TITLE
Release 2.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 9200
 ENTRYPOINT java -Xmx2048m \
           -Drestolino.classes=target/classes \
           -Drestolino.packageprefix=com.github.onsdigital.zebedee.api \
-          -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+          -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
           -Dotel.propagators=tracecontext,baggage \
           -Dotel.service.name=zebedee \
           -Dotel.javaagent.enabled=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ ENTRYPOINT java -Xmx2048m \
           -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
           -Dotel.propagators=tracecontext,baggage \
           -Dotel.service.name=zebedee \
+          -Dotel.javaagent.enabled=false \
           -cp "target/dependency/*:target/classes/" \
           com.github.davidcarboni.restolino.Main

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -8,7 +8,7 @@ ADD dependency target/dependency
 CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"    \
     -Drestolino.packageprefix=com.github.onsdigital.zebedee.api \
     -Drestolino.classes=target/classes                          \
-    -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+    -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
     -Dotel.propagators=tracecontext,baggage \
     -Dotel.service.name=zebedee \
     -Dotel.javaagent.enabled=false \

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -11,4 +11,5 @@ CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"    \
     -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
     -Dotel.propagators=tracecontext,baggage \
     -Dotel.service.name=zebedee \
+    -Dotel.javaagent.enabled=false \
     com.github.davidcarboni.restolino.Main

--- a/README.md
+++ b/README.md
@@ -110,37 +110,41 @@ Otherwise :violin: kindly ask someone from the dev team to help troubleshoot.
 
 ### Optional configuration options
 
-| Environment variable                              | Default                                     | Description
-|---------------------------------------------------| --------------------------------------------| -----------
-| DEFAULT_WEBSITE_URL                               | "http://localhost:8080"                     | Service URL
-| DEFAULT_SLACK_WARNING_CHANNEL                     | "slack-client-test"                         | Slack channel
-| DEFAULT_SLACK_ALARM_CHANNEL                       | "slack-client-test"                         | Slack alarm channel
-| DEFAULT_SLACK_USERNAME                            | "Zebedee"                                   | Slack user
-| DEFAULT_PUBLIC_WEBSITE_URL                        | "http://localhost:8080"                     | Service public URL
-| DEFAULT_FLORENCE_URL                              | "http://localhost:8081"                     | Florence URL
-| DEFAULT_BRIAN_URL                                 | "http://localhost:8083"                     | Brian URL
-| DEFAULT_TRAIN_URL                                 | "http://localhost:8084"                     | Train URL
-| DEFAULT_DYLAN_URL                                 | "http://localhost:8085"                     | Dylan URL
-| CONTENT_DIRECTORY                                 | "content"                                   | Content directory
-| KAFKA_SEC_PROTO                                   | _unset_                                     | if set to "TLS", kafka connections will use TLS
-| KAFKA_SEC_CLIENT_CERT                             | _unset_                                     | PEM for the client certificate [1]
-| KAFKA_SEC_CLIENT_KEY                              | _unset_                                     | PEM for the client key [1]
-| MATHJAX_SERVICE_URL                               | "http://localhost:8888"                     | Mathjax service URL
-| DATASET_API_URL                                   | "http://localhost:22000"                    | Dataset API URL
-| IMAGE_API_URL                                     | "http://localhost:24700"                    | Image API URL
-| ENABLE_KAFKA                                      | false                                       | Feature flag to send kafka messages when a collection is published
-| KAFKA_ADDR                                        | "localhost:9092"                            | Comma seperated list of kafka brokers
-| KAFKA_CONTENT_UPDATED_TOPIC                       | content-updated                             | Kafka topic to send content updated event to
-| DATASET_API_AUTH_TOKEN                            | "FD0108EA-825D-411C-9B1D-41EF7727F465"      | Dataset API authentication token
-| SERVICE_AUTH_TOKEN                                | "15C0E4EE-777F-4C61-8CDB-2898CEB34657"      | Service API authentication token
-| SESSIONS_API_URL                                  | "http://localhost:24400"                    | Session API URL
-| KEYRING_SECRET_KEY                                | "KEYRING_SECRET_KEY";                       | Keyring encryption key
-| KEYRING_INIT_VECTOR                               | "KEYRING_INIT_VECTOR"                       | Keyring init vector
-| VERIFY_RETRY_DELAY                                | 5000; //milliseconds                        | Retry delay duration
-| VERIFY_RETRY_COUNT                                | 10                                          | Retry count for how long, in seconds, to wait for retry
-| DEFAULT_PREPROCESS_SECONDS_BEFORE_PUBLISH         | 30                                          | how many seconds before the actual publish time should we run the preprocess
-| DEFAULT_SECONDS_TO_CACHE_AFTER_SCHEDULED_PUBLISH  | 30                                          | how many additional seconds after the publi
-| IDENTITY_API_URL                                  | "http://localhost:25600"                    | Identity API URL
+| Environment variable                             | Default                                                            | Description                                                                  |
+|--------------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------|
+| DEFAULT_WEBSITE_URL                              | "http://localhost:8080"                                            | Service URL                                                                  |
+| DEFAULT_LEGACY_CACHE_API_URL                     | "http://localhost:29100"                                           | Cache API Service URL                                                        |
+| DEFAULT_SLACK_WARNING_CHANNEL                    | "slack-client-test"                                                | Slack channel                                                                |
+| DEFAULT_SLACK_ALARM_CHANNEL                      | "slack-client-test"                                                | Slack alarm channel                                                          |
+| DEFAULT_SLACK_USERNAME                           | "Zebedee"                                                          | Slack user                                                                   |
+| DEFAULT_PUBLIC_WEBSITE_URL                       | "http://localhost:8080"                                            | Service public URL                                                           |
+| DEFAULT_FLORENCE_URL                             | "http://localhost:8081"                                            | Florence URL                                                                 |
+| DEFAULT_BRIAN_URL                                | "http://localhost:8083"                                            | Brian URL                                                                    |
+| DEFAULT_TRAIN_URL                                | "http://localhost:8084"                                            | Train URL                                                                    |
+| DEFAULT_DYLAN_URL                                | "http://localhost:8085"                                            | Dylan URL                                                                    |
+| CONTENT_DIRECTORY                                | "content"                                                          | Content directory                                                            |
+| KAFKA_SEC_PROTO                                  | _unset_                                                            | if set to "TLS", kafka connections will use TLS                              |
+| KAFKA_SEC_CLIENT_CERT                            | _unset_                                                            | PEM for the client certificate [1]                                           |
+| KAFKA_SEC_CLIENT_KEY                             | _unset_                                                            | PEM for the client key [1]                                                   |
+| MATHJAX_SERVICE_URL                              | "http://localhost:8888"                                            | Mathjax service URL                                                          |
+| DATASET_API_URL                                  | "http://localhost:22000"                                           | Dataset API URL                                                              |
+| IMAGE_API_URL                                    | "http://localhost:24700"                                           | Image API URL                                                                |
+| ENABLE_KAFKA                                     | false                                                              | Feature flag to send kafka messages when a collection is published           |
+| ENABLE_LEGACY_CACHE_API                          | false                                                              | Feature flag to enable Cache API                                             |
+| KAFKA_ADDR                                       | "localhost:9092"                                                   | Comma seperated list of kafka brokers                                        |
+| KAFKA_CONTENT_UPDATED_TOPIC                      | content-updated                                                    | Kafka topic to send content updated event to                                 |
+| DATASET_API_AUTH_TOKEN                           | "FD0108EA-825D-411C-9B1D-41EF7727F465"                             | Dataset API authentication token                                             |
+| SERVICE_AUTH_TOKEN                               | "15C0E4EE-777F-4C61-8CDB-2898CEB34657"                             | Service API authentication token                                             |
+| LEGACY_CACHE_API_AUTH_TOKEN                      | "748896205c3b42b43adb4b22fff11784c5d971187f280ab1b6f142c3d69e64e4" | Legacy Cache API authentication token                                        |
+| SESSIONS_API_URL                                 | "http://localhost:24400"                                           | Session API URL                                                              |
+| KEYRING_SECRET_KEY                               | "KEYRING_SECRET_KEY";                                              | Keyring encryption key                                                       |
+| KEYRING_INIT_VECTOR                              | "KEYRING_INIT_VECTOR"                                              | Keyring init vector                                                          |
+| VERIFY_RETRY_DELAY                               | 5000; //milliseconds                                               | Retry delay duration                                                         |
+| VERIFY_RETRY_COUNT                               | 10                                                                 | Retry count for how long, in seconds, to wait for retry                      |
+| DEFAULT_PREPROCESS_SECONDS_BEFORE_PUBLISH        | 30                                                                 | how many seconds before the actual publish time should we run the preprocess |
+| DEFAULT_SECONDS_TO_CACHE_AFTER_SCHEDULED_PUBLISH | 30                                                                 | how many additional seconds after the publi                                  |
+| IDENTITY_API_URL                                 | "http://localhost:25600"                                           | Identity API URL                                                             |
+
 ### New Central Keyring configuration
 The new central keyring feature is currently behind a feature flag:
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,11 @@
                 <version>2.4.6</version>
             </dependency>
             <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
                 <version>3.17</version>
@@ -415,15 +420,6 @@
                             <artifactId>lucene-queryparser</artifactId>
                             <version>5.5.4</version>
                         </exlude>
-
-                        <!-- https://trello.com/c/wotCeMmc -->
-                        <exlude>
-                            <groupId>org.yaml</groupId>
-                            <artifactId>snakeyaml</artifactId>
-                            <version>1.15</version>
-                        </exlude>
-
-
                     </excludeCoordinates>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,17 +23,23 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <restolino.version>0.6.0</restolino.version>
-        <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
+        <restolino.version>0.7.1</restolino.version>
+        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
-        <spring.version>5.3.20</spring.version>
-        <dp.logging.version>2.0.0-beta.8</dp.logging.version>
-        <batik.version>1.16</batik.version>
-        <logback.version>1.2.11</logback.version>
+        <spring.version>5.3.31</spring.version>
+        <dp.logging.version>v2.0.0-beta.11</dp.logging.version>
+        <batik.version>1.17</batik.version>
+        <logback.version>1.3.14</logback.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Keep logging at the beginning of the file so that org.slf4j dependency is imported at its latest version required by logging to work -->
+            <dependency>
+                <groupId>com.github.onsdigital</groupId>
+                <artifactId>dp-logging</artifactId>
+                <version>${dp.logging.version}</version>
+            </dependency>
 
             <!-- Main -->
             <dependency>
@@ -46,7 +52,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-cryptolite-java</artifactId>
-                <version>1.5.0</version>
+                <version>1.5.1</version>
             </dependency>
 
             <!-- Any sub modules depending on Zebedee reader and content wrappers should depend on project version as all modules are released together under same version-->
@@ -59,26 +65,26 @@
             <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
-                <version>0.9.10</version>
+                <version>0.10.2</version>
             </dependency>
 
             <!-- commons -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.15.1</version>
             </dependency>
 
             <!--Gson-->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.9</version>
+                <version>2.10.1</version>
             </dependency>
 
             <!--SVG conversion-->
@@ -123,14 +129,14 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.1-jre</version>
+                <version>32.1.3-jre</version>
             </dependency>
 
             <!-- override the snappy version used by kafka client -->
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.5</version>
             </dependency>
 
             <!-- File upload -->
@@ -142,7 +148,7 @@
             <dependency>
                 <groupId>com.github.davidcarboni</groupId>
                 <artifactId>encrypted-file-upload</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.2</version>
                 <exclusions>
                     <!-- Brings in an older version of davidcarboni/cryptolite which conflicts
                          with the onsdigital fork. This stops the old version being imported. -->
@@ -156,7 +162,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.10.13</version>
+                <version>2.12.6</version>
             </dependency>
 
             <dependency>
@@ -185,28 +191,21 @@
                 <version>2.3</version>
             </dependency>
 
-            <!-- Logging -->
-            <dependency>
-                <groupId>com.github.onsdigital</groupId>
-                <artifactId>dp-logging</artifactId>
-                <version>${dp.logging.version}</version>
-            </dependency>
-
             <!-- Http -->
             <dependency>
                 <groupId>com.github.davidcarboni</groupId>
                 <artifactId>httpino</artifactId>
-                <version>0.0.7</version>
+                <version>0.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.14</version>
             </dependency>
 
             <dependency>
@@ -217,7 +216,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>2.1.1</version>
+                <version>2.4.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
@@ -231,11 +230,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>2.1.1</version>
@@ -243,12 +237,12 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.15</version>
+                <version>4.4.16</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.16.0</version>
             </dependency>
 
             <dependency>
@@ -266,19 +260,19 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-jwt-verifier-java</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.1</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.0</version>
+                <version>1.11.3</version>
             </dependency>
 
             <dependency>
@@ -290,9 +284,10 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>1.28.4</version>
+                <version>1.28.5</version>
             </dependency>
 
+            <!-- ch.qos.logback:logback-classic supports JDK 8 only on logback version 1.3.x -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
@@ -302,13 +297,13 @@
             <dependency>
                 <groupId>com.carrotsearch</groupId>
                 <artifactId>hppc</artifactId>
-                <version>0.7.1</version>
+                <version>0.9.1</version>
             </dependency>
 
             <dependency>
                 <groupId>software.amazon.opentelemetry</groupId>
                 <artifactId>aws-opentelemetry-agent</artifactId>
-                <version>1.31.0</version>
+                <version>1.32.0</version>
             </dependency>
 
             <!-- Test -->
@@ -362,13 +357,14 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <encoding>${encoding}</encoding>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>audit-dependencies-critical</id>
@@ -397,12 +393,12 @@
                         <exlude>
                             <groupId>io.netty</groupId>
                             <artifactId>netty</artifactId>
-                            <version>3.10.5.Final</version>
+                            <version>3.10.6.Final</version>
                         </exlude>
                         <exlude>
                             <groupId>org.elasticsearch</groupId>
                             <artifactId>elasticsearch</artifactId>
-                            <version>2.1.1</version>
+                            <version>2.4.6</version>
                         </exlude>
                         <!-- End Trello #1717 -->
 
@@ -417,53 +413,16 @@
                         <exlude>
                             <groupId>org.apache.lucene</groupId>
                             <artifactId>lucene-queryparser</artifactId>
-                            <version>5.3.1</version>
+                            <version>5.5.4</version>
                         </exlude>
 
                         <!-- https://trello.com/c/wotCeMmc -->
                         <exlude>
                             <groupId>org.yaml</groupId>
                             <artifactId>snakeyaml</artifactId>
-                            <version>1.33</version>
+                            <version>1.15</version>
                         </exlude>
 
-                        <exlude>
-                            <groupId>org.xerial.snappy</groupId>
-                            <artifactId>snappy-java</artifactId>
-                            <version>1.1.10.1</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.xmlgraphics</groupId>
-                            <artifactId>batik-transcoder</artifactId>
-                            <version>${batik.version}</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.avro</groupId>
-                            <artifactId>avro</artifactId>
-                            <version>1.11.0</version>
-                        </exlude>
-
-                        <exlude>
-                            <groupId>org.apache.xmlgraphics</groupId>
-                            <artifactId>batik-bridge</artifactId>
-                            <version>${batik.version}</version>
-                        </exlude>
-
-                        <!-- exclude [CVE-2023-6378] CWE-502: Deserialization of Untrusted Data (7.5) -->
-                        <exlude>
-                            <groupId>ch.qos.logback</groupId>
-                            <artifactId>logback-classic</artifactId>
-                            <version>${logback.version}</version>
-                        </exlude>
-
-                        <!-- exclude [CVE-2023-6378] CWE-502: Deserialization of Untrusted Data (7.5) -->
-                        <exlude>
-                            <groupId>ch.qos.logback</groupId>
-                            <artifactId>logback-core</artifactId>
-                            <version>${logback.version}</version>
-                        </exlude>
 
                     </excludeCoordinates>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <dp.logging.version>v2.0.0-beta.11</dp.logging.version>
         <batik.version>1.17</batik.version>
         <logback.version>1.3.14</logback.version>
+        <mockito.version>3.12.4</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -274,6 +275,13 @@
                 <version>3.6.1</version>
             </dependency>
 
+            <!-- To fix vulnerabilities in transient imported commons-compress by avro -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
@@ -336,7 +344,14 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.12.4</version>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/run-reader.sh
+++ b/run-reader.sh
@@ -26,7 +26,7 @@ java $JAVA_OPTS \
  -DSTART_EMBEDDED_SERVER=N \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
  -DFORMAT_LOGGING=$FORMAT_LOGGING \
- -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+ -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
  -Dotel.propagators=tracecontext,baggage \
  -Dotel.javaagent.enabled=false \
  -cp "zebedee-reader/target/classes/:zebedee-reader/target/dependency/*" \

--- a/run-reader.sh
+++ b/run-reader.sh
@@ -28,6 +28,7 @@ java $JAVA_OPTS \
  -DFORMAT_LOGGING=$FORMAT_LOGGING \
  -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
  -Dotel.propagators=tracecontext,baggage \
+ -Dotel.javaagent.enabled=false \
  -cp "zebedee-reader/target/classes/:zebedee-reader/target/dependency/*" \
  com.github.davidcarboni.restolino.Main
 

--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,7 @@ java $JAVA_OPTS \
  -Drestolino.classes=$RESTOLINO_CLASSES \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
  -DSTART_EMBEDDED_SERVER=N \
- -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+ -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
  -Dotel.propagators=tracecontext,baggage \
  -Dotel.javaagent.enabled=false \
  -cp "zebedee-cms/target/classes:zebedee-cms/target/dependency/*" \

--- a/run.sh
+++ b/run.sh
@@ -32,8 +32,9 @@ java $JAVA_OPTS \
  -Drestolino.classes=$RESTOLINO_CLASSES \
  -Drestolino.packageprefix=$PACKAGE_PREFIX \
  -DSTART_EMBEDDED_SERVER=N \
-  -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
-  -Dotel.propagators=tracecontext,baggage \
+ -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+ -Dotel.propagators=tracecontext,baggage \
+ -Dotel.javaagent.enabled=false \
  -cp "zebedee-cms/target/classes:zebedee-cms/target/dependency/*" \
  com.github.davidcarboni.restolino.Main
 

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -29,6 +29,11 @@
     </repositories>
 
     <dependencies>
+        <!-- Logging -->
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+        </dependency>
 
         <!--Restolino-->
         <dependency>
@@ -74,11 +79,6 @@
             <artifactId>opencsv</artifactId>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-logging</artifactId>
-        </dependency>
 
         <!-- Http -->
         <dependency>
@@ -148,11 +148,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -208,7 +203,14 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>dp-authorisation-java</artifactId>
-            <version>2.2.0</version>
+            <version>2.6.0</version>
+        </dependency>
+
+        <!-- Threads -->
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
         </dependency>
 
         <!-- Spreadsheet generator -->
@@ -278,7 +280,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -294,7 +296,7 @@
             <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
-                <version>1.10.2</version>
+                <version>1.11.3</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -261,6 +261,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/Configuration.java
@@ -20,6 +20,7 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 public class Configuration {
 
     private static final String DEFAULT_WEBSITE_URL = "http://localhost:8080";
+    private static final String DEFAULT_LEGACY_CACHE_API_URL = "http://localhost:29100";
     private static final String DEFAULT_SLACK_WARNING_CHANNEL = "slack-client-test";
     private static final String DEFAULT_SLACK_ALARM_CHANNEL = "slack-client-test";
     private static final String DEFAULT_PUBLIC_WEBSITE_URL = "http://localhost:8080";
@@ -37,6 +38,7 @@ public class Configuration {
     private static final String KAFKA_CONTENT_UPDATED_TOPIC = "content-updated";
     private static final String DATASET_API_AUTH_TOKEN = "FD0108EA-825D-411C-9B1D-41EF7727F465";
     private static final String SERVICE_AUTH_TOKEN = "15C0E4EE-777F-4C61-8CDB-2898CEB34657";
+    private static final String LEGACY_CACHE_API_AUTH_TOKEN = "748896205c3b42b43adb4b22fff11784c5d971187f280ab1b6f142c3d69e64e4";
     private static final String DEFAULT_SLACK_USERNAME = "Zebedee";
     private static final String SESSIONS_API_URL = "http://localhost:24400";
     private static final String KEYRING_SECRET_KEY = "KEYRING_SECRET_KEY";
@@ -55,6 +57,10 @@ public class Configuration {
 
     // how many additional seconds after the publish
     private static final int DEFAULT_SECONDS_TO_CACHE_AFTER_SCHEDULED_PUBLISH = 30;
+
+    public static boolean isLegacyCacheAPIEnabled() {
+        return BooleanUtils.toBoolean(StringUtils.defaultIfBlank(getValue("ENABLE_LEGACY_CACHE_API"), "false"));
+    }
 
     public static boolean isSchedulingEnabled() {
         return BooleanUtils.toBoolean(StringUtils.defaultIfBlank(getValue("scheduled_publishing_enabled"), "true"));
@@ -109,6 +115,10 @@ public class Configuration {
 
     public static String getFlorenceUrl() {
         return StringUtils.defaultIfBlank(getValue("FLORENCE_URL"), DEFAULT_FLORENCE_URL);
+    }
+
+    public static String getLegacyCacheApiUrl() {
+        return StringUtils.defaultIfBlank(getValue("LEGACY_CACHE_API_URL"), DEFAULT_LEGACY_CACHE_API_URL);
     }
 
     public static String getSlackUsername() {
@@ -182,6 +192,11 @@ public class Configuration {
     public static String getServiceAuthToken() {
         String serviceAuthToken = StringUtils.defaultIfBlank(getValue("SERVICE_AUTH_TOKEN"), SERVICE_AUTH_TOKEN);
         return "Bearer " + serviceAuthToken;
+    }
+
+    public static String getLegacyCacheAPIAuthToken() {
+        String authToken = StringUtils.defaultIfBlank(getValue("LEGACY_CACHE_API_AUTH_TOKEN"), LEGACY_CACHE_API_AUTH_TOKEN);
+        return "Bearer " + authToken;
     }
 
     public static String[] getTheTrainUrls() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClient.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClient.java
@@ -1,0 +1,52 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.davidcarboni.httpino.*;
+import com.github.onsdigital.zebedee.configuration.Configuration;
+import com.github.onsdigital.zebedee.model.publishing.WebsiteResponse;
+import com.github.onsdigital.zebedee.util.EncryptionUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.io.IOException;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+
+public class LegacyCacheApiClient {
+    private static final String CACHE_TIMES_RESOURCE_PATH = "/v1/cache-times/";
+
+    private LegacyCacheApiClient() {}
+
+    public static void sendPayloads(Http http, Host host, Iterable<LegacyCacheApiPayload> payloads) throws IOException {
+        String legacyCacheApiServiceToken = Configuration.getLegacyCacheAPIAuthToken();
+        NameValuePair authHeader = new BasicNameValuePair("Authorization", legacyCacheApiServiceToken);
+
+        for (LegacyCacheApiPayload payload : payloads) {
+            String resourceId = EncryptionUtils.createMD5Checksum(payload.uriToUpdate);
+            String path = CACHE_TIMES_RESOURCE_PATH + resourceId;
+
+            info().data("path", path)
+                    .data("payload", Serialiser.serialise(payload))
+                    .log("sending request to Legacy Cache API");
+
+            Endpoint endpoint = new Endpoint(host, path);
+
+            Response<WebsiteResponse> response = http.put(endpoint, payload, WebsiteResponse.class, authHeader);
+            logResponse(response, payload.collectionId);
+        }
+    }
+
+    private static void logResponse(Response<WebsiteResponse> response, String collectionId) {
+        String responseMessage = response.body == null ? response.statusLine.getReasonPhrase() : response.body.getMessage();
+
+        if (response.statusLine.getStatusCode() > 302) {
+            error().data("responseMessage", responseMessage)
+                    .data("collectionId", collectionId)
+                    .log("Error response from Legacy Cache API");
+        } else {
+            info().data("responseMessage", responseMessage)
+                    .data("collectionId", collectionId)
+                    .log("Response from Legacy Cache API");
+        }
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayload.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayload.java
@@ -1,0 +1,26 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.onsdigital.zebedee.model.publishing.PublishNotification;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
+public class LegacyCacheApiPayload {
+    @SerializedName("collection_id")
+    public String collectionId;
+    @SerializedName("release_time")
+    public String publishDate;
+    @SerializedName("path")
+    public String uriToUpdate;
+
+    public LegacyCacheApiPayload(String collectionId, String uriToUpdate, Date publishDate) {
+        this.collectionId = collectionId;
+        this.publishDate = PublishNotification.format(publishDate);
+        this.uriToUpdate = uriToUpdate;
+    }
+
+    public LegacyCacheApiPayload(String collectionId, String uriToUpdate) {
+        this.collectionId = collectionId;
+        this.uriToUpdate = uriToUpdate;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
@@ -1,0 +1,88 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.onsdigital.zebedee.model.Collection;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.util.*;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.*;
+
+public class LegacyCacheApiPayloadBuilder {
+    java.util.Collection<LegacyCacheApiPayload> payloads;
+
+    private LegacyCacheApiPayloadBuilder(java.util.Collection<LegacyCacheApiPayload> payloads) {
+        this.payloads = payloads;
+    }
+
+    public java.util.Collection<LegacyCacheApiPayload> getPayloads() {
+        return payloads;
+    }
+
+    public static class Builder {
+        private Collection collection;
+        private Date publishDate;
+        private final Map<String, LegacyCacheApiPayload> payloadsByPath = new HashMap<>();
+
+        public Builder() {}
+
+        public LegacyCacheApiPayloadBuilder.Builder collection(Collection collection) {
+            this.collection = collection;
+            return this;
+        }
+
+        public LegacyCacheApiPayloadBuilder.Builder publishDate(Date publishDate) {
+            this.publishDate = publishDate;
+            return this;
+        }
+
+        public LegacyCacheApiPayloadBuilder build() {
+            Objects.requireNonNull(this.collection);
+            String collectionId = collection.getDescription().getId();
+            try {
+                collection.reviewedUris()
+                        .forEach(uri -> {
+                                    String pagePath = PayloadPathUpdater.getCanonicalPagePath(uri, collectionId);
+                                    LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, pagePath, this.publishDate);
+                                    if (isValid(legacyCacheApiPayload)) {
+                                        payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
+                                        addPayloadForBulletinLatest(legacyCacheApiPayload.uriToUpdate, collectionId, this.publishDate);
+                                    }
+                                }
+                        );
+                collection.getDescription().getPendingDeletes()
+                        .forEach(pendingDelete -> {
+                            String uriToDelete = pendingDelete.getRoot().getUri();
+                            uriToDelete = PayloadPathUpdater.getCanonicalPagePath(uriToDelete, collectionId);
+                            LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, uriToDelete);
+                            if (isValid(legacyCacheApiPayload)) {
+                                payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
+                            }
+                        });
+            } catch (IOException e) {
+                error().data("collectionId", collectionId)
+                        .logException(e, "failed initialising PublishNotification when reading collection reviewedUris");
+            }
+
+            return new LegacyCacheApiPayloadBuilder(this.payloadsByPath.values());
+        }
+
+        private void addPayloadForBulletinLatest(String uriToUpdate, String collectionId, Date clearCacheDate) {
+            if (PayloadPathUpdater.isPayloadPathBulletinLatest(uriToUpdate)) {
+                // first apply updatePath on uriToUpdate
+                LegacyCacheApiPayload legacyCacheApiPayloadLatest = new LegacyCacheApiPayload(collectionId, uriToUpdate, clearCacheDate);
+                // then add latest when updated path contains a bulletins
+                legacyCacheApiPayloadLatest.uriToUpdate = PayloadPathUpdater.getPathForBulletinLatest(legacyCacheApiPayloadLatest.uriToUpdate);
+                payloadsByPath.put(legacyCacheApiPayloadLatest.uriToUpdate, legacyCacheApiPayloadLatest);
+            }
+        }
+
+        private boolean isValid(LegacyCacheApiPayload payload) {
+            if (StringUtils.isEmpty(payload.uriToUpdate)) {
+                warn().data("payload", payload).log("invalid payload: URI was empty or null");
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdater.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdater.java
@@ -1,0 +1,138 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.onsdigital.zebedee.util.URIUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+
+public class PayloadPathUpdater {
+    // Segment input variables
+    private static final String BULLETIN_SEGMENT = "/bulletins";
+    private static final String ADHOC_SEGMENT = "/adhocs";
+    private static final String ARTICLE_SEGMENT = "/articles";
+    private static final String DATA_SEGMENT_WITHOUT_SLASH = "data";
+    private static final String DATASETS_SEGMENT = "/datasets";
+    private static final String LINE_CHART_CONFIG_SEGMENT_WITHOUT_SLASH = "linechartconfig";
+    private static final String QMIS_SEGMENT = "/qmis";
+    private static final String METHODOLOGY_SEGMENT = "/methodologies";
+    private static final String TIME_SERIES_SEGMENT = "/timeseries";
+    private static final String VISUALISATIONS_SEGMENT = "/visualisations";
+
+    // Resource types
+    private static final List<String> RESOURCE_TYPE_SEGMENTS = Arrays.asList(
+            "/chartconfig?",
+            "/chartimage?",
+            "/embed?",
+            "/chart?",
+            "/resource?",
+            "/generator?",
+            "/file?",
+            "/export?"
+    );
+
+    private PayloadPathUpdater() {}
+
+    public static String getCanonicalPagePath(String incomingUrl, String collectionId) {
+        try {
+            if (StringUtils.isEmpty(incomingUrl)) {
+                return incomingUrl;
+            }
+
+            String updatedUri = URIUtils.removeTrailingSlash(incomingUrl.trim());
+            if (StringUtils.isEmpty(updatedUri)) {
+                return "";
+            }
+
+            // Order matters:
+
+            // 1. If starts with /visualisation/ then /visualisation/xxx/xxxx ---> /visualisation/xxx (keep 1 segment) - return here
+            if (updatedUri.startsWith(VISUALISATIONS_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, VISUALISATIONS_SEGMENT, 1);
+            }
+
+            // 2. If resource then e.g. /embed?uri='/something' ---> /something:
+            //      /chartconfig
+            //      /chartimage
+            //      /embed
+            //      /chart
+            //      /resource
+            //      /generator
+            //      /file
+            //      /export
+            for (String keyword : RESOURCE_TYPE_SEGMENTS) {
+                if (updatedUri.startsWith(keyword) && URIUtils.hasQueryParams(updatedUri)) {
+                    updatedUri = URIUtils.getQueryParameterFromURL(updatedUri, "uri");
+                    break;
+                }
+            }
+
+            // 3. If bulletin or article then /xxxx/bulletin/xxxx1/xxxx2/xxxx3 --> /bulletin/xxxx1/xxxx2  (keep 2 segment) & RETURN modified
+            if (updatedUri.contains(ARTICLE_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, ARTICLE_SEGMENT, 2);
+            }
+            if (updatedUri.contains(BULLETIN_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, BULLETIN_SEGMENT, 2);
+            }
+            // 4. If qmis or adhoc or methodologies then /xxxx/qmis/xxx1/xxx2 --> /qmis/xxx1 & RETURNS modified
+            if (updatedUri.contains(ADHOC_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, ADHOC_SEGMENT, 1);
+            }
+            if (updatedUri.contains(QMIS_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, QMIS_SEGMENT, 1);
+            }
+            if (updatedUri.contains(METHODOLOGY_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, METHODOLOGY_SEGMENT, 1);
+            }
+
+            // 5. For the below if (a) is true, skip (b):
+            //      (a) If path ends with /data then /xxx1/data/ --> /xxx1
+            //      (b) If path ends with filename + extension remove it /xxx/filename.extension --> /xxx
+            String lastSegment = URIUtils.getLastSegment(updatedUri);
+            if (lastSegment != null) {
+                if (lastSegment.equals(DATA_SEGMENT_WITHOUT_SLASH)) {
+                    updatedUri = URIUtils.removeLastSegment(updatedUri);
+                } else if (URIUtils.isLastSegmentFileExtension(updatedUri)) {
+                    updatedUri = URIUtils.removeLastSegment(updatedUri);
+                }
+            }
+
+            // 6. If timeseries:
+            //      (a) then /timeseries/xxx --> /xxx or /timeseries/xxx1/xxx2 --> /xxx1/xxx2 (keep up to 2 segments)
+            //      (b) If path ends with /xxx/linechartconfig --> /xxx
+            //      (c) RETURN modified
+            if (updatedUri.contains(TIME_SERIES_SEGMENT)) {
+                updatedUri = URIUtils.getNSegmentsAfterSegmentInput(updatedUri, TIME_SERIES_SEGMENT, 2);
+                if (URIUtils.getLastSegment(updatedUri).equals(LINE_CHART_CONFIG_SEGMENT_WITHOUT_SLASH)) {
+                    return URIUtils.removeLastSegment(updatedUri);
+                }
+                return updatedUri;
+            }
+
+            // 7. If dataset path then /datasets/xxx --> /xxx or /datasets/xxx1/xxx2/xxx3 --> /xxx1/xxx2 (keep up to 2 segments) & RETURN modified
+            if (updatedUri.contains(DATASETS_SEGMENT)) {
+                return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, DATASETS_SEGMENT, 2);
+            }
+            return updatedUri;
+
+        } catch (NullPointerException e) {
+            error().data("collectionId", collectionId)
+                    .data("incomingUrl", incomingUrl)
+                    .logException(e, "failed initialising LegacyCacheApi Payload - failed updating url path for incoming url");
+            return null;
+        }
+    }
+
+    public static boolean isPayloadPathBulletinLatest(String uriToUpdate) {
+        return uriToUpdate != null && uriToUpdate.contains(BULLETIN_SEGMENT) && !uriToUpdate.endsWith("/latest");
+    }
+
+    public static String getPathForBulletinLatest(String uriToUpdate) {
+        if (uriToUpdate.contains(PayloadPathUpdater.BULLETIN_SEGMENT)) {
+            return URIUtils.getNSegmentsAfterSegmentInput(uriToUpdate, BULLETIN_SEGMENT, 1) + "/latest";
+        }
+        return null;
+    }
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/EncryptionUtils.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/EncryptionUtils.java
@@ -4,11 +4,16 @@ import com.github.davidcarboni.cryptolite.Crypto;
 import org.apache.commons.io.FileUtils;
 
 import javax.crypto.SecretKey;
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Created by thomasridd on 25/11/2015.
@@ -63,5 +68,22 @@ public class EncryptionUtils {
      */
     public static InputStream encryptionInputStream(Path path, SecretKey key) throws IOException {
         return encryptionInputStream(Files.newInputStream(path), key);
+    }
+
+    public static String createMD5Checksum(String value) {
+        if (value == null){
+            throw new IllegalArgumentException("Input value cannot be null");
+        }
+
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Error generating MD5 checksum", e);
+        }
+
+        byte[] byteEncodedMessage = value.getBytes(UTF_8);
+        byte[] md5Digest = messageDigest.digest(byteEncodedMessage);
+        return DatatypeConverter.printHexBinary(md5Digest).toLowerCase();
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PublishNotificationTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PublishNotificationTest.java
@@ -1,0 +1,385 @@
+package com.github.onsdigital.zebedee.model.publishing;
+
+import com.github.davidcarboni.httpino.*;
+import com.github.onsdigital.zebedee.configuration.Configuration;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.ContentDetail;
+import com.github.onsdigital.zebedee.json.EventType;
+import com.github.onsdigital.zebedee.json.PendingDelete;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.publishing.legacycacheapi.LegacyCacheApiPayload;
+import com.github.onsdigital.zebedee.model.publishing.legacycacheapi.LegacyCacheApiClient;
+import com.github.onsdigital.zebedee.util.EncryptionUtils;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicStatusLine;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PublishNotificationTest {
+    private MockedStatic<Configuration> mockConfiguration;
+    private AutoCloseable mockitoAnnotations;
+    @Mock
+    private Collection collection;
+    @Mock
+    private Collection collectionWithDeletes;
+    private Host legacyCacheApiHost;
+    private List<String> urisToUpdate;
+    @Captor
+    private ArgumentCaptor<Endpoint> endpointCapture;
+    @Captor
+    private ArgumentCaptor<LegacyCacheApiPayload> payloadCapture;
+    @Captor
+    private ArgumentCaptor<Class<Object>> classCapture;
+
+    @Before
+    public void setUp() throws IOException {
+        mockitoAnnotations = MockitoAnnotations.openMocks(this);
+        mockConfiguration = mockStatic(Configuration.class);
+
+        urisToUpdate = new ArrayList<>();
+        urisToUpdate.add("/economy/inflationandprices/articles/producerpriceinflation/latest");
+        urisToUpdate.add("/economy/inflationandprices/articles/producerpriceinflation/october2022");
+        urisToUpdate.add("/economy/inflationandprices/articles/producerpriceinflation/october2023");
+
+        String legacyCacheApiUrl = "http://localhost:29100";
+        legacyCacheApiHost = new Host(legacyCacheApiUrl);
+        when(Configuration.getLegacyCacheApiUrl()).thenReturn(legacyCacheApiUrl);
+
+        List<Host> websiteHosts = new ArrayList<>();
+        websiteHosts.add(new Host("http://localhost:8080"));
+        when(Configuration.getWebsiteHosts()).thenReturn(websiteHosts);
+
+        Date publishDate = new Date(1609866000000L);
+        Date clearCacheDateTime = new DateTime(publishDate).plusSeconds(Configuration.getSecondsToCacheAfterScheduledPublish()).toDate();
+
+        CollectionDescription mockCollectionDescription = mock(CollectionDescription.class);
+        CollectionDescription mockCollectionDescriptionWithDeletes = mock(CollectionDescription.class);
+        when(mockCollectionDescription.getId()).thenReturn("cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+        when(mockCollectionDescription.getPublishDate()).thenReturn(clearCacheDateTime);
+        when(mockCollectionDescriptionWithDeletes.getId()).thenReturn("cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+        when(mockCollectionDescriptionWithDeletes.getPublishDate()).thenReturn(clearCacheDateTime);
+
+        when(collection.getDescription()).thenReturn(mockCollectionDescription);
+        when(collection.reviewedUris()).thenReturn(urisToUpdate);
+
+        PendingDelete pendingDelete = mock (PendingDelete.class);
+        PendingDelete pendingDelete2 = mock (PendingDelete.class);
+        ContentDetail contentDetail = mock (ContentDetail.class);
+        ContentDetail contentDetail2 = mock (ContentDetail.class);
+
+        when(pendingDelete.getRoot()).thenReturn(contentDetail);
+        when(pendingDelete2.getRoot()).thenReturn(contentDetail2);
+        when(contentDetail.getUri()).thenReturn("/economy/inflationandprices/bulletins/producerpriceinflation/october2022/data.json");
+        when(contentDetail2.getUri()).thenReturn("/economy/inflationandprices/bulletins/producerpriceinflation/october2023/data.json");
+
+        List<PendingDelete> pendingDeleteList = new ArrayList<>();
+        pendingDeleteList.add(pendingDelete);
+        pendingDeleteList.add(pendingDelete2);
+
+        when(collectionWithDeletes.reviewedUris()).thenReturn(urisToUpdate);
+        when(collectionWithDeletes.getDescription()).thenReturn(mockCollectionDescriptionWithDeletes);
+        when(mockCollectionDescriptionWithDeletes.getPendingDeletes()).thenReturn(pendingDeleteList);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockitoAnnotations.close();
+        mockConfiguration.close();
+    }
+
+    @Test
+    public void payloadCacheAPIIsCorrect() {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        PublishNotification publishNotification = new PublishNotification(collection, null, null);
+
+        String expectedPayload = "{" +
+                "\"collection_id\":\"cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\"," +
+                "\"release_time\":\"2021-01-05T17:00:00.000Z\"," +
+                "\"path\":\"/economy/inflationandprices/articles/producerpriceinflation/latest\"" +
+                "}";
+
+        boolean hasExpectedPayload = publishNotification.getLegacyCacheApiPayloads()
+                .stream()
+                .map(Serialiser::serialise)
+                .anyMatch(jsonPayload -> jsonPayload.equals(expectedPayload));
+
+        assertTrue(hasExpectedPayload);
+    }
+
+    @Test
+    public void payloadCacheAPIIsCorrectWithDeletes() {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        PublishNotification publishNotification = new PublishNotification(collectionWithDeletes);
+        assertEquals(5, publishNotification.getLegacyCacheApiPayloads().size());
+
+        String expectedPayload = "{" +
+                "\"collection_id\":\"cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\"," +
+                "\"release_time\":\"2021-01-05T17:00:00.000Z\"," +
+                "\"path\":\"/economy/inflationandprices/articles/producerpriceinflation/latest\"" +
+                "}";
+
+        String expectedPayloadDelete = "{" +
+                "\"collection_id\":\"cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\"," +
+                "\"path\":\"/economy/inflationandprices/bulletins/producerpriceinflation/october2022\"" +
+                "}";
+
+        List<String> jsonPayloads = publishNotification.getLegacyCacheApiPayloads()
+                .stream()
+                .map(Serialiser::serialise)
+                .collect(Collectors.toList());
+
+        boolean hasExpectedPayload = jsonPayloads.contains(expectedPayload);
+        boolean hasExpectedPayloadDelete = jsonPayloads.contains(expectedPayloadDelete);
+
+        assertTrue(hasExpectedPayload);
+        assertTrue(hasExpectedPayloadDelete);
+    }
+
+    @Test
+    public void canCreatePublishNotificationWithURLsSetToNullWhenCacheEnabled() {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        PublishNotification publishNotification = new PublishNotification(collection, null, null);
+        assertNotNull(publishNotification);
+    }
+
+    @Test
+    public void canCreatePublishNotificationWithURLsSetToNullWhenCacheDisabled() {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(false);
+
+        PublishNotification publishNotification = new PublishNotification(collection, null, null);
+        assertNotNull(publishNotification);
+    }
+
+
+    @Test
+    public void publishNotificationWhenCacheAPIEnabledReturns5PayloadsTest() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+        urisToUpdate.add("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+        when(collection.reviewedUris()).thenReturn(urisToUpdate);
+
+        assertEquals(4, collection.reviewedUris().size());
+
+        PublishNotification publishNotification = new PublishNotification(collection);
+        assertEquals(5, publishNotification.getLegacyCacheApiPayloads().size());
+
+        List<String> expectedURIs = new ArrayList<>();
+        expectedURIs.add("/economy/inflationandprices/articles/producerpriceinflation/latest");
+        expectedURIs.add("/economy/inflationandprices/articles/producerpriceinflation/october2022");
+        expectedURIs.add("/economy/inflationandprices/articles/producerpriceinflation/october2023");
+        expectedURIs.add("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022");
+        expectedURIs.add("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest");
+
+        boolean hasExpectedURIs = publishNotification.getLegacyCacheApiPayloads()
+                .stream()
+                .map(payload -> payload.uriToUpdate)
+                .allMatch(expectedURIs::contains);
+
+        assertTrue(hasExpectedURIs);
+    }
+
+    @Test
+    public void publishNotificationWhenCacheAPIEnabledTest() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        assertEquals(3, collection.reviewedUris().size());
+
+        PublishNotification publishNotification = new PublishNotification(collection);
+        assertEquals(3, publishNotification.getLegacyCacheApiPayloads().size());
+
+        Http mockHttp = mock(Http.class);
+        ProtocolVersion version = new ProtocolVersion("1", 1, 0);
+        BasicStatusLine basicStatusLine = new BasicStatusLine(version, 200, "OK");
+
+        WebsiteResponse websiteResponse = new WebsiteResponse();
+        websiteResponse.setMessage("OK");
+        Response<Object> response = new Response<>(basicStatusLine, websiteResponse);
+        when(mockHttp.put(any(), any(), any(), any())).thenReturn(response);
+
+        LegacyCacheApiClient.sendPayloads(mockHttp, legacyCacheApiHost, publishNotification.getLegacyCacheApiPayloads());
+
+        verify(mockHttp, times(3)).put(endpointCapture.capture(), payloadCapture.capture(), classCapture.capture(), any());
+
+        List<String> expectedEndpoints = new ArrayList<>();
+        expectedEndpoints.add("/v1/cache-times/a4706c4475f284457782beba7225283c");
+        expectedEndpoints.add("/v1/cache-times/e1b8d3843ea2dc98211bde230a1bc1b6");
+        expectedEndpoints.add("/v1/cache-times/16dc6c498a4e4b20dbcb66b00971ab3a");
+
+        boolean expectedEndpointsHaveBeenCalled = endpointCapture.getAllValues()
+                .stream()
+                .map(endpoint -> endpoint.url().toString())
+                .allMatch(url -> {
+                    for (String expectedEndpoint : expectedEndpoints) {
+                        if (url.contains(expectedEndpoint)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+
+        assertTrue(expectedEndpointsHaveBeenCalled);
+
+        List<String> expectedPaths = new ArrayList<>();
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/latest");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2022");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2023");
+
+        boolean expectedPathsHaveBeenSet = payloadCapture.getAllValues()
+                .stream()
+                .map(payload -> payload.uriToUpdate)
+                .allMatch(expectedPaths::contains);
+
+        assertTrue(expectedPathsHaveBeenSet);
+    }
+
+    @Test
+    public void publishNotificationWhenCacheAPIEnabledAndUNLOCKTest() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        assertEquals(3, collectionWithDeletes.reviewedUris().size());
+        assertEquals(2, collectionWithDeletes.getDescription().getPendingDeletes().size());
+
+        PublishNotification publishNotification = new PublishNotification(collectionWithDeletes);
+        assertEquals(5, publishNotification.getLegacyCacheApiPayloads().size());
+
+        Http mockHttp = mock(Http.class);
+        ProtocolVersion version = new ProtocolVersion("1", 1, 0);
+        BasicStatusLine basicStatusLine = new BasicStatusLine(version, 200, "OK");
+
+        WebsiteResponse websiteResponse = new WebsiteResponse();
+        websiteResponse.setMessage("OK");
+        Response<Object> response = new Response<>(basicStatusLine, websiteResponse);
+        when(mockHttp.put(any(), any(), any(), any())).thenReturn(response);
+
+        publishNotification.removePublishDateForUnlockedEvents(EventType.UNLOCKED);
+        LegacyCacheApiClient.sendPayloads(mockHttp, legacyCacheApiHost, publishNotification.getLegacyCacheApiPayloads());
+
+        verify(mockHttp, times(5)).put(endpointCapture.capture(), payloadCapture.capture(), classCapture.capture(), any());
+
+        List<String> expectedPaths = new ArrayList<>();
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/latest");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2022");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2023");
+        expectedPaths.add("/economy/inflationandprices/bulletins/producerpriceinflation/october2022");
+        expectedPaths.add("/economy/inflationandprices/bulletins/producerpriceinflation/october2023");
+
+        boolean hasExpectedPaths = payloadCapture.getAllValues().stream().map(payload -> payload.uriToUpdate).allMatch(expectedPaths::contains);
+
+        assertTrue(hasExpectedPaths);
+
+        boolean allDatesAreNull = payloadCapture.getAllValues().stream().map(payload -> payload.publishDate).allMatch(Objects::isNull);
+
+        assertTrue(allDatesAreNull);
+    }
+
+    @Test
+    public void publishNotificationWhenCacheAPIEnabledAndPUBLISHTest() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        assertEquals(3, collectionWithDeletes.reviewedUris().size());
+        assertEquals(2, collectionWithDeletes.getDescription().getPendingDeletes().size());
+
+        PublishNotification publishNotification = new PublishNotification(collectionWithDeletes);
+        assertEquals(5, publishNotification.getLegacyCacheApiPayloads().size());
+
+        Http mockHttp = mock(Http.class);
+        ProtocolVersion version = new ProtocolVersion("1", 1, 0);
+        BasicStatusLine basicStatusLine = new BasicStatusLine(version, 200, "OK");
+
+        WebsiteResponse websiteResponse = new WebsiteResponse();
+        websiteResponse.setMessage("OK");
+        Response<Object> response = new Response<>(basicStatusLine, websiteResponse);
+        when(mockHttp.put(any(), any(), any(), any())).thenReturn(response);
+
+        LegacyCacheApiClient.sendPayloads(mockHttp, legacyCacheApiHost, publishNotification.getLegacyCacheApiPayloads());
+
+        verify(mockHttp, times(5)).put(endpointCapture.capture(), payloadCapture.capture(), classCapture.capture(), any());
+
+        List<String> expectedPaths = new ArrayList<>();
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/latest");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2022");
+        expectedPaths.add("/economy/inflationandprices/articles/producerpriceinflation/october2023");
+        expectedPaths.add("/economy/inflationandprices/bulletins/producerpriceinflation/october2022");
+        expectedPaths.add("/economy/inflationandprices/bulletins/producerpriceinflation/october2023");
+
+        boolean hasExpectedPaths = payloadCapture.getAllValues().stream().map(payload -> payload.uriToUpdate).allMatch(expectedPaths::contains);
+
+        assertTrue(hasExpectedPaths);
+
+        Long expectedNumberOfPayloadsWithoutPublishDate = 2L;
+        Long payloadsWithoutPublishDate = payloadCapture.getAllValues().stream().filter(payload -> payload.publishDate == null).count();
+
+        assertEquals(expectedNumberOfPayloadsWithoutPublishDate, payloadsWithoutPublishDate);
+    }
+
+    @Test
+    public void publishNotificationNoClientCallsWhenNoUrlsWhenCacheAPIEnabledTest() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        urisToUpdate = new ArrayList<>();
+        when(collection.reviewedUris()).thenReturn(urisToUpdate);
+
+        PublishNotification publishNotification = new PublishNotification(collection);
+        assertEquals(0, publishNotification.getLegacyCacheApiPayloads().size());
+
+        Http httpMock = mock(Http.class);
+
+        LegacyCacheApiClient.sendPayloads(httpMock, legacyCacheApiHost, new ArrayList<>());
+
+        verify(httpMock, never()).postJson(any(), any(), any());
+    }
+
+    @Test
+    public void constructorDoesNotThrowWhenUrlsIsNullTest() throws IOException {
+        urisToUpdate = new ArrayList<>();
+        urisToUpdate.add(null);
+        when(collection.reviewedUris()).thenReturn(urisToUpdate);
+
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        List<Host> hosts = new ArrayList<>();
+        hosts.add(new Host("http://localhost:29100"));
+        when(Configuration.getWebsiteHosts()).thenReturn(hosts);
+
+        assertTrue(Configuration.isLegacyCacheAPIEnabled());
+
+        PublishNotification publishNotification = new PublishNotification(collection, null, null);
+
+        assertNotNull(publishNotification);
+    }
+
+    @Test
+    public void checkZebedeeCodeChecksumIsSameAsProxyCodeChecksum() throws IOException {
+        when(Configuration.isLegacyCacheAPIEnabled()).thenReturn(true);
+
+        String uri = "/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls";
+        urisToUpdate = new ArrayList<>();
+        urisToUpdate.add(uri);
+
+        when(collection.reviewedUris()).thenReturn(urisToUpdate);
+
+        PublishNotification publishNotification = new PublishNotification(collection);
+
+        String resultUri = publishNotification.getLegacyCacheApiPayloads().iterator().next().uriToUpdate;
+        String uriChecksum = EncryptionUtils.createMD5Checksum(resultUri);
+
+        String expectedChecksum = "4c0185c09adc47b557ff3c6db81be8cc"; // checksum from proxy generated should match for given url
+
+        assertEquals(expectedChecksum, uriChecksum);
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClientTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClientTest.java
@@ -1,0 +1,92 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.davidcarboni.httpino.Host;
+import com.github.davidcarboni.httpino.Http;
+import com.github.davidcarboni.httpino.Response;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.publishing.WebsiteResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LegacyCacheApiClientTest {
+    @Mock
+    private Collection collection;
+    private AutoCloseable mockitoAnnotations;
+    private List<LegacyCacheApiPayload> payloads;
+    private Http httpMock;
+    private Host host;
+
+    @Before
+    public void setup() {
+        mockitoAnnotations = MockitoAnnotations.openMocks(this);
+
+        CollectionDescription cdmock = mock(CollectionDescription.class);
+        when(collection.getDescription()).thenReturn(cdmock);
+
+        LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collection.getDescription().getId(), null, new Date());
+        payloads = new ArrayList<>();
+        payloads.add(legacyCacheApiPayload);
+
+        httpMock = mock(Http.class);
+
+        host = new Host("http://localhost:29100");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockitoAnnotations.close();
+    }
+
+    @Test
+    public void sendNotificationPUTNeverCalledWhenPayloadsIsEmptyTest() throws IOException {
+        payloads.clear();
+
+        LegacyCacheApiClient.sendPayloads(httpMock, host, payloads);
+
+        verify(httpMock, never()).put(any(), any(), any(), any());
+    }
+
+    @Test
+    public void sendNotificationThrowsExceptionWhenURIIsEmptyTest() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> LegacyCacheApiClient.sendPayloads(httpMock, host, payloads));
+
+        verify(httpMock, never()).put(any(), any(), any(), any());
+    }
+
+    @Test
+    public void sendNotificationPUTCalledWhenPayloadIsSetTest() throws IOException {
+        payloads.get(0).uriToUpdate = "/economy/inflationandprices/bulletins/latest";
+
+        ProtocolVersion version = new ProtocolVersion("1", 1, 0);
+        BasicStatusLine basicStatusLine = new BasicStatusLine(version, 200, "OK");
+
+        WebsiteResponse websiteResponse = new WebsiteResponse();
+        websiteResponse.setMessage("OK");
+        Response<Object> response = new Response<>(basicStatusLine, websiteResponse);
+
+        when(httpMock.put(any(), any(), any(), any())).thenReturn(response);
+
+        LegacyCacheApiClient.sendPayloads(httpMock, host, payloads);
+
+        verify(httpMock, times(1)).put(any(), any(), any(), any());
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
@@ -1,0 +1,371 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.model.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Enclosed.class)
+public class LegacyCacheApiPayloadBuilderTest {
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestVisualisation {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestVisualisation(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkVisualisations() {
+            return Arrays.asList(new Object[][]{
+                    // case 1
+                    {"/ons/seg1", "/ons/seg1"}, {"/ons/seg1/seg2/", "/ons/seg1/seg2"},
+                    // case 2: visualisation => keep 1 after type
+                    {"/visualisations/dvc1945/seasonalflu/", "/visualisations/dvc1945"}, {"/visualisations/dvc1945/seasonalflu/index.html", "/visualisations/dvc1945"},
+                    // case 2 + trailing slash
+                    {"/visualisations/dvc1945/seasonalflu/index.html/", "/visualisations/dvc1945"},});
+        }
+
+        @Test
+        public void testVisualisation() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestResources {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestResources(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkResourcesPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{{"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}});
+        }
+
+        @Test
+        public void testResources() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestBulletin {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestBulletin(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkBulletinsPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // bulletins & articles => keep 2 after type
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},
+                    // trailing slash
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023/", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},});
+        }
+
+        @Test
+        public void testBulletinPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestQMisAndAdhocAndMethods {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestQMisAndAdhocAndMethods(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkQMisAndAdhocAndMethodsPath() {
+            return Arrays.asList(new Object[][]{
+                    // qmis & adhoc => keep 1 after type
+                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
+                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"},
+                    // trailing slash
+                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi/", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
+                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},});
+        }
+
+        @Test
+        public void testQMISAndAdhocPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestData {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestData(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkDataPath() {
+            // resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // remove /data
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/something/data", "/economy/grossdomesticproductgdp/something"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
+                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/data", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},
+                    // remove data + trailing slash
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/something/data/", "/economy/grossdomesticproductgdp/something"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data/", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"}});
+        }
+
+        @Test
+        public void testDataPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestTimeseries {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestTimeseries(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkTimeSeriesPath() {
+            return Arrays.asList(new Object[][]{
+
+                    // timeseries => keep up to 2 after type
+                    {"/economy/grossdomesticproductgdp/timeseries/ihyq", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    // timeseries => remove linechartconfig
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig", "/economy/grossdomesticproductgdp/timeseries"},
+                    // timeseries + trailing slash
+                    {"/economy/grossdomesticproductgdp/timeseries/ihyq/", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries"}});
+        }
+
+        @Test
+        public void testTimeseries() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestDataset {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestDataset(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkDatasetPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // datasets => keep up to 2 after type
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    // trailing slash
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    // Topic pages
+                    {"/economy", "/economy"},
+                    {"/economy/inflationandpriceindices", "/economy/inflationandpriceindices"},
+                    {"/economy/inflationandpriceindices/", "/economy/inflationandpriceindices"},
+                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
+                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours/", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
+                    // Static pages
+                    {"/aboutus/transparencyandgovernance/dataprotection", "/aboutus/transparencyandgovernance/dataprotection"},
+                    {"/aboutus/transparencyandgovernance/dataprotection/", "/aboutus/transparencyandgovernance/dataprotection"}, {"/file?uri=/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals/c3ac8759.png", "/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals"}});
+        }
+
+        @Test
+        public void testDataset() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LegacyCacheApiPayloadParameterisedTestEncode {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public LegacyCacheApiPayloadParameterisedTestEncode(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkEncodedPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // Encoded endpoints
+                    {"/file?uri=%2Feconomy%2Fseg1", "/economy/seg1"},
+                    {"/file?uri=%2Feconomy%2Fseg1%2Fseg2", "/economy/seg1/seg2"}});
+        }
+
+        @Test
+        public void testEncoded() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(MockitoJUnitRunner.class)
+    public static class LegacyCacheApiPayloadNonParameterisedTest {
+        @Mock
+        private Collection collection;
+        private List<String> urisToUpdate;
+        private final Date publishDate = new Date(1609866000000L);
+        private AutoCloseable mockitoAnnotations;
+
+        @Before
+        public void setUp() throws IOException {
+            mockitoAnnotations = MockitoAnnotations.openMocks(this);
+            urisToUpdate = new ArrayList<>();
+
+            CollectionDescription mockCollectionDescription = mock(CollectionDescription.class);
+            when(mockCollectionDescription.getId()).thenReturn("cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+            when(collection.getDescription()).thenReturn(mockCollectionDescription);
+            when(collection.reviewedUris()).thenReturn(urisToUpdate);
+        }
+
+        @After
+        public void tearDown() throws Exception {
+            mockitoAnnotations.close();
+            urisToUpdate.clear();
+        }
+
+        @Test
+        public void NotificationPayloadCacheApiForBulletinLatestReturnsTwoTest() {
+            String testUriBulletin = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/";
+            urisToUpdate.add(testUriBulletin);
+
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            assertEquals(2, payloads.size());
+
+            String expectedURI = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest";
+            boolean hasExpectedURI = payloads.stream().map(payload -> payload.uriToUpdate).anyMatch(uri -> uri.equals(expectedURI));
+
+            assertTrue(hasExpectedURI);
+        }
+
+        @Test
+        public void NotificationPayloadCacheApiForBulletinLatestReturnsTwoFromParamUrlTest() {
+            String testUriWithBulletinAsQueryParam = "/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/&format=csv";
+
+            urisToUpdate.clear();
+            urisToUpdate.add(testUriWithBulletinAsQueryParam);
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            assertEquals(2, payloads.size());
+
+            String expectedURI = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest";
+            boolean hasExpectedURI = payloads.stream().map(payload -> payload.uriToUpdate).anyMatch(uri -> uri.equals(expectedURI));
+
+            assertTrue(hasExpectedURI);
+        }
+
+        @Test
+        public void NotificationPayloadCacheApiForBulletinLatestReturnsOneTest() {
+            String testUriBulletinWithLatestString = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest/30d7d6c2/";
+
+            urisToUpdate.clear();
+            urisToUpdate.add(testUriBulletinWithLatestString);
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            assertEquals(1, payloads.size());
+            assertTrue(payloads.iterator().next().uriToUpdate.contains("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"));
+        }
+
+        @Test
+        public void NotificationPayloadCacheApiForBulletinLatestReturnsOneForNoBulletinsTest() {
+            String testUriWithArticlesString = "/economy/inflationandpriceindices/articles/producerpriceinflation/october2022/30d7d6c2/";
+
+            urisToUpdate.clear();
+            urisToUpdate.add(testUriWithArticlesString);
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            assertEquals(1, payloads.size());
+            assertTrue(payloads.iterator().next().uriToUpdate.contains("/economy/inflationandpriceindices/articles/producerpriceinflation/october2022"));
+        }
+
+        @Test
+        public void testGetPathForBulletinLatest() {
+            String result = PayloadPathUpdater.getPathForBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertEquals("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", result);
+        }
+
+        @Test
+        public void testIsPathBulletinLatest() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertTrue(result);
+        }
+
+        @Test
+        public void testIsPathBulletinLatestFalseForArticlesPath() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/articles/producerpriceinflation/october2022/30d7d6c2/");
+            assertFalse(result);
+        }
+
+
+        @Test
+        public void testIsPathBulletinLatestFalse() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest");
+            assertFalse(result);
+        }
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/EncryptionUtilsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/EncryptionUtilsTest.java
@@ -1,7 +1,5 @@
 package com.github.onsdigital.zebedee.util;
 
-import static org.junit.Assert.*;
-
 import com.github.davidcarboni.cryptolite.Keys;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -9,22 +7,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.crypto.SecretKey;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
 
 /**
  * Created by thomasridd on 25/11/2015.
  */
 public class EncryptionUtilsTest {
-Path path;
+    Path path;
 
     @Before
     public void setUp() throws Exception {
-        path = Files.createTempFile("EncryptionUtilsTest","txt");
+        path = Files.createTempFile("EncryptionUtilsTest", "txt");
     }
 
     @After
@@ -73,4 +71,16 @@ Path path;
         assertEquals(plain, value);
     }
 
+    @Test
+    public void givenValue_generatingChecksum_thenVerifying() {
+        String input = "hello world";
+        String expectedChecksum = "5eb63bbbe01eeed093cb22bb8f5acdc3";
+        String result = EncryptionUtils.createMD5Checksum(input);
+        assertEquals(expectedChecksum, result);
+    }
+
+    @Test
+    public void givenNullValue_generatingChecksum_throwsException() {
+        assertThrows(IllegalArgumentException.class, () -> EncryptionUtils.createMD5Checksum(null));
+    }
 }

--- a/zebedee-cms/src/test/resources/xls/example-table.html
+++ b/zebedee-cms/src/test/resources/xls/example-table.html
@@ -25,7 +25,7 @@
 <td rowspan="2" style="white-space:pre-wrap;text-align:left;border-top:thin solid black;">Offence group</td><td style="white-space:pre-wrap;color: black; ">&nbsp;</td><td style="white-space:pre-wrap;text-align:center;border-bottom:thin solid black;color: black; ">January 2014 to December 2014 compared with:</td><td style="white-space:pre-wrap;text-align:center;border-bottom:thin solid black;color: black; ">&nbsp;</td><td style="white-space:pre-wrap;text-align:center;border-bottom:thin solid black;font-weight:bold;color: black; ">&nbsp;</td>
 </tr>
 <tr style="height:24.0pt;">
-<td style="white-space:pre-wrap;text-align:right;border-bottom:thin solid black;font-weight:bold;">Jan-14 to 
+<td style="white-space:pre-wrap;text-align:right;border-bottom:thin solid black;font-weight:bold;">Jan-14 to
 Dec-14</td><td style="white-space:pre-wrap;text-align:right;border-bottom:thin solid black;">Apr-03 to 
 Mar-04</td><td style="white-space:pre-wrap;text-align:right;border-bottom:thin solid black;">Apr-08 to 
 Mar-09</td><td style="white-space:pre-wrap;text-align:right;border-bottom:thin solid black;">Jan-13 to

--- a/zebedee-reader.nomad
+++ b/zebedee-reader.nomad
@@ -47,7 +47,7 @@ job "zebedee-reader" {
           "-Xmx{{WEB_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.classes=target/classes",
-          "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
+          "-javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
           "-Dotel.javaagent.enabled=false",

--- a/zebedee-reader.nomad
+++ b/zebedee-reader.nomad
@@ -50,6 +50,7 @@ job "zebedee-reader" {
           "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
+          "-Dotel.javaagent.enabled=false",
           "-Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api",
           "com.github.davidcarboni.restolino.Main",
         ]

--- a/zebedee-reader/Dockerfile
+++ b/zebedee-reader/Dockerfile
@@ -14,6 +14,7 @@ ENTRYPOINT java -Xmx2048m \
           -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \
           -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
           -Dotel.propagators=tracecontext,baggage \
+          -Dotel.javaagent.enabled=false \
           -Dotel.service.name=zebedee \
           -cp "target/dependency/*:target/classes/" \
           com.github.davidcarboni.restolino.Main

--- a/zebedee-reader/Dockerfile
+++ b/zebedee-reader/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 9200
 ENTRYPOINT java -Xmx2048m \
           -Drestolino.classes=target/classes \
           -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \
-          -javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+          -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
           -Dotel.propagators=tracecontext,baggage \
           -Dotel.javaagent.enabled=false \
           -Dotel.service.name=zebedee \

--- a/zebedee-reader/Dockerfile.concourse
+++ b/zebedee-reader/Dockerfile.concourse
@@ -8,6 +8,7 @@ ADD classes target/classes
 CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"           \
     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
     -Dotel.propagators=tracecontext,baggage \
+    -Dotel.javaagent.enabled=false \
     -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \
     -Drestolino.classes=target/classes                                 \
     com.github.davidcarboni.restolino.Main

--- a/zebedee-reader/Dockerfile.concourse
+++ b/zebedee-reader/Dockerfile.concourse
@@ -6,7 +6,7 @@ ADD dependency target/dependency
 ADD classes target/classes
 
 CMD java -Xmx2048m -cp "target/dependency/*:target/classes/"           \
-    -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+    -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
     -Dotel.propagators=tracecontext,baggage \
     -Dotel.javaagent.enabled=false \
     -Drestolino.packageprefix=com.github.onsdigital.zebedee.reader.api \

--- a/zebedee-reader/Dockerfile.local
+++ b/zebedee-reader/Dockerfile.local
@@ -18,7 +18,7 @@ ENTRYPOINT java $JAVA_OPTS \
      -Dcontent_dir=$CONTENT_DIR \
      -DSTART_EMBEDDED_SERVER=N \
      -Drestolino.packageprefix=$PACKAGE_PREFIX \
-     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
+     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
      -Dotel.propagators=tracecontext,baggage \
      -Dotel.javaagent.enabled=false \
      -cp "target/dependency/*:target/classes/" \

--- a/zebedee-reader/Dockerfile.local
+++ b/zebedee-reader/Dockerfile.local
@@ -20,5 +20,6 @@ ENTRYPOINT java $JAVA_OPTS \
      -Drestolino.packageprefix=$PACKAGE_PREFIX \
      -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.31.0.jar \
      -Dotel.propagators=tracecontext,baggage \
+     -Dotel.javaagent.enabled=false \
      -cp "target/dependency/*:target/classes/" \
      com.github.davidcarboni.restolino.Main

--- a/zebedee-reader/Dockerfile.local
+++ b/zebedee-reader/Dockerfile.local
@@ -18,7 +18,7 @@ ENTRYPOINT java $JAVA_OPTS \
      -Dcontent_dir=$CONTENT_DIR \
      -DSTART_EMBEDDED_SERVER=N \
      -Drestolino.packageprefix=$PACKAGE_PREFIX \
-     -javaagent:zebedee-cms/target/dependency/aws-opentelemetry-agent-1.32.0.jar \
+     -javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar \
      -Dotel.propagators=tracecontext,baggage \
      -Dotel.javaagent.enabled=false \
      -cp "target/dependency/*:target/classes/" \

--- a/zebedee-reader/pom.xml
+++ b/zebedee-reader/pom.xml
@@ -29,6 +29,12 @@
     </repositories>
 
     <dependencies>
+       <!-- Logging -->
+        <dependency>
+            <groupId>com.github.onsdigital</groupId>
+            <artifactId>dp-logging</artifactId>
+        </dependency>
+
         <!--Restolino-->
         <dependency>
             <groupId>com.github.onsdigital</groupId>
@@ -69,12 +75,6 @@
             <artifactId>opencsv</artifactId>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>com.github.onsdigital</groupId>
-            <artifactId>dp-logging</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -99,11 +99,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>
@@ -167,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/util/PageTypeResolver.java
@@ -107,7 +107,7 @@ class PageTypeResolver implements JsonDeserializer<Page> {
 
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addUrls(
                     PageTypeResolver.class.getProtectionDomain().getCodeSource().getLocation());
-            configurationBuilder.addClassLoader(PageTypeResolver.class.getClassLoader());
+            configurationBuilder.addClassLoaders(PageTypeResolver.class.getClassLoader());
             Set<Class<? extends Page>> classes = new Reflections(configurationBuilder).getSubTypesOf(Page.class);
 
             for (Class<? extends Page> contentClass : classes) {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/util/URIUtils.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/util/URIUtils.java
@@ -2,9 +2,18 @@ package com.github.onsdigital.zebedee.util;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.removeEnd;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 /**
  * Created by bren on 31/07/15.
@@ -24,7 +33,6 @@ public class URIUtils {
         return uri;
     }
 
-
     /**
      * @param uri The URI of the item. If url ends with forwards slash removes the forward slash
      * @return
@@ -36,13 +44,12 @@ public class URIUtils {
         return uri;
     }
 
-
     /**
      * Resolves nth path segment, if n is bigger than number of segments or a negative value returns null.
      * Segment numbers are 1 based
      * <p>
      * e.g. ("/data/economy/yadayada", 2) = "economy"
-     *
+     * <p>
      * Note this method only works for absolute uris. Relative uris will not work as expected.
      *
      * @param uri
@@ -66,11 +73,11 @@ public class URIUtils {
         return uri.split("/");
     }
 
-
     public static String getLastSegment(String uri) {
         if (isEmpty(uri)) {
             return null;
         }
+        // getSegments will return [] empty array for passing in one slash "/"
         String[] segments = getSegments(uri);
         if (ArrayUtils.isEmpty(segments)) {
             return null;
@@ -79,11 +86,60 @@ public class URIUtils {
         return segments[segments.length - 1];
     }
 
-    public static String removeLastSegment(String uri) {
-        if (isEmpty(uri)) {
-            return null;
+    public static String getQueryParameterFromURL(String url, String queryParam) {
+        try {
+            String decoded = URLDecoder.decode(url, StandardCharsets.UTF_8.toString());
+            List<NameValuePair> params = URLEncodedUtils.parse(new URI(decoded), StandardCharsets.UTF_8);
+            Optional<NameValuePair> result = params.stream().filter(param -> param.getName().equals(queryParam)).findFirst();
+            if (result.isPresent()){
+                return result.get().getValue();
+            }
+        } catch (UnsupportedEncodingException | URISyntaxException e) {
+            throw new RuntimeException("Error retrieving query parameter from path", e);
         }
-        String result =  removeEnd(removeTrailingSlash(uri), FORWARD_SLASH + getLastSegment(uri));
+        return null;
+    }
+
+    public static boolean isLastSegmentFileExtension(String path) {
+        if ("".equals(path)){
+            return false;
+        }
+        String lastSegment = getLastSegment(path);
+        if (lastSegment == null){
+            return false;
+        }
+        return lastSegment.contains(".");
+    }
+
+    public static boolean hasQueryParams(String path) {
+        return path.contains("=");
+    }
+
+    public static String removeLastSegment(String uri) {
+        String result = removeEnd(removeTrailingSlash(uri), FORWARD_SLASH + getLastSegment(uri));
         return isEmpty(result) ? "/" : result;
+    }
+
+    public static String getNSegmentsAfterSegmentInput(String uri, String segmentInput, int n) {
+        if (!uri.contains(segmentInput)) {
+            return uri;
+        }
+        int start = uri.indexOf(segmentInput);
+        String everythingAfterSegment = uri.substring(start + segmentInput.length());
+        return uri.substring(0, start + segmentInput.length()) + getNSegments(removeLeadingSlash(everythingAfterSegment), n);
+    }
+
+    public static String getNSegments(String uri, int n) {
+        StringBuilder result = new StringBuilder();
+        String[] parts = removeLeadingSlash(uri).split("/");
+        int minimumOfSegments = Math.min(parts.length, n);
+        for (int i = 0; i < minimumOfSegments; i++) {
+            if (parts[i] != null) {
+                result.append("/").append(parts[i]);
+            } else {
+                break;
+            }
+        }
+        return result.toString();
     }
 }

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/util/URIUtilsTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/util/URIUtilsTest.java
@@ -1,0 +1,160 @@
+package com.github.onsdigital.zebedee.util;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.*;
+
+public class URIUtilsTest {
+
+    @Test
+    public void removeLastSegmentWhenEndingOnEmpty(){
+        String result = URIUtils.removeLastSegment("//");
+        assertEquals("/",result);
+    }
+
+    @Test
+    public void removeLastSegmentWhenEndingOnSlash(){
+        String result = URIUtils.removeLastSegment("/segment1/segment2/segment3/");
+        assertEquals("/segment1/segment2",result);
+    }
+
+    @Test
+    public void removeLastSegment(){
+        String result = URIUtils.removeLastSegment("/segment1/segment2/segment3");
+        assertEquals("/segment1/segment2",result);
+    }
+
+    @Test
+    public void getQueryParameterFromURLShouldFailBecauseParameterNamesAreCaseSensitiveTest() throws UnsupportedEncodingException{
+        String url = "/file?URI=" + "/Economy/inflation/articles/research/topic/health/december2023/december2023/";
+        String result = URIUtils.getQueryParameterFromURL(url, "Uri");
+        assertEquals(null, result);
+    }
+
+    @Test
+    public void getQueryParameterFromURLTest() throws UnsupportedEncodingException{
+        String url = "/file?URI=" + "/Economy/inflation/articles/research/topic/health/december2023/december2023/";
+        String result = URIUtils.getQueryParameterFromURL(url, "URI");
+        assertEquals("/Economy/inflation/articles/research/topic/health/december2023/december2023/", result);
+    }
+
+    @Test
+    public void isLastSegmentFileExtensionYes() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023/december2023.json";
+        boolean result = URIUtils.isLastSegmentFileExtension(url);
+        assertTrue(result);
+    }
+
+    @Test
+    public void isLastSegmentFileExtensionNo() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023/december2023/";
+        boolean result = URIUtils.isLastSegmentFileExtension(url);
+        assertFalse(result);
+    }
+
+    @Test
+    public void isLastSegmentFileExtensionNo2() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023/december2023";
+        boolean result = URIUtils.isLastSegmentFileExtension(url);
+        assertFalse(result);
+    }
+
+    @Test
+    public void isLastSegmentFileExtensionNo3() {
+        boolean result = URIUtils.isLastSegmentFileExtension("/");
+        assertFalse(result);
+    }
+
+    @Test
+    public void getLastSegments() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023";
+        String result = URIUtils.getLastSegment(url);
+        assertEquals("december2023", result);
+    }
+
+    @Test
+    public void getLastSegmentsOfEmptyReturnsNull() {
+        String url = "";
+        String result = URIUtils.getLastSegment(url);
+        assertNull(result);
+    }
+
+    @Test
+    public void getLastSegmentsOfOneSlashReturnsNull() {
+        String url = "/";
+        String result = URIUtils.getLastSegment(url);
+        assertNull(result);
+    }
+
+    @Test
+    public void getLastSegmentsFileName() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023/december2023.json";
+        String result = URIUtils.getLastSegment(url);
+        assertEquals("december2023.json", result);
+    }
+
+    @Test
+    public void getLastSegmentsFileName2() {
+        String url = "december2023.json";
+        String result = URIUtils.getLastSegment(url);
+        assertEquals("december2023.json", result);
+    }
+
+    @Test
+    public void getNSegmentsAfterSegment() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023";
+        String result = URIUtils.getNSegmentsAfterSegmentInput(url, "/articles", 2);
+        assertEquals("/economy/inflation/articles/research/topic", result);
+    }
+
+    @Test
+    public void getNSegmentsAfterSegment10th() {
+        String url = "/economy/inflation/articles/research/topic/health/december2023";
+        String result = URIUtils.getNSegmentsAfterSegmentInput(url, "/articles", 10);
+        assertEquals("/economy/inflation/articles/research/topic/health/december2023", result);
+    }
+
+    @Test
+    public void getNSegmentsAfterSegmentIfNotExistsReturnSameURL() {
+        String url = "/economy/inflation/bulletins/research/topic/health/december2023";
+        String result = URIUtils.getNSegmentsAfterSegmentInput(url, "/articles", 2);
+        assertEquals(url, result);
+    }
+
+    @Test
+    public void getNSegmentsNEquals2() {
+        String url = "/economy/inflation/bulletins/research/topic/health/december2023";
+        String result = URIUtils.getNSegments(url, 2);
+        assertEquals("/economy/inflation", result);
+    }
+
+    @Test
+    public void getNSegmentsNlongerThenAvailable() {
+        String url = "/economy/inflation/bulletins/research/topic/health/december2023";
+        String result = URIUtils.getNSegments(url, 9);
+        assertEquals("/economy/inflation/bulletins/research/topic/health/december2023", result);
+    }
+
+    @Test
+    public void getNSegmentsForPassNEquals0() {
+        String url = "/economy/inflation/bulletins/research/topic/health/december2023";
+        String result = URIUtils.getNSegments(url, 0);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void getNSegmentsForSlashOnly() {
+        String url = "/";
+        String result = URIUtils.getNSegments(url, 2);
+        assertEquals("/", result);
+    }
+
+    @Test
+    public void getNSegmentsForNegative() {
+        String url = "/economy/inflation/bulletins/research/topic/health/december2023";
+        String result = URIUtils.getNSegments(url, -2);
+        assertEquals("", result);
+    }
+}

--- a/zebedee.nomad
+++ b/zebedee.nomad
@@ -52,6 +52,7 @@ job "zebedee" {
           "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
+          "-Dotel.javaagent.enabled=false",
           "-Drestolino.packageprefix=com.github.onsdigital.zebedee.api",
           "com.github.davidcarboni.restolino.Main",
         ]

--- a/zebedee.nomad
+++ b/zebedee.nomad
@@ -49,7 +49,7 @@ job "zebedee" {
           "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-cp target/dependency/*:target/classes/",
           "-Drestolino.classes=target/classes",
-          "-javaagent:target/dependency/aws-opentelemetry-agent-1.31.0.jar",
+          "-javaagent:target/dependency/aws-opentelemetry-agent-1.32.0.jar",
           "-Dotel.propagators=tracecontext,baggage",
           "-Dotel.service.name=zebedee",
           "-Dotel.javaagent.enabled=false",


### PR DESCRIPTION
### What

Release 2.21.0 includes:
- Feature flag added so that Zebedee communicates with the Legacy Cache API instead of Babbage
- Downgrade elasticsearch for snakeyaml
- Update internal and external dependencies to latest minor version
- Disabling otel

### How to review

Check release changes are okay

### Who can review

Anyone from ONS