### PR TITLE
Stop latest being set if migrationLink is present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.9.0</version>
+                <version>3.9.1</version>
             </dependency>
 
             <!-- To fix vulnerabilities in transient imported commons-compress by avro -->

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/content/page/base/PageDescription.java
@@ -11,28 +11,33 @@ import java.util.List;
 /**
  * Created by bren on 04/06/15.
  * <p/>
- * A wrapper class that holds all possible description fields used in all page types.
- * Instead of creating a hierarchy of description object ( as it was done initially ),
- * we accumulate all description fields of all page in this folder to avoid serialising/deserialising pitfalls
+ * A wrapper class that holds all possible description fields used in all page
+ * types.
+ * Instead of creating a hierarchy of description object ( as it was done
+ * initially ),
+ * we accumulate all description fields of all page in this folder to avoid
+ * serialising/deserialising pitfalls
  * <p/>
  */
 public class PageDescription extends Content implements Comparable<PageDescription> {
 
-    /*Release fields*/
+    /* Release fields */
     public Boolean finalised;
-    /*Migration Data*/
+    /* Migration Data */
     public transient String theme;
     public transient String level2;
     public transient String level3;
-    //Index is used for ordering if set
+    // Index is used for ordering if set
     private Integer index;
     private String title;
-    //Below fields are not common for all page types. But there is no immediate generic type to put these fields in
-    //These fields won't be serialised into json if empty
+    // Below fields are not common for all page types. But there is no immediate
+    // generic type to put these fields in
+    // These fields won't be serialised into json if empty
     private String summary;
-    private List<String> keywords; //Used for search engines to read ?
+    private List<String> keywords; // Used for search engines to read ?
     private String metaDescription;
-    /*Statistics Description*/
+    private String migrationLink;
+    /* Statistics Description */
     private Boolean nationalStatistic;
     private Boolean latestRelease;
     private Contact contact;
@@ -42,14 +47,14 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     private String edition;
     private String _abstract;
     private List<String> authors;
-    private String headline;//Used in compendium
-    /*Bulletin headlines*/
+    private String headline;// Used in compendium
+    /* Bulletin headlines */
     private String headline1;
     private String headline2;
     private String headline3;
     private String datasetId;
     private URI datasetUri;
-    /*Statistical Data description*/
+    /* Statistical Data description */
     private String cdid;
     // We provide a minimal default for the unit, otherwise highcharts shows
     // "undefined":
@@ -57,7 +62,7 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     private String preUnit = "";
     private String source = ""; // Where a statistic comes from. Typically "Office for National Statistics"
     private String monthLabelStyle;
-    //Below fields appear on references to time series on other content types
+    // Below fields appear on references to time series on other content types
     private String date;
     private String number;
     private String mainMeasure;
@@ -65,14 +70,14 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     private String keyNote;
     /** This value is displayed beneath the time series title: */
     private String additionalText;
-    /*QMI Description*/
+    /* QMI Description */
     private String surveyName;
     private String frequency;
     private String compilation;
     private String geographicCoverage;
     private String sampleSize;
     private Date lastRevised;
-    /*Adhoc content reference*/
+    /* Adhoc content reference */
     private String reference;
     private Boolean cancelled;
     private List<String> cancellationNotice;
@@ -90,7 +95,7 @@ public class PageDescription extends Content implements Comparable<PageDescripti
 
     @Override
     public int compareTo(PageDescription o) {
-        //nulls last or first
+        // nulls last or first
         if (this.index == null) {
             return -1;
         }
@@ -129,6 +134,14 @@ public class PageDescription extends Content implements Comparable<PageDescripti
         this.metaDescription = metaDescription;
     }
 
+    public String getMigrationLink() {
+        return migrationLink;
+    }
+
+    public void setMigrationLink(String migrationLink) {
+        this.migrationLink = migrationLink;
+    }
+
     public boolean isNationalStatistic() {
         return nationalStatistic != null && nationalStatistic;
     }
@@ -145,12 +158,12 @@ public class PageDescription extends Content implements Comparable<PageDescripti
         this.monthLabelStyle = monthLabelStyle;
     }
 
