### PR TITLE
Add generate redirect list on collection approval

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionDescription.java
@@ -39,6 +39,7 @@ public class CollectionDescription extends CollectionBase {
     private Date publishEndDate;
     private boolean isEncrypted;
     private Events events;
+    private List<CollectionRedirect> redirects;
 
     /**
      * Default constuructor for serialisation.
@@ -54,6 +55,7 @@ public class CollectionDescription extends CollectionBase {
         this.eventsByUri = new HashMap<>();
         this.datasets = new HashSet<>();
         this.datasetVersions = new HashSet<>();
+        this.redirects = new ArrayList<>();
     }
 
     /**
@@ -73,6 +75,7 @@ public class CollectionDescription extends CollectionBase {
         this.eventsByUri = new HashMap<>();
         this.datasets = new HashSet<>();
         this.datasetVersions = new HashSet<>();
+        this.redirects = new ArrayList<>();
     }
 
 
@@ -358,5 +361,23 @@ public class CollectionDescription extends CollectionBase {
 
     public void setPublishResults(final List<Result> publishResults) {
         this.publishResults = publishResults;
+    }
+
+    public List<CollectionRedirect> getRedirects() {
+        if (this.redirects == null) {
+            this.redirects = new ArrayList<>();
+        }
+        return this.redirects;
+    }
+
+    public void setRedirects(final List<CollectionRedirect> redirects) {
+        this.redirects = redirects;
+    }
+
+    public void addRedirect(final CollectionRedirect redirect) {
+        if (this.redirects == null) {
+            this.redirects = new ArrayList<>();
+        }
+        this.redirects.add(redirect);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionRedirect.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionRedirect.java
@@ -1,0 +1,61 @@
+package com.github.onsdigital.zebedee.json;
+
+import java.util.Objects;
+
+/**
+ * Represents a redirect that has been added to a collection.
+ */
+public class CollectionRedirect {
+
+    private String from;
+    private String to;
+    private CollectionRedirectAction action;
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public CollectionRedirectAction getAction() {
+        return action;
+    }
+
+    public void setAction(CollectionRedirectAction action) {
+        this.action = action;
+    }
+
+    public CollectionRedirect(String from, String to, CollectionRedirectAction action) {
+        this.from = from;
+        this.to = to;
+        this.action = action;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CollectionRedirect that = (CollectionRedirect) o;
+
+        return from.equals(that.getFrom()) &&
+            to.equals(that.getTo()) &&
+            action.equals(that.getAction());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to, action);
+    }
+
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionRedirectAction.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionRedirectAction.java
@@ -1,0 +1,11 @@
+package com.github.onsdigital.zebedee.json;
+
+/**
+ * Enum to define the various actions of the collection redirect implementation
+ */
+public enum CollectionRedirectAction {
+    CREATE,
+    UPDATE,
+    DELETE,
+    NO_ACTION,
+}

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventLog.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventLog.java
@@ -12,6 +12,7 @@ import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.APP
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.COMPRESSED_ZIP_FILES;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.CREATED_PUBLISH_NOTIFICATION;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.GENERATED_PDFS;
+import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.GENERATED_REDIRECT_LIST;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.GENERATED_TIME_SERIES;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.POPULATED_RELEASE_PAGE;
 import static com.github.onsdigital.zebedee.model.approval.ApprovalEventType.RESOLVED_DETAILS;
@@ -55,7 +56,7 @@ public class ApprovalEventLog {
         addEvent(ADD_DATASET_VERSION_DETAILS);
     }
 
-    public void populatedResleasePage() {
+    public void populatedReleasePage() {
         addEvent(POPULATED_RELEASE_PAGE);
     }
 
@@ -65,6 +66,10 @@ public class ApprovalEventLog {
 
     public void generatedPDFs() {
         addEvent(GENERATED_PDFS);
+    }
+
+    public void generatedRedirectList() {
+        addEvent(GENERATED_REDIRECT_LIST);
     }
 
     public void createdPublishNotificaion() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/ApprovalEventType.java
@@ -14,6 +14,8 @@ public enum ApprovalEventType {
 
     GENERATED_PDFS("generatedPDFs"),
 
+    GENERATED_REDIRECT_LIST("generatedRedirectList"),
+
     CREATED_PUBLISH_NOTIFICATION("createdPublishNotification"),
 
     COMPRESSED_ZIP_FILES("compressedZipFiles"),

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/approval/tasks/CollectionPdfGenerator.java
@@ -5,7 +5,6 @@ import com.github.onsdigital.zebedee.content.page.base.PageType;
 import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ContentDetail;
-import com.github.onsdigital.zebedee.logging.CMSLogEvent;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.ContentWriter;
 import com.github.onsdigital.zebedee.reader.ContentReader;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/NoOpRedirectService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/NoOpRedirectService.java
@@ -1,6 +1,9 @@
 package com.github.onsdigital.zebedee.service;
 
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.dis.redirect.api.sdk.model.Redirect;
+import com.github.onsdigital.zebedee.json.CollectionRedirect;
 
 /**
  * A no-op RedirectService that does nothing. This is used for the case where redirect API
@@ -9,7 +12,12 @@ import com.github.onsdigital.dis.redirect.api.sdk.model.Redirect;
 public class NoOpRedirectService implements RedirectService {
 
     @Override
-    public Redirect getRedirect(String redirectPath) {
-        return new Redirect();
+    public void generateRedirectListForCollection(Collection collection, CollectionReader collectionReader) {
+        // NoOp implementation
+    }
+
+    @Override
+    public CollectionRedirect getCollectionRedirect(Redirect redirect){
+        return null;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectService.java
@@ -1,9 +1,11 @@
 package com.github.onsdigital.zebedee.service;
 
-import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectAPIException;
-import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectNotFoundException;
-import com.github.onsdigital.dis.redirect.api.sdk.exception.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.dis.redirect.api.sdk.model.Redirect;
+import com.github.onsdigital.zebedee.json.CollectionRedirect;
+
 
 import java.io.IOException;
 
@@ -12,10 +14,8 @@ import java.io.IOException;
  */
 public interface RedirectService {
 
-    /**
-     * Get a redirect
-     */
-    Redirect getRedirect(String redirectID)
-        throws IOException, BadRequestException, RedirectNotFoundException,
-        RedirectAPIException;
+    void generateRedirectListForCollection(Collection collection, CollectionReader collectionReader)
+        throws IOException, ZebedeeException;
+    
+    public CollectionRedirect getCollectionRedirect(Redirect redirect) throws ZebedeeException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectServiceImpl.java
@@ -7,8 +7,18 @@ import com.github.onsdigital.dis.redirect.api.sdk.exception.BadRequestException;
 import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectAPIException;
 import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectNotFoundException;
 import com.github.onsdigital.dis.redirect.api.sdk.model.Redirect;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
+import com.github.onsdigital.zebedee.content.page.base.Page;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionRedirect;
+import com.github.onsdigital.zebedee.json.CollectionRedirectAction;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.reader.ContentReader;
 
-import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+import org.apache.commons.lang.StringUtils;
+
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 
 /**
  * Redirect related services
@@ -26,14 +36,62 @@ public class RedirectServiceImpl implements RedirectService {
         this.redirectClient = redirectClient;
     }
 
+    public void generateRedirectListForCollection(Collection collection, CollectionReader collectionReader)
+        throws IOException, ZebedeeException {
+            ContentReader reviewedContentReader = collectionReader.getReviewed();
 
-    public Redirect getRedirect(String redirectPath)
-        throws IOException, BadRequestException, RedirectNotFoundException,
-        RedirectAPIException {
-            info()
-                .data("redirectPath", redirectPath)
-                .log("getting redirect for path");
+            // Loop through the uri's in the collection
+            for (String reviewedUri : reviewedContentReader.listUris()) {
 
-            return redirectClient.getRedirect(redirectPath);
+                // Ignoring previous versions loop through the pages
+                if (reviewedUri.toLowerCase().endsWith("data.json")) {
+
+                    // Strip off data.json
+                    String pageUri = reviewedUri.substring(0, reviewedUri.length() - "/data.json".length());
+
+                    // Find all pages
+                    Page page = reviewedContentReader.getContent(pageUri);
+
+                    String migrationPath = page.getDescription().getMigrationLink();
+
+                    if (migrationPath != null) {
+                        Redirect redirect = new Redirect(pageUri, migrationPath);
+                        CollectionRedirect collectionRedirect = getCollectionRedirect(redirect);
+                        if (collectionRedirect.getAction() != CollectionRedirectAction.NO_ACTION){
+                            System.out.println(collectionRedirect.getFrom());
+                            System.out.println(collectionRedirect.getAction());
+
+                            System.out.println(collectionRedirect.getTo());
+
+                            collection.getDescription().addRedirect(collectionRedirect);
+                        }
+                    }
+                }
+            }
         }
+
+    public CollectionRedirect getCollectionRedirect(Redirect redirect) throws ZebedeeException {
+
+        System.out.println("I'm actually running this function");
+        CollectionRedirectAction collectionRedirectAction = CollectionRedirectAction.NO_ACTION;
+
+        try {
+            Redirect apiRedirect = redirectClient.getRedirect(redirect.getFrom());
+
+            if (StringUtils.isBlank(redirect.getTo()) && StringUtils.isNotBlank(apiRedirect.getTo())) {
+                collectionRedirectAction = CollectionRedirectAction.DELETE;
+            } else if (!redirect.getTo().equals(apiRedirect.getTo()) ){
+                collectionRedirectAction = CollectionRedirectAction.UPDATE;
+            }
+        } catch (RedirectNotFoundException notFoundException){
+            if (StringUtils.isNotBlank(redirect.getTo())){
+                collectionRedirectAction = CollectionRedirectAction.CREATE;
+            }
+        } catch (BadRequestException | RedirectAPIException | IOException ex) {
+            error().exception(ex).log("error communicating with redirect API");
+            throw new InternalServerError("couldn't generate redirect from redirect API data");
+        }
+
+        return new CollectionRedirect(redirect.getFrom(), redirect.getTo(), collectionRedirectAction);
+    }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/RedirectServiceImpl.java
@@ -58,11 +58,6 @@ public class RedirectServiceImpl implements RedirectService {
                         Redirect redirect = new Redirect(pageUri, migrationPath);
                         CollectionRedirect collectionRedirect = getCollectionRedirect(redirect);
                         if (collectionRedirect.getAction() != CollectionRedirectAction.NO_ACTION){
-                            System.out.println(collectionRedirect.getFrom());
-                            System.out.println(collectionRedirect.getAction());
-
-                            System.out.println(collectionRedirect.getTo());
-
                             collection.getDescription().addRedirect(collectionRedirect);
                         }
                     }
@@ -72,7 +67,6 @@ public class RedirectServiceImpl implements RedirectService {
 
     public CollectionRedirect getCollectionRedirect(Redirect redirect) throws ZebedeeException {
 
-        System.out.println("I'm actually running this function");
         CollectionRedirectAction collectionRedirectAction = CollectionRedirectAction.NO_ACTION;
 
         try {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/CollectionDescriptionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/json/CollectionDescriptionTest.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.json;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,5 +97,21 @@ public class CollectionDescriptionTest {
         Optional<CollectionDatasetVersion> option = collection.getDatasetVersion(datasetID, edition, version);
         assertFalse(option.isPresent());
         assertFalse(collection.getDatasetVersions().contains(datasetVersion));
+    }
+
+    @Test
+    public void testAddRedirect() {
+
+        // Given a collection description and a CollectionRedirect
+        CollectionDescription collection = new CollectionDescription();
+
+        CollectionRedirect redirect = new CollectionRedirect("/from", "/to", CollectionRedirectAction.CREATE);
+
+        // When a redirect is added
+        collection.addRedirect(redirect);
+
+        // Then the dataset is in the collection description
+        List<CollectionRedirect> collectionRedirects = collection.getRedirects();
+        assertTrue(collectionRedirects.contains(redirect));
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/RedirectServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/service/RedirectServiceImplTest.java
@@ -1,7 +1,19 @@
 package com.github.onsdigital.zebedee.service;
 
 import com.github.onsdigital.dis.redirect.api.sdk.RedirectClient;
+import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectAPIException;
+import com.github.onsdigital.dis.redirect.api.sdk.exception.RedirectNotFoundException;
 import com.github.onsdigital.dis.redirect.api.sdk.model.Redirect;
+import com.github.onsdigital.zebedee.content.page.base.PageDescription;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionRedirect;
+import com.github.onsdigital.zebedee.json.CollectionRedirectAction;
+import com.github.onsdigital.zebedee.reader.CollectionReader;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.reader.ContentReader;
+import com.github.onsdigital.zebedee.content.page.base.Page;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -11,9 +23,30 @@ import org.mockito.MockitoAnnotations;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class RedirectServiceImplTest {
     @Mock
     RedirectClient mockRedirectAPI;
+
+    @Mock
+    Collection mockCollection;
+
+    @Mock
+    CollectionDescription mockCollectionDescription;
+
+    @Mock
+    CollectionReader mockCollectionReader;
+
+    @Mock
+    ContentReader mockContentReader;
+
+    @Mock
+    Page mockPage;
+
+    @Mock
+    PageDescription mockDescription;
 
     @Before
     public void setup() {
@@ -21,16 +54,234 @@ public class RedirectServiceImplTest {
     }
 
     @Test
-    public void testGetRedirect() throws Exception {
-        // Given the API returns a redirect for a key
-        when(mockRedirectAPI.getRedirect("/from")).thenReturn(new Redirect("/from", "/to"));
+    public void testGenerateRedirectListForCollectionCreate() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenThrow(new RedirectNotFoundException());
         RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
 
-        // When getRedirect is called
-        Redirect redirect = redirectService.getRedirect("/from");
+        // And a collection with a migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("/destination");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
 
-        // Then the expected Redirect should be returned
-        assertEquals("/to", redirect.getTo());
+        // When generateRedirectListForCollection is called
+        redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader);
+
+        // Then the expected CollectionRedirect should be added in the collection description 
+        CollectionRedirect expectedCollectionRedirect = new CollectionRedirect("/origin", "/destination", CollectionRedirectAction.CREATE);
+        verify(mockCollectionDescription, times(1)).addRedirect(expectedCollectionRedirect);
+    }
+
+    @Test
+    public void testGenerateRedirectListForCollectionUpdate() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenReturn(new Redirect("/origin", "/originaldestination"));
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // And a collection with a migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("/destination");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+
+        // When generateRedirectListForCollection is called
+        redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader);
+
+        // Then the expected CollectionRedirect should be added in the collection description 
+        CollectionRedirect expectedCollectionRedirect = new CollectionRedirect("/origin", "/destination", CollectionRedirectAction.UPDATE);
+        verify(mockCollectionDescription, times(1)).addRedirect(expectedCollectionRedirect);
+    }
+
+    @Test
+    public void testGenerateRedirectListForCollectionNoAction() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenReturn(new Redirect("/origin", "/destination"));
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // And a collection with a migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("/destination");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        // When generateRedirectListForCollection is called
+        redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader);
+
+        // Then no CollectionRedirect should be added in the collection description 
+        verify(mockCollectionDescription, times(0)).addRedirect(any());
+    }
+
+    @Test
+    public void testGenerateRedirectListForCollectionNoLink() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenThrow(new RedirectNotFoundException());
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // And a collection with a blank migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        // When generateRedirectListForCollection is called
+        redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader);
+
+        // Then no CollectionRedirect should be added in the collection description 
+        verify(mockCollectionDescription, times(0)).addRedirect(any());
+    }
+
+    @Test
+    public void testGenerateRedirectListForCollectionDelete() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenReturn(new Redirect("/origin", "/destination"));
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // And a collection with a blank migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        // When generateRedirectListForCollection is called
+        redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader);
+
+        // Then the expected CollectionRedirect should be added in the collection description 
+        CollectionRedirect expectedCollectionRedirect = new CollectionRedirect("/origin", "", CollectionRedirectAction.DELETE);
+        verify(mockCollectionDescription, times(1)).addRedirect(expectedCollectionRedirect);
+    }
+
+    @Test
+    public void testGenerateRedirectListForCollectionError() throws Exception {
+        // Given a redirect API that doesn't have any redirects in it
+        when(mockRedirectAPI.getRedirect(any())).thenThrow(new RedirectAPIException());
+        RedirectService redirectService = spy(new RedirectServiceImpl(mockRedirectAPI));
+
+        // And a collection with a blank migrationLink
+        List<String> uris = Arrays.asList("/origin/data.json");
+        when(mockDescription.getMigrationLink()).thenReturn("");
+        when(mockPage.getDescription()).thenReturn(mockDescription);
+        when(mockContentReader.listUris()).thenReturn(uris);
+        when(mockCollectionReader.getReviewed()).thenReturn(mockContentReader);
+        when(mockContentReader.getContent("/origin")).thenReturn(mockPage);
+
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+
+        // When generateRedirectListForCollection is called an exception is thrown
+        ZebedeeException ex = assertThrows(ZebedeeException.class, () -> redirectService.generateRedirectListForCollection(mockCollection, mockCollectionReader));
+
+        // Then the message should show what has happened
+        assertEquals("couldn't generate redirect from redirect API data", ex.getMessage());
+    }
+
+    @Test
+    public void testGetCollectionRedirectUpdate() throws Exception {
+        // Given the API returns a redirect for a key with a different to
+        Redirect redirect = new Redirect("/from", "/to");
+        Redirect apiRedirect = new Redirect("/from", "/totwo");
+
+        when(mockRedirectAPI.getRedirect("/from")).thenReturn(apiRedirect);
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // When getCollectionRedirect is called
+        CollectionRedirect collectionRedirect = redirectService.getCollectionRedirect(redirect);
+
+        // Then the expected collectionRedirect should be returned
+        assertEquals(redirect.getFrom(), collectionRedirect.getFrom());
+        assertEquals(redirect.getTo(), collectionRedirect.getTo());
+        assertEquals(CollectionRedirectAction.UPDATE, collectionRedirect.getAction());
+    }
+
+    @Test
+    public void testGetCollectionRedirectDelete() throws Exception {
+        // Given the collection has a blank migration path
+        Redirect redirect = new Redirect("/from", "");
+        // And the api has an existing redirect
+        Redirect apiRedirect = new Redirect("/from", "/totwo");
+
+        when(mockRedirectAPI.getRedirect("/from")).thenReturn(apiRedirect);
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // When getCollectionRedirect is called
+        CollectionRedirect collectionRedirect = redirectService.getCollectionRedirect(redirect);
+
+        // Then the expected collectionRedirect should be returned
+        assertEquals(redirect.getFrom(), collectionRedirect.getFrom());
+        assertEquals(redirect.getTo(), collectionRedirect.getTo());
+        assertEquals(CollectionRedirectAction.DELETE, collectionRedirect.getAction());
+    }
+
+    @Test
+    public void testGetCollectionRedirectNothing() throws Exception {
+        // Given the collection has the same migration path
+        Redirect redirect = new Redirect("/from", "/to");
+        // And the api has an existing redirect that matches
+        Redirect apiRedirect = new Redirect("/from", "/to");
+
+        when(mockRedirectAPI.getRedirect("/from")).thenReturn(apiRedirect);
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // When getCollectionRedirect is called
+        CollectionRedirect collectionRedirect = redirectService.getCollectionRedirect(redirect);
+
+        // Then the expected collectionRedirect should be returned
+        assertEquals(redirect.getFrom(), collectionRedirect.getFrom());
+        assertEquals(redirect.getTo(), collectionRedirect.getTo());
+        assertEquals(CollectionRedirectAction.NO_ACTION, collectionRedirect.getAction());
+    }
+
+    @Test
+    public void testGetCollectionRedirectCreate() throws Exception {
+        // Given the collection has the same migration path
+        Redirect redirect = new Redirect("/from", "/to");
+        // And the api has no existing redirect that matches
+        when(mockRedirectAPI.getRedirect("/from")).thenThrow(new RedirectNotFoundException());
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // When getCollectionRedirect is called
+        CollectionRedirect collectionRedirect = redirectService.getCollectionRedirect(redirect);
+
+        // Then the expected collectionRedirect should be returned
+        assertEquals(redirect.getFrom(), collectionRedirect.getFrom());
+        assertEquals(redirect.getTo(), collectionRedirect.getTo());
+        assertEquals(CollectionRedirectAction.CREATE, collectionRedirect.getAction());
+    }
+
+    @Test
+    public void testGetCollectionRedirectNoActionBlank() throws Exception {
+        // Given the collection has the same migration path
+        Redirect redirect = new Redirect("/from", "");
+        // And the api has no existing redirect that matches
+        when(mockRedirectAPI.getRedirect("/from")).thenThrow(new RedirectNotFoundException());
+        RedirectService redirectService = new RedirectServiceImpl(mockRedirectAPI);
+
+        // When getCollectionRedirect is called
+        CollectionRedirect collectionRedirect = redirectService.getCollectionRedirect(redirect);
+
+        // Then the expected collectionRedirect should be returned
+        assertEquals(redirect.getFrom(), collectionRedirect.getFrom());
+        assertEquals(redirect.getTo(), collectionRedirect.getTo());
+        assertEquals(CollectionRedirectAction.NO_ACTION, collectionRedirect.getAction());
     }
 }
 


### PR DESCRIPTION
### What

This PR adds the funtionality to generate a redirect list from a collection.

### How to review

Check looks ok, tests pass, functionality makes sense. 

To test:

- set env vars:
  - ENABLE_JWT_SESSIONS=true
  - ENABLE_REDIRECT_API=true
- run:
  - florence
  - zebedee (in cms mode)
  - dp-api-router
  - port forward dp-identity-api to sandbox
  - dis-redirect-api
  - redis

The follow test cases apply:
- Add a migrationLink to a page that does not have a link in redis (should CREATE)
- Alter a migrationLink to a page that already has a link in redis (should UPDATE)
- Publish a page with a migrationLink that is already present in redis (should not be added)
- Remove a migrationLink from a page that already has a link in redis (should DELETE)
- Publish a page with no migrationLink that does not have a link in redis (should not be added)

At the approval stage you will see the redirects be added to the 'redirects' array in the collection data.json. 

### Who can review

Not me. 