### PR TITLE
Skip unit tests on audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ audit-cms:
 
 .PHONY: audit-reader
 audit-reader:
-	mvn install -pl zebedee-reader -Dmaven.test.skip -Dossindex.skip=true
-	mvn -pl zebedee-reader ossindex:audit
+	mvn -pl zebedee-reader -Dmaven.test.skip ossindex:audit
 
 .PHONY: build
 build: build-cms

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ audit : audit-cms
 .PHONY: audit-cms
 audit-cms:
 	mvn install -pl zebedee-reader -Dmaven.test.skip -Dossindex.skip=true
-	mvn ossindex:audit
+	mvn -Dmaven.test.skip ossindex:audit
 
 .PHONY: audit-reader
 audit-reader:
-	mvn -pl zebedee-reader -Dossindex.skip=true test
+	mvn install -pl zebedee-reader -Dmaven.test.skip -Dossindex.skip=true
 	mvn -pl zebedee-reader ossindex:audit
 
 .PHONY: build

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndexTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/api/endpoint/PublishedIndexTest.java
@@ -2,6 +2,8 @@ package com.github.onsdigital.zebedee.reader.api.endpoint;
 
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.reader.api.bean.PublishedIndexResponse;
+import com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,7 +22,10 @@ public class PublishedIndexTest {
     private HttpServletResponse response = mock(HttpServletResponse.class);
 
     @Before
-    public void initialize(){ publishedIndex = new PublishedIndex();}
+    public void initialize(){ 
+        publishedIndex = new PublishedIndex();
+        ReaderConfiguration.init("target/test-classes/test-content/");
+    }
 
     @Test
     public void readReturnsSuccess() throws ZebedeeException, IOException {


### PR DESCRIPTION
### What

Stopped zebedee from running unit tests on audit as not necessary.
Fixed race condition in unit tests due to ReaderConfiguration failure. 

### How to review

Check audit still runs and is effective - I did this locally by removing an exclusion. 

### Who can review

Not me. 