### PR TITLE
Fix log bug causing incorrect timestamps

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -141,13 +141,14 @@ public class CollectionPdfGenerator {
         if (language == null) {
             throw new InvalidParameterException("Language can't be null");
         }
-        CMSLogEvent e = info().data("uri", uri).data("lang", language.toString()).collectionID(collection);
         try {
             pdfService.generatePdf(writer, uri, language);
-            e.log("content PDF generated successfully");
+            info().data("uri", uri).data("lang", language.toString()).collectionID(collection)
+                    .log("content PDF generated successfully");
             return true;
         } catch (Exception ex) {
-            e.exception(ex).log("error generating PDF content");
+            info().data("uri", uri).data("lang", language.toString()).collectionID(collection)
+                    .exception(ex).log("error generating PDF content");
             throw new InternalServerError("error generating PDF content", ex);
         }
     }


### PR DESCRIPTION
### What

Fix bug causing incorrect timestamps in logging.

The log timestamp is set during instantiation in the `info()` method. So when the event is reused, the log line has the earlier timestamp, not the actual timestamp of the log line.

### How to review

Check code, ensure tests pass.

### Who can review

Anyone