### PR TITLE
enlarge elasticsearch results window from default of 10000

### DIFF
--- a/zebedee-reader/src/main/resources/search/index-config.yml
+++ b/zebedee-reader/src/main/resources/search/index-config.yml
@@ -1,6 +1,7 @@
 index :
     number_of_shards : 3
     number_of_replicas : 0
+    max_result_window : 20000
 analysis :
   analyzer :
     #Overwriting default index analyzer


### PR DESCRIPTION
### What

getting errors from reindex :

```
RemoteTransportException[[Gypsy Moth][172.17.0.2:xxx][indices:data/read/search[phase/dfs]]]; nested: QueryPhaseExecutionException[Result window is too large, from + size must be less than or equal to: [10000] but was [10020]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level parameter.];
Caused by: QueryPhaseExecutionException[Result window is too large, from + size must be less than or equal to: [10000] but was [10020]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level parameter.]
```

so this should increase that window

### How to review

test no breakage in sandbox

### Who can review

!me
