### PR TITLE
Get correct dataset version for ts and non-ts datasets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.6.1</version>
+                <version>3.9.0</version>
             </dependency>
 
             <!-- To fix vulnerabilities in transient imported commons-compress by avro -->

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApproveTask.java
@@ -534,10 +534,14 @@ public class ApproveTask implements Callable<Boolean> {
         if (listOfUris == null) {
             throw new IllegalArgumentException("input array can't be null");
         }
+
+        String datasetId = extractDatasetId(fileName);
+        String baseFilename = datasetId.replaceAll(DatasetWhitelistChecker.REG_EX_STR, "");
+
         String datasetVersion = "";
         for (String uri : listOfUris) {
             if (uri.endsWith(".csv") || uri.endsWith(".xlsx") || uri.endsWith(".xls") || uri.endsWith(".csdb")) {
-                if (uri.contains("previous") && uri.contains(extractFileName(fileName))) {
+                if (uri.contains("previous") && uri.contains(baseFilename)) {
                     datasetVersion = extractDatasetVersion(uri);
                     return datasetVersion;
                 }


### PR DESCRIPTION
### What

Getting correct dataset version for ts and non-ts datasets
Bump kafka client to fix vulnerability issue

### How to review

Changes are ok and test pass.

- Run the static-files-with-auth stack.
- Create a collection with two or more datasets that are going to the lockbox.
- Collection should get approved and published successfully. Files should be uploaded to the correct version folders.

### Who can review

Anyone