-    public Boolean isLatestRelease() { 
-        return latestRelease != null && latestRelease; 
+    public Boolean isLatestRelease() {
+        return latestRelease != null && latestRelease;
     }
 
-    public void setLatestRelease(Boolean latestRelease) { 
-        this.latestRelease = latestRelease; 
+    public void setLatestRelease(Boolean latestRelease) {
+        this.latestRelease = latestRelease;
     }
 
     public Contact getContact() {
@@ -454,7 +467,7 @@ public class PageDescription extends Content implements Comparable<PageDescripti
     }
 
     public void setApiDatasetId(String apiDatasetId) {
-      this.apiDatasetId = apiDatasetId;
+        this.apiDatasetId = apiDatasetId;
     }
 
     public String getCanonicalTopic() {

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
@@ -196,7 +196,9 @@ public class FileSystemContentReader implements ContentReader {
             Path parent = contentPath.getParent();
             assertIsEditionsFolder(parent);
             page = resolveLatest(contentPath);
-            page.getDescription().setLatestRelease(true);
+            if (page.getDescription().getMigrationLink() == null || page.getDescription().getMigrationLink().isEmpty()){
+                page.getDescription().setLatestRelease(true);
+            }
         } catch(Throwable t) {
             span.recordException(t);
             throw t;

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/FileSystemContentReader.java
@@ -196,7 +196,7 @@ public class FileSystemContentReader implements ContentReader {
             Path parent = contentPath.getParent();
             assertIsEditionsFolder(parent);
             page = resolveLatest(contentPath);
-            if (page.getDescription().getMigrationLink() == null || page.getDescription().getMigrationLink().isEmpty()){
+            if (StringUtils.isBlank(page.getDescription().getMigrationLink())){
                 page.getDescription().setLatestRelease(true);
             }
         } catch(Throwable t) {

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ContentReaderTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/ContentReaderTest.java
@@ -191,6 +191,13 @@ public class ContentReaderTest {
     public void testGetLatestContent() throws ZebedeeException, IOException {
         Page latestContent = contentReader.getLatestContent("/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts");
         assertEquals("2015", latestContent.getDescription().getEdition());
+        assertEquals(true, latestContent.getDescription().isLatestRelease());
+    }
+
+    @Test
+    public void testGetLatestContentMigration() throws ZebedeeException, IOException {
+        Page latestContent = contentReader.getLatestContent("/economy/environmentalaccounts/articles/uknaturalcapitallandcoverintheuk");
+        assertEquals(false, latestContent.getDescription().isLatestRelease());
     }
 
     @Test

--- a/zebedee-reader/src/test/resources/test-content/zebedee/master/economy/environmentalaccounts/articles/uknaturalcapitallandcoverintheuk/2015-03-17/data.json
+++ b/zebedee-reader/src/test/resources/test-content/zebedee/master/economy/environmentalaccounts/articles/uknaturalcapitallandcoverintheuk/2015-03-17/data.json
@@ -159,7 +159,8 @@
       " pasture",
       " grassland"
     ],
-    "metaDescription": "We take a look at land cover ecosystem accounts for the United Kingdom (UK). The land cover accounts based on data from the Countryside Survey show that the land cover changed significantly in the UK between 1998 and 2007."
+    "metaDescription": "We take a look at land cover ecosystem accounts for the United Kingdom (UK). The land cover accounts based on data from the Countryside Survey show that the land cover changed significantly in the UK between 1998 and 2007.",
+    "migrationLink":"/migration-link"
   },
   "relatedArticles": [],
   "links": [],


### PR DESCRIPTION
### What

Stop `latestRelease` being set if `migrationLink` is present on latest item in a series.

### How to review

Check looks ok. 

To test you can:

- find your zebedee content store
- alter the latest edition of an editorial series to have a `migrationLink` in the description block
- query for the uri of the edition on the /data endpoint (/data?uri=${uri}
- see that `latestRelease` is no longer set

Regression test against those with it not set. 

### Who can review

Not me. 