### PR TITLE
Make log line less noisy

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -366,7 +366,7 @@ public class PostPublisher {
                 .stream().map(temp -> convertUriForEvent(temp))
                 .collect(Collectors.toList());
         info().data("collectionId", collection.getId())
-                .data("Reviewed-uris", reviewedUris)
+                .data("reviewed-uris-count", reviewedUris.size())
                 .data("publishing", true)
                 .log("converted reviewed URIs for kafka event");
         sendMessage(collection, reviewedUris, LEGACYCONTENTFLAG);


### PR DESCRIPTION
### What

Make log line less noisy. 

Log was previously appending all uris in a collection (potentially many thousands) into a single log line. Not great in production. I've reduced this to only log out the number of uris instead. 

### How to review

Check sanity of code and all tests pass

### Who can review

Anyone