### PR TITLE
Send request to Legacy Cache API on approval

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PublishNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PublishNotification.java
@@ -38,13 +38,12 @@ public class PublishNotification {
     }
 
     public PublishNotification(Collection collection, List<String> urisToUpdate, List<ContentDetail> urisToDelete) {
-        // Delay the clearing of the cache after publish to minimise load on the server while publishing.
-        Date clearCacheDate = new DateTime(collection.getDescription().getPublishDate())
-                .plusSeconds(Configuration.getSecondsToCacheAfterScheduledPublish()).toDate();
-
         if (Configuration.isLegacyCacheAPIEnabled()) {
-            this.legacyCacheApiPayloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(clearCacheDate).build().getPayloads();
+            this.legacyCacheApiPayloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
         } else {
+            // Delay the clearing of the cache after publish to minimise load on the server while publishing.
+            Date clearCacheDate = new DateTime(collection.getDescription().getPublishDate())
+                    .plusSeconds(Configuration.getSecondsToCacheAfterScheduledPublish()).toDate();
             this.payload = new NotificationPayload(collection.getDescription().getId(), urisToUpdate, urisToDelete, clearCacheDate);
         }
     }
@@ -110,7 +109,7 @@ public class PublishNotification {
     }
 
     private void sendRequestToLegacyCacheApi(EventType eventType) {
-        if (eventType.equals(EventType.PUBLISHED) || eventType.equals(EventType.UNLOCKED)) {
+        if (eventType.equals(EventType.APPROVED) || eventType.equals(EventType.UNLOCKED)) {
             info().data("eventType", eventType.name()).log("sending request to Legacy Cache API");
 
             removePublishDateForUnlockedEvents(eventType);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
@@ -21,7 +21,6 @@ public class LegacyCacheApiPayloadBuilder {
 
     public static class Builder {
         private Collection collection;
-        private Date publishDate;
         private final Map<String, LegacyCacheApiPayload> payloadsByPath = new HashMap<>();
 
         public Builder() {}
@@ -31,22 +30,18 @@ public class LegacyCacheApiPayloadBuilder {
             return this;
         }
 
-        public LegacyCacheApiPayloadBuilder.Builder publishDate(Date publishDate) {
-            this.publishDate = publishDate;
-            return this;
-        }
-
         public LegacyCacheApiPayloadBuilder build() {
             Objects.requireNonNull(this.collection);
             String collectionId = collection.getDescription().getId();
+            Date publishDate = collection.getDescription().getPublishDate();
             try {
                 collection.reviewedUris()
                         .forEach(uri -> {
                                     String pagePath = PayloadPathUpdater.getCanonicalPagePath(uri, collectionId);
-                                    LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, pagePath, this.publishDate);
+                                    LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, pagePath, publishDate);
                                     if (isValid(legacyCacheApiPayload)) {
                                         payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
-                                        addPayloadForBulletinLatest(legacyCacheApiPayload.uriToUpdate, collectionId, this.publishDate);
+                                        addPayloadForBulletinLatest(legacyCacheApiPayload.uriToUpdate, collectionId, publishDate);
                                     }
                                 }
                         );

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
@@ -271,7 +271,6 @@ public class LegacyCacheApiPayloadBuilderTest {
         @Mock
         private Collection collection;
         private List<String> urisToUpdate;
-        private final Date publishDate = new Date(1609866000000L);
         private AutoCloseable mockitoAnnotations;
 
         @Before
@@ -279,8 +278,11 @@ public class LegacyCacheApiPayloadBuilderTest {
             mockitoAnnotations = MockitoAnnotations.openMocks(this);
             urisToUpdate = new ArrayList<>();
 
+            Date publishDate = new Date(1609866000000L);
+
             CollectionDescription mockCollectionDescription = mock(CollectionDescription.class);
             when(mockCollectionDescription.getId()).thenReturn("cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+            when(mockCollectionDescription.getPublishDate()).thenReturn(publishDate);
 
             when(collection.getDescription()).thenReturn(mockCollectionDescription);
             when(collection.reviewedUris()).thenReturn(urisToUpdate);
@@ -297,7 +299,7 @@ public class LegacyCacheApiPayloadBuilderTest {
             String testUriBulletin = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/";
             urisToUpdate.add(testUriBulletin);
 
-            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
             assertEquals(2, payloads.size());
 
             String expectedURI = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest";
@@ -312,7 +314,7 @@ public class LegacyCacheApiPayloadBuilderTest {
 
             urisToUpdate.clear();
             urisToUpdate.add(testUriWithBulletinAsQueryParam);
-            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
             assertEquals(2, payloads.size());
 
             String expectedURI = "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest";
@@ -327,7 +329,7 @@ public class LegacyCacheApiPayloadBuilderTest {
 
             urisToUpdate.clear();
             urisToUpdate.add(testUriBulletinWithLatestString);
-            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
             assertEquals(1, payloads.size());
             assertTrue(payloads.iterator().next().uriToUpdate.contains("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"));
         }
@@ -338,7 +340,7 @@ public class LegacyCacheApiPayloadBuilderTest {
 
             urisToUpdate.clear();
             urisToUpdate.add(testUriWithArticlesString);
-            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).publishDate(publishDate).build().getPayloads();
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
             assertEquals(1, payloads.size());
             assertTrue(payloads.iterator().next().uriToUpdate.contains("/economy/inflationandpriceindices/articles/producerpriceinflation/october2022"));
         }


### PR DESCRIPTION
### What

We are currently sending requests to the Legacy Cache API when we receive a `PUBLISHED` event, but we should be sending them when we receive an `APPROVED` event. This PR fixes this. The reason why it was done this way is that we didn't think that we could get the publishing time on `APPROVED` events, we thought that the time we get with those events was the time at which the changes were approved. However, we have now verified that the date returned by `collection.getDescription().getPublishDate()` when receiving an `APPROVED` event is the correct publishing date, and not the approval date/time, like we originally thought.

Therefore, we're now sending a PUT request to the Legacy Cache API when we receive an `APPROVED` event, and we're ignoring the `PUBLISHED` events, as they're now redundant, and they are sent at the publishing time, which is too late for the Legacy Cache Proxy to be able to set the calculated `max-age` directive.

### How to review

Run the ONS stack locally, ensure that the Legacy Cache API is running, and set the `ENABLE_LEGACY_CACHE_API` feature flag. Then use Florence to create or update collections. When you approve the changes, you should see how the API immediately receives a call from Zebedee.

### Who can review

Anyone at ONS.
