### PR TITLE
change colour of Slack notification: pre-publish,publish now yellow

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/SlackNotification.java
@@ -286,7 +286,7 @@ public class SlackNotification {
                         break;
                     case COMPLETED:
                         pm.setText("Pre-publish completed for collection");
-                        attch.setColor("good");
+                        attch.setColor("warning");
                         break;
                     case FAILED:
                         pm.setText("Pre-publish *failed* for collection");
@@ -306,7 +306,7 @@ public class SlackNotification {
                         break;
                     case COMPLETED:
                         pm.setText("Publish completed for collection");
-                        attch.setColor("good");
+                        attch.setColor("warning");
                         break;
                     case FAILED:
                         pm.setText("Publish *failed* for collection");


### PR DESCRIPTION
### What

do you watch #publish-log and get confused whether a Collection has been published?

do you wish the intermediate stages of that process didn't show as Green?

do you squint at the 'publish completed' and confuse it with 'post-publish completed'?

well, this is the PR for you: offering clarity when scanning Slack, this changes the colour of some Slack notifications:

- completions of `pre-publish`  and `publish` now show as *yellow* (not green)
- only `post-publish completed` is *green* (i.e. full completion success)

### How to review

Observe an increase in clarity and calmness. 🧘 

### Who can review

You, dear reader. You.
