### PR TITLE
Feature/add automated collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,18 +190,9 @@ Otherwise :violin: kindly ask someone from the dev team to help troubleshoot.
 | VERIFY_RETRY_COUNT                               | 10                                                                             | Retry count for how long, in seconds, to wait for retry                      |
 | VERIFY_RETRY_DELAY                               | 5000; //milliseconds                                                           | Retry delay duration                                                         |
 
-### New Central Keyring configuration
+### Central Keyring configuration
 
-The new central keyring feature is currently behind a feature flag:
-
-```bash
-export ENABLE_CENTRALISED_KEYRING=true/false
-```
-
-- If enabled Zebedee will attempt to read/write from the new central keyring and default to the legacy keyring if
-unsuccessful.
-- If disabled Zebedee will add/remove keys from both legacy and central keyring implementations but will
-only read from the legacy keyring.
+Zebedee will read/write from the central keyring for encrypting collections.
 
 The central keyring requires encryption config to be provided in app configutation. These secrets can be generated
 using the [collection-keyring-secrets-generator][7].

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collection.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.zebedee.audit.Audit;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.InternalServerError;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
@@ -105,24 +106,29 @@ public class Collection {
             throw new NotFoundException("The collection you are trying to get was not found.");
         }
 
-        requireViewPermission(session, collectionID);
+        CollectionDescription description = collection.getDescription();
+        if (description == null) {
+            info().log("get collection endpoint: request unsuccessful collection description not found");
+            throw new InternalServerError("The collection description was not found.");
+        }
+
+        requireViewPermission(session, collectionID, description.getType());
 
         // TODO: Question - I am not sure why it's necessary to duplicate the description instead of just returning it?
         // Collate the result:
         CollectionDescription result = new CollectionDescription();
-        result.setId(collection.getDescription().getId());
-        result.setName(collection.getDescription().getName());
-        result.setPublishDate(collection.getDescription().getPublishDate());
+        result.setId(description.getId());
+        result.setName(description.getName());
+        result.setPublishDate(description.getPublishDate());
         result.setInProgressUris(collection.inProgressUris());
         result.setCompleteUris(collection.completeUris());
         result.setReviewedUris(collection.reviewedUris());
-        result.setEventsByUri(collection.getDescription().getEventsByUri());
-        result.setApprovalStatus(collection.getDescription().getApprovalStatus());
-        result.setType(collection.getDescription().getType());
-        result.setTeams(collection.getDescription().getTeams());
-        result.setEncrypted(collection.getDescription().isEncrypted());
-        result.setReleaseUri(collection.getDescription().getReleaseUri());
-
+        result.setEventsByUri(description.getEventsByUri());
+        result.setApprovalStatus(description.getApprovalStatus());
+        result.setType(description.getType());
+        result.setTeams(description.getTeams());
+        result.setEncrypted(description.isEncrypted());
+        result.setReleaseUri(description.getReleaseUri());
         info().user(session.getEmail())
                 .collectionID(collectionID)
                 .log("get collection endpoint: request compeleted successfully");
@@ -163,7 +169,7 @@ public class Collection {
             return null;
         }
 
-        requireEditPermission(session);
+        requireEditPermission(session, collectionDescription.getType());
 
         info().user(session.getEmail()).log("create collection endpoint: user granted canEdit permission");
 
@@ -225,7 +231,11 @@ public class Collection {
             throw new UnauthorizedException("You are not authorised to update collections.");
         }
 
-        requireEditPermission(session);
+        CollectionDescription currentCollectionDescription = collection.getDescription();
+
+        // Check user has permission to edit the collection type both currently and in the update request (in case of type change).
+        requireEditPermission(session, currentCollectionDescription.getType());
+        requireEditPermission(session, collectionDescription.getType());
 
         info().user(session.getEmail())
                 .collectionID(collectionId)
@@ -284,6 +294,17 @@ public class Collection {
             throw new NotFoundException("The collection you are trying to delete was not found");
         }
 
+        CollectionDescription description = collection.getDescription();
+        if (description == null) {
+            info().log("delete collection endpoint: request unsuccessful collection description not found");
+            throw new InternalServerError("The collection description was not found.");
+        }
+
+        //TODO: This should really be requireDeletePermission but this not currently supported
+        // and we would need to implement it in three different ways. Come back to this post 
+        // migration to the decentralised permissions model.
+        requireEditPermission(session, description.getType());
+
         deleteCollection(collection, session);
 
         Audit.Event.COLLECTION_DELETED
@@ -300,7 +321,7 @@ public class Collection {
     }
 
     private void deleteCollection(com.github.onsdigital.zebedee.model.Collection c, Session s)
-            throws InternalServerError, NotFoundException, BadRequestException {
+            throws InternalServerError {
         // Delete the collection.
         try {
             collections.delete(c, s);
@@ -321,12 +342,12 @@ public class Collection {
         }
     }
 
-    private void requireViewPermission(Session session, String collectionId) throws UnauthorizedException {
+    private void requireViewPermission(Session session, String collectionId, CollectionType collectionType) throws ForbiddenException {
         boolean canView = false;
         try {
-            canView = permissionsService.canView(session, collectionId);
+            canView = permissionsService.canView(session, collectionId, collectionType);
         } catch (IOException ex) {
-            throw new UnauthorizedException("You are not authorised to view this collection");
+            throw new ForbiddenException("You are not authorised to view this collection");
         }
 
         if (!canView) {
@@ -334,23 +355,23 @@ public class Collection {
                     .collectionID(collectionId)
                     .log("request unsuccessful user denied view permission");
 
-            throw new UnauthorizedException("You are not authorised to view this collection");
+            throw new ForbiddenException("You are not authorised to view this collection");
         }
     }
 
-    private void requireEditPermission(Session session) throws UnauthorizedException {
+    private void requireEditPermission(Session session, CollectionType collectionType) throws ForbiddenException {
         boolean canEdit = false;
         try {
-            canEdit = permissionsService.canEdit(session);
+            canEdit = permissionsService.canEdit(session, collectionType);
         } catch (IOException ex) {
-            throw new UnauthorizedException("You are not authorised to edit collections.");
+            throw new ForbiddenException("You are not authorised to edit this type of collection.");
         }
 
         if (!canEdit) {
             warn().user(session.getEmail())
                     .log("request unsuccessful user denied edit permission");
 
-            throw new UnauthorizedException("You are not authorised to edit collections.");
+            throw new ForbiddenException("You are not authorised to edit this type of collection.");
         }
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Collections.java
@@ -132,7 +132,7 @@ public class Collections {
 
         Session session = zebedeeCmsService.getSession();
         if (session == null || !zebedeeCmsService.getPermissions().canEdit(session)) {
-            info().log("Forbidden request made to the collection endpoint");
+            info().log("user is not authorised to edit collections");
             response.setStatus(HttpStatus.SC_FORBIDDEN);
             return;
         }
@@ -140,7 +140,6 @@ public class Collections {
         String user = session.getEmail();
 
         Path path = Path.newInstance(request);
-        
 
         if (!isValidPath(path)) {
             info().data("path", path).data("method", request.getMethod()).log("Endpoint for collections not found");
@@ -154,8 +153,21 @@ public class Collections {
 
         Collection collection = zebedeeCmsService.getCollection(collectionID);
         if (collection == null) {
-            info().data("collectionId", collectionID).log("Collection not found");
+            info().data("collection_id", collectionID).log("collection not found");
             response.setStatus(HttpStatus.SC_NOT_FOUND);
+            return;
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null || collectionDescription.getType() == null) {
+            info().data("collection_id", collectionID).log("collection description or type not found");
+            response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        if (!zebedeeCmsService.getPermissions().canEdit(session, collectionDescription.getType())) {
+            info().data("collection_type", collectionDescription.getType()).log("user is not authorised to edit collections of this type");
+            response.setStatus(HttpStatus.SC_FORBIDDEN);
             return;
         }
 
@@ -231,6 +243,19 @@ public class Collections {
         if (collection == null) {
             info().data("collectionId", collectionID).log("Collection not found");
             response.setStatus(HttpStatus.SC_NOT_FOUND);
+            return;
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            info().data("collectionId", collectionID).log("collection description not found");
+            response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        if (!zebedeeCmsService.getPermissions().canEdit(session, collectionDescription.getType())) {
+            info().log("user is not authorised to edit collections of this type");
+            response.setStatus(HttpStatus.SC_FORBIDDEN);
             return;
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Transfer.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Transfer.java
@@ -17,35 +17,44 @@ import java.nio.file.Path;
 
 /**
  * Created by kanemorgan on 24/03/2015.
+ * TODO:I don't believe this is used and so could be removed LM 16/03/2026
  */
 @Api
 public class Transfer {
 
     /**
-     * Moves files between collections using the endpoint <code>/Transfer/[CollectionName]</code>
+     * Moves files between collections using the endpoint
+     * <code>/Transfer/[CollectionName]</code>
      *
-     * @param request This should contain a X-Florence-Token header for the current session
-     * @param response <ul>
-     *                 <li>If the either collection does not exist:  {@link HttpStatus#NOT_FOUND_404}</li>
-     *                 <li>If the file does not exist:  {@link HttpStatus#NOT_FOUND_404}</li>
-     *                 <li>If user not authorised to transfer:  {@link HttpStatus#UNAUTHORIZED_401}</li>
-     *                 <li>A file with that name already exists in the second collection:  {@link HttpStatus#CONFLICT_409}</li>
-     * @param params A {@link TransferRequest} object
+     * @param request  This should contain a X-Florence-Token header for the current
+     *                 session
+     * @param response
+     *                 <ul>
+     *                 <li>If the either collection does not exist:
+     *                 {@link HttpStatus#NOT_FOUND_404}</li>
+     *                 <li>If the file does not exist:
+     *                 {@link HttpStatus#NOT_FOUND_404}</li>
+     *                 <li>If user not authorised to transfer:
+     *                 {@link HttpStatus#UNAUTHORIZED_401}</li>
+     *                 <li>A file with that name already exists in the second
+     *                 collection: {@link HttpStatus#CONFLICT_409}</li>
+     * @param params   A {@link TransferRequest} object
      * @return success true/false
      * @throws IOException
      */
     @POST
-    public boolean move(HttpServletRequest request, HttpServletResponse response, TransferRequest params) throws IOException {
+    public boolean move(HttpServletRequest request, HttpServletResponse response, TransferRequest params)
+            throws IOException {
         // user has permission
         Session session = Root.zebedee.getSessions().get();
-        if (!Root.zebedee.getPermissionsService().canEdit(session)){
-            response.setStatus(HttpStatus.UNAUTHORIZED_401);
+        if (!Root.zebedee.getPermissionsService().canEdit(session)) {
+            response.setStatus(HttpStatus.FORBIDDEN_403);
             return false;
         }
 
         // get the source collection
-        Collection source = getSource(params,request);
-        if(source == null) {
+        Collection source = getSource(params, request);
+        if (source == null) {
             response.setStatus(HttpStatus.NOT_FOUND_404);
             return false;
         }
@@ -63,9 +72,15 @@ public class Transfer {
             return false;
         }
 
+        if (!Root.zebedee.getPermissionsService().canEdit(session, destination.getDescription().getType()) ||
+                !Root.zebedee.getPermissionsService().canEdit(session, source.getDescription().getType())) {
+            response.setStatus(HttpStatus.FORBIDDEN_403);
+            return false;
+        }
+
         Path destinationPath = destination.getInProgressPath(params.uri);
 
-        if (Files.exists(destinationPath)){
+        if (Files.exists(destinationPath)) {
             response.setStatus(HttpStatus.CONFLICT_409);
             return false;
         }
@@ -80,7 +95,8 @@ public class Transfer {
         return true;
     }
 
-    private Collection getSource(TransferRequest params, HttpServletRequest request) throws  IOException{
-        return params.source == null ? Collections.getCollection(request) : Root.zebedee.getCollections().list().getCollection(params.source);
+    private Collection getSource(TransferRequest params, HttpServletRequest request) throws IOException {
+        return params.source == null ? Collections.getCollection(request)
+                : Root.zebedee.getCollections().list().getCollection(params.source);
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
@@ -92,7 +92,7 @@ public class Version {
 
         Session session = Root.zebedee.getSessions().get();
         if (session == null || !Root.zebedee.getPermissionsService().canEdit(session)) {
-            throw new UnauthorizedException("You are not authorised to edit content.");
+            throw new UnauthorizedException("You are not authorised to delete content.");
         }
 
         Collection collection = Collections.getCollection(request);
@@ -104,7 +104,7 @@ public class Version {
         }
 
         if (!Root.zebedee.getPermissionsService().canEdit(session, collectionDescription.getType())) {
-            throw new ForbiddenException("You are not authorised to edit content for this collection type.");
+            throw new ForbiddenException("You are not authorised to delete content for this collection type.");
         }
 
         try {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/api/Version.java
@@ -2,8 +2,9 @@ package com.github.onsdigital.zebedee.api;
 
 import com.github.davidcarboni.restolino.framework.Api;
 import com.github.onsdigital.zebedee.audit.Audit;
-import com.github.onsdigital.zebedee.exceptions.BadRequestException;
-import com.github.onsdigital.zebedee.exceptions.NotFoundException;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.model.Collection;
@@ -44,6 +45,15 @@ public class Version {
         Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");
 
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new InternalServerError("Collection description is missing");
+        }
+
+        if (!Root.zebedee.getPermissionsService().canEdit(session, collectionDescription.getType())) {
+            throw new UnauthorizedException("You are not authorised to edit content for this collection type.");
+        }
+
         ContentItemVersion version = null;
         try {
             CollectionWriter collectionWriter = new ZebedeeCollectionWriter(Root.zebedee, collection, session);
@@ -78,7 +88,7 @@ public class Version {
      *                 Returns HTTP 401 if the user is not authorised to edit content.
      */
     @DELETE
-    public boolean delete(HttpServletRequest request, HttpServletResponse response) throws IOException, BadRequestException, NotFoundException, UnauthorizedException {
+    public boolean delete(HttpServletRequest request, HttpServletResponse response) throws IOException, ZebedeeException {
 
         Session session = Root.zebedee.getSessions().get();
         if (session == null || !Root.zebedee.getPermissionsService().canEdit(session)) {
@@ -87,6 +97,15 @@ public class Version {
 
         Collection collection = Collections.getCollection(request);
         String uri = request.getParameter("uri");
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new InternalServerError("Collection description is missing");
+        }
+
+        if (!Root.zebedee.getPermissionsService().canEdit(session, collectionDescription.getType())) {
+            throw new ForbiddenException("You are not authorised to edit content for this collection type.");
+        }
 
         try {
             info().uri(uri).collectionID(collection).user(session).log("deleting collection version content");

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/configuration/CMSFeatureFlags.java
@@ -13,7 +13,6 @@ public class CMSFeatureFlags {
     public static final String ENABLE_DATASET_IMPORT = "ENABLE_DATASET_IMPORT";
     public static final String ENABLE_VERIFY_PUBLISH_CONTENT = "ENABLE_VERIFY_PUBLISH_CONTENT";
     private static final String ENABLE_DATASET_VERSION_VERIFICATION = "ENABLE_DATASET_VERSION_VERIFICATION";
-    private static final String ENABLE_CENTRALISED_KEYRING = "ENABLE_CENTRALISED_KEYRING";
     public static final String ENABLE_IMAGE_PUBLISHING = "ENABLE_IMAGE_PUBLISHING";
     private static final String ENABLE_JWT_SESSIONS = "ENABLE_JWT_SESSIONS";
     private static final String ENABLE_PERMISSIONS_API = "ENABLE_PERMISSIONS_API";
@@ -28,7 +27,6 @@ public class CMSFeatureFlags {
     private final boolean isDatasetImportEnabled;
     private final boolean isVerifyPublishEnabled;
     private final boolean isDatasetVersionVerificationEnabled;
-    private final boolean isCentralisedKeyringEnabled;
     private final boolean isImagePublishingEnabled;
     private final boolean isJwtSessionsEnabled;
     private final boolean isPermissionsAPIEnabled;
@@ -43,7 +41,6 @@ public class CMSFeatureFlags {
         this.isDatasetImportEnabled = Boolean.valueOf(getConfigValue(ENABLE_DATASET_IMPORT));
         this.isVerifyPublishEnabled = Boolean.valueOf(getConfigValue(ENABLE_VERIFY_PUBLISH_CONTENT));
         this.isDatasetVersionVerificationEnabled = Boolean.valueOf(getConfigValue(ENABLE_DATASET_VERSION_VERIFICATION));
-        this.isCentralisedKeyringEnabled = Boolean.valueOf(getConfigValue(ENABLE_CENTRALISED_KEYRING));
         this.isImagePublishingEnabled = Boolean.valueOf(getConfigValue(ENABLE_IMAGE_PUBLISHING));
         this.isJwtSessionsEnabled = Boolean.valueOf(getConfigValue(ENABLE_JWT_SESSIONS));
         this.isPermissionsAPIEnabled = Boolean.valueOf(getConfigValue(ENABLE_PERMISSIONS_API));
@@ -54,7 +51,6 @@ public class CMSFeatureFlags {
         info().data(ENABLE_DATASET_IMPORT, isDatasetImportEnabled)
                 .data(ENABLE_VERIFY_PUBLISH_CONTENT, isVerifyPublishEnabled)
                 .data(ENABLE_DATASET_VERSION_VERIFICATION, isDatasetVersionVerificationEnabled)
-                .data(ENABLE_CENTRALISED_KEYRING, isCentralisedKeyringEnabled)
                 .data(ENABLE_IMAGE_PUBLISHING, isImagePublishingEnabled)
                 .data(ENABLE_JWT_SESSIONS, isJwtSessionsEnabled)
                 .data(ENABLE_PERMISSIONS_API, isPermissionsAPIEnabled)
@@ -94,10 +90,6 @@ public class CMSFeatureFlags {
      */
     public boolean isDatasetVersionVerificationEnabled() {
         return this.isDatasetVersionVerificationEnabled;
-    }
-
-    public boolean isCentralisedKeyringEnabled() {
-        return isCentralisedKeyringEnabled;
     }
 
     public boolean isImagePublishingEnabled() {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionType.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/CollectionType.java
@@ -1,6 +1,9 @@
 package com.github.onsdigital.zebedee.json;
 
+// N.B. these are supplied lower case from 
+// external sources.
 public enum CollectionType {
     scheduled,
-    manual
+    manual,
+    automated
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImpl.java
@@ -1,9 +1,9 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
-import com.github.onsdigital.zebedee.json.CollectionDescription;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -76,7 +76,7 @@ public class CollectionKeyringImpl implements CollectionKeyring {
         validateSession(session);
         validateCollection(collection);
 
-        boolean hasPermission = hasViewPermissions(session, collection.getDescription().getId());
+        boolean hasPermission = hasViewPermissionsForType(session, collection.getDescription().getId(), collection.getDescription().getType());
 
         if (!hasPermission) {
             return null;
@@ -90,7 +90,7 @@ public class CollectionKeyringImpl implements CollectionKeyring {
         validateSession(session);
         validateCollection(collection);
 
-        boolean hasPermission = hasEditPermissions(session);
+        boolean hasPermission = hasEditPermissionsForType(session, collection.getDescription().getType());
 
         if (!hasPermission) {
             return;
@@ -105,7 +105,7 @@ public class CollectionKeyringImpl implements CollectionKeyring {
         validateCollection(collection);
         validateKey(key);
 
-        boolean hasPermission = hasEditPermissions(session);
+        boolean hasPermission = hasEditPermissionsForType(session, collection.getDescription().getType());
 
         if (!hasPermission) {
             return;
@@ -163,9 +163,17 @@ public class CollectionKeyringImpl implements CollectionKeyring {
         }
     }
 
-    private boolean hasViewPermissions(Session session, String collectionId) throws KeyringException {
+    private boolean hasViewPermissionsForType(Session session, String collectionId, CollectionType collectionType) throws KeyringException {
         try {
-            return permissionsService.canView(session, collectionId);
+            return permissionsService.canView(session, collectionId, collectionType);
+        } catch (IOException ex) {
+            throw new KeyringException(ex);
+        }
+    }
+
+    private boolean hasEditPermissionsForType(Session session, CollectionType collectionType) throws KeyringException {
+        try {
+            return permissionsService.canEdit(session, collectionType);
         } catch (IOException ex) {
             throw new KeyringException(ex);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -413,7 +413,7 @@ public class Collection {
         }
 
         if (collectionDescription.getTeams() != null) {
-            Set<String> teamIds = setViewerTeams(collectionDescription, zebedee, session);
+            setViewerTeams(collectionDescription, zebedee, session);
             updatedCollection.getDescription().setTeams(collectionDescription.getTeams());
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -783,7 +783,7 @@ public class Collection {
         }
 
         boolean contentWasCompleted = contentWasCompleted(uri);
-        if (contentWasCompleted == false) {
+        if (!contentWasCompleted) {
             throw new BadRequestException("Item has not been marked completed");
         }
 
@@ -796,26 +796,23 @@ public class Collection {
             throw new BadRequestException("Item has already been reviewed");
         }
 
-        if (permission && !userCompletedContent) {
+        // Move the complete copy to reviewed:
+        Path source = complete.get(uri);
 
-            // Move the complete copy to reviewed:
-            Path source = complete.get(uri);
-
-            if (source == null) {
-                source = inProgress.get(uri);
-            }
-
-            Path destination = reviewed.toPath(uri);
-
-            if (recursive) {
-                reviewRecursive(source, destination, session);
-            } else {
-                reviewSingleFile(source, destination);
-            }
-
-            addEvent(uri, new Event(new Date(), EventType.REVIEWED, session.getEmail()));
-            result = true;
+        if (source == null) {
+            source = inProgress.get(uri);
         }
+
+        Path destination = reviewed.toPath(uri);
+
+        if (recursive) {
+            reviewRecursive(source, destination, session);
+        } else {
+            reviewSingleFile(source, destination);
+        }
+
+        addEvent(uri, new Event(new Date(), EventType.REVIEWED, session.getEmail()));
+        result = true;
 
         return result;
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -789,7 +789,15 @@ public class Collection {
 
         boolean userCompletedContent = didUserCompleteContent(session.getEmail(), uri);
         if (userCompletedContent) {
-            throw new UnauthorizedException("Reviewer must be a second set of eyes");
+            boolean selfApprovePermission = zebedee.getPermissionsService().canSelfApprove(session, this.getDescription().getType());
+            boolean isAutomatedCollection = this.getDescription().getType() == CollectionType.automated;
+            if (!selfApprovePermission) {
+                throw new ForbiddenException("Reviewer must be a second set of eyes");
+            }
+
+            if (!isAutomatedCollection) {
+                throw new BadRequestException("Only automated collections can be self-approved");
+            }
         }
 
         if (reviewed.get(uri) != null) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -11,6 +11,7 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.CollectionNotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
 import com.github.onsdigital.zebedee.exceptions.DeleteContentRequestDeniedException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
@@ -631,7 +632,7 @@ public class Collection {
         }
 
         // Does the current user have permission to edit?
-        boolean permission = zebedee.getPermissionsService().canEdit(session);
+        boolean permission = zebedee.getPermissionsService().canEdit(session, this.getDescription().getType());
 
         if (!isBeingEdited && !hasDeleteMarker && !exists && permission) {
             // Copy from Published to in progress:
@@ -683,7 +684,7 @@ public class Collection {
 
 
         // Does the user have permission to edit?
-        boolean permission = zebedee.getPermissionsService().canEdit(session);
+        boolean permission = zebedee.getPermissionsService().canEdit(session, this.getDescription().getType());
         if (!permission) {
             info().data("path", uri).data("collectionId", this.getDescription().getId()).data("user", session.getEmail())
                     .log("Content was not saved as user does not have EDIT permission");
@@ -729,7 +730,7 @@ public class Collection {
 
     public boolean complete(Session session, String uri, boolean recursive) throws IOException {
         boolean result = false;
-        boolean permission = zebedee.getPermissionsService().canEdit(session);
+        boolean permission = zebedee.getPermissionsService().canEdit(session, this.getDescription().getType());
 
         if (isInProgress(uri) && permission) {
             // Move the in-progress copy to completed:
@@ -772,9 +773,9 @@ public class Collection {
             throw new NotFoundException("File not found");
         }
 
-        boolean permission = zebedee.getPermissionsService().canEdit(session);
+        boolean permission = zebedee.getPermissionsService().canEdit(session, this.getDescription().getType());
         if (!permission) {
-            throw new UnauthorizedException("Insufficient permissions");
+            throw new ForbiddenException("Insufficient permissions for this collection type");
         }
 
         if (Files.isDirectory(this.find(uri))) {

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -294,8 +294,7 @@ public class Collections {
             throws IOException {
         try {
             String collectionName = getCollectionNameFromId(collectionId);
-            Collection collection = getCollectionByName(collectionName);
-            return collection;
+            return getCollectionByName(collectionName);
         } catch (IOException | CollectionNotFoundException e) {
             return list().getCollection(collectionId);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -199,7 +199,7 @@ public class Collections {
         }
 
         // Check authorisation
-        if (!permissionsService.canEdit(session)) {
+        if (!permissionsService.canEdit(session, collection.getDescription().getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
@@ -329,7 +329,7 @@ public class Collections {
         }
 
         // User has permission
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collection.getDescription().getType())) {
             error().log("approve collection: user permission check failed");
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
@@ -406,23 +406,28 @@ public class Collections {
             throw new BadRequestException("Please provide a valid collection.");
         }
 
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
+        }
+
         // User has permission
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
         // don't do anything if the approval status is not complete.
-        if (collection.getDescription().getApprovalStatus() != ApprovalStatus.COMPLETE) {
+        if (collectionDescription.getApprovalStatus() != ApprovalStatus.COMPLETE) {
             return true;
         }
 
         // Go ahead
-        collection.getDescription().setApprovalStatus(ApprovalStatus.NOT_STARTED);
-        collection.getDescription().addEvent(new Event(new Date(), EventType.UNLOCKED, session.getEmail()));
+        collectionDescription.setApprovalStatus(ApprovalStatus.NOT_STARTED);
+        collectionDescription.addEvent(new Event(new Date(), EventType.UNLOCKED, session.getEmail()));
 
         // Remove redirects
         if (cmsFeatureFlags().isRedirectAPIEnabled()){
-            collection.getDescription().setRedirects(new ArrayList<>());
+            collectionDescription.setRedirects(new ArrayList<>());
         }
         
         publishingNotificationConsumer.accept(collection, EventType.UNLOCKED);
@@ -450,13 +455,18 @@ public class Collections {
             throw new BadRequestException("Please provide a valid collection.");
         }
 
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
+        }
+
         // User has permission
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
         // Check approval status
-        if (collection.getDescription().getApprovalStatus() != ApprovalStatus.COMPLETE) {
+        if (collectionDescription.getApprovalStatus() != ApprovalStatus.COMPLETE) {
             throw new ConflictException("This collection cannot be published because it is not approved");
         }
 
@@ -496,12 +506,17 @@ public class Collections {
             IOException, BadRequestException {
 
         if (collection == null) {
-            throw new BadRequestException("Please specify a valid collection.");
+            throw new BadRequestException("Please provide a valid collection.");
         }
 
-        // Check view permissionsServiceImpl
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
+        }
+
+        // Check view permissions
         if (!permissionsService.canView(session,
-                collection.getDescription().getId())) {
+                collectionDescription.getId(), collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
@@ -554,11 +569,16 @@ public class Collections {
 
         // Collection exists
         if (collection == null) {
-            throw new BadRequestException("Please specify a valid collection");
+            throw new BadRequestException("Please provide a valid collection.");
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
         }
 
         // User has permission
-        if (!permissionsService.canEdit(session)) {
+        if (!permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
@@ -722,11 +742,16 @@ public class Collections {
 
         // Collection (null check before authorisation check)
         if (collection == null) {
-            throw new BadRequestException("Please specify a collection");
+            throw new BadRequestException("Please provide a valid collection.");
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
         }
 
         // Authorisation
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
@@ -848,11 +873,16 @@ public class Collections {
     public void moveContent(Session session, Collection collection, String uri, String newUri) throws ZebedeeException, IOException {
 
         if (collection == null) {
-            throw new BadRequestException("Please specify a collection");
+            throw new BadRequestException("Please provide a valid collection.");
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
         }
 
         // Authorisation
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 
@@ -876,11 +906,16 @@ public class Collections {
             ZebedeeException {
 
         if (collection == null) {
-            throw new BadRequestException("Please specify a collection");
+            throw new BadRequestException("Please provide a valid collection.");
+        }
+
+        CollectionDescription collectionDescription = collection.getDescription();
+        if (collectionDescription == null) {
+            throw new BadRequestException("Collection description not found for collection");
         }
 
         // Authorisation
-        if (session == null || !permissionsService.canEdit(session)) {
+        if (session == null || !permissionsService.canEdit(session, collectionDescription.getType())) {
             throw new UnauthorizedException(getUnauthorizedMessage(session));
         }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -56,7 +56,7 @@ public class ZebedeeCollectionReader extends CollectionReader {
      *                   {@link CollectionKeyring}.
      * @param collection the {@link Collection} the reader will read the content from
      * @param session    the {@link Session} of the {@link User} who will use the reader.
-     * @throws IOException           problem creating the read.
+     * @throws IOException           problem creating the reader.
      * @throws NotFoundException     the collection is not found
      * @throws UnauthorizedException the user is not authorised to read the collection content
      */

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -43,7 +43,7 @@ public class ZebedeeCollectionReader extends CollectionReader {
     static final String COLLECTION_KEY_NULL_ERR =
             "error constructing ZebedeeCollectionReader key required but keyring returned null";
 
-    public ZebedeeCollectionReader(Collection collection, SecretKey key) throws BadRequestException, IOException, UnauthorizedException, NotFoundException {
+    public ZebedeeCollectionReader(Collection collection, SecretKey key) throws IOException, UnauthorizedException, NotFoundException {
         init(collection, key);
     }
 

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReader.java
@@ -6,6 +6,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.ContentReader;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -29,6 +30,8 @@ public class ZebedeeCollectionReader extends CollectionReader {
             "error constructing ZebedeeCollectionReader keyring required but was null";
     static final String COLLECTION_NULL_ERR =
             "error constructing ZebedeeCollectionReader collection required but was null";
+    static final String COLLECTION_DESCRIPTION_NULL_ERR =
+            "error constructing ZebedeeCollectionReader collection description required but was null";
     static final String SESSION_NULL_ERR =
             "error constructing ZebedeeCollectionReader session required but was null";
     static final String GET_USER_ERR =
@@ -61,7 +64,7 @@ public class ZebedeeCollectionReader extends CollectionReader {
             throws IOException, NotFoundException, UnauthorizedException {
         validate(zebedee, collection, session);
 
-        checkUserAuthorisedToAccessCollection(zebedee, collection.getDescription().getId(), session);
+        checkUserAuthorisedToAccessCollection(zebedee, collection.getDescription().getId(), collection.getDescription().getType(), session);
 
         SecretKey key = getCollectionKey(zebedee, collection, session);
 
@@ -90,16 +93,20 @@ public class ZebedeeCollectionReader extends CollectionReader {
             throw new NotFoundException(COLLECTION_NULL_ERR);
         }
 
+        if (collection.getDescription() == null) {
+            throw new NotFoundException(COLLECTION_NULL_ERR);
+        }
+
         if (session == null) {
             throw new UnauthorizedException(SESSION_NULL_ERR);
         }
     }
 
-    private void checkUserAuthorisedToAccessCollection(Zebedee zebedee, String collectionId, Session session)
+    private void checkUserAuthorisedToAccessCollection(Zebedee zebedee, String collectionId, CollectionType collectionType, Session session)
             throws IOException, UnauthorizedException {
         boolean isAuthorised = false;
         try {
-            isAuthorised = zebedee.getPermissionsService().canView(session, collectionId);
+            isAuthorised = zebedee.getPermissionsService().canView(session, collectionId, collectionType);
         } catch (Exception ex) {
             throw new IOException(PERMISSIONS_CHECK_ERR, ex);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
@@ -9,7 +9,6 @@ import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.user.model.User;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.zebedee.api.Root;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.reader.configuration.ReaderConfiguration;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -36,6 +37,8 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
             "error constructing ZebedeeCollectionWriter user required but was null";
     static final String COLLECTION_NULL_ERR =
             "error constructing ZebedeeCollectionWriter collection required but was null";
+    static final String COLLECTION_DESCRIPTION_NULL_ERR =
+            "error constructing ZebedeeCollectionWriter collection description required but was null";
     static final String PERMISSION_DENIED_ERR =
             "error constructing ZebedeeCollectionWriter user does not have edit permission for collection";
     static final String PERMISSIONS_CHECK_ERR =
@@ -52,8 +55,7 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
             throws BadRequestException, IOException, UnauthorizedException, NotFoundException {
         validateParams(zebedee, collection, session);
         this.zebedee = zebedee;
-
-        checkUserAuthorisedToAccessCollection(zebedee, session);
+        checkUserAuthorisedToAccessCollection(zebedee, session, collection.getDescription().getType());
 
         SecretKey key = getCollectionKey(zebedee, collection, session);
 
@@ -98,16 +100,20 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
             throw new NotFoundException(COLLECTION_NULL_ERR);
         }
 
+        if (collection.getDescription() == null) {
+            throw new NotFoundException(COLLECTION_DESCRIPTION_NULL_ERR);
+        }
+
         if (session == null) {
             throw new UnauthorizedException(SESSION_NULL_ERR);
         }
     }
 
-    private void checkUserAuthorisedToAccessCollection(Zebedee zebedee, Session session)
+    private void checkUserAuthorisedToAccessCollection(Zebedee zebedee, Session session, CollectionType collectionType)
             throws IOException, UnauthorizedException {
         boolean isAuthorised = false;
         try {
-            isAuthorised = zebedee.getPermissionsService().canEdit(session);
+            isAuthorised = zebedee.getPermissionsService().canEdit(session, collectionType);
         } catch (Exception ex) {
             throw new IOException(PERMISSIONS_CHECK_ERR, ex);
         }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriter.java
@@ -52,7 +52,7 @@ public class ZebedeeCollectionWriter extends CollectionWriter {
      * Create a new instance of CollectionWriter for the given Zebedee instance, collection, and session.
      */
     public ZebedeeCollectionWriter(Zebedee zebedee, Collection collection, Session session)
-            throws BadRequestException, IOException, UnauthorizedException, NotFoundException {
+            throws IOException, UnauthorizedException, NotFoundException {
         validateParams(zebedee, collection, session);
         this.zebedee = zebedee;
         checkUserAuthorisedToAccessCollection(zebedee, session, collection.getDescription().getType());

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/scheduled/task/PrePublishCollectionsTask.java
@@ -163,7 +163,7 @@ public class PrePublishCollectionsTask extends ScheduledTask {
                         SlackNotification.publishNotification(PostPublisher.getPublishedCollection(collection), SlackNotification.CollectionStage.PRE_PUBLISH, SlackNotification.StageStatus.COMPLETED);
 
                         return true;
-                    } catch (BadRequestException | IOException | UnauthorizedException | NotFoundException e) {
+                    } catch (IOException | UnauthorizedException | NotFoundException e) {
                         // FIXME using PostPublisher.getPublishedCollection feels a bit hacky
                         // TODO pass through the error?
                         SlackNotification.publishNotification(PostPublisher.getPublishedCollection(collection), SlackNotification.CollectionStage.PRE_PUBLISH,SlackNotification.StageStatus.FAILED);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/model/Permissions.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/model/Permissions.java
@@ -4,6 +4,7 @@ public class Permissions {
     private Permissions() {
     }
 
-    public static final String LEGACY_READ = "legacy:read";
     public static final String LEGACY_EDIT = "legacy:edit";
+    public static final String LEGACY_READ = "legacy:read";
+    public static final String LEGACY_SELF_APPROVE = "legacy:self-approve";
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
@@ -143,6 +143,15 @@ public class JWTPermissionsServiceImpl implements PermissionsService {
     }
 
     /**
+     * canSelfApprove is a permission that allows a user to approve their own content. This is not functional
+     * with this implementation - see {@link PermissionsServiceImplementation#canSelfApprove(Session)}
+     */
+    @Override
+    public boolean canSelfApprove(Session session, CollectionType collectionType) throws IOException {
+        return false;
+    }
+
+    /**
      * implemented as part of session migration to JWT
      * will not be required once jwt has been migrated but will error if invoked
      *

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.permissions.service;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
 import com.github.onsdigital.zebedee.permissions.model.AccessMapping;
 import com.github.onsdigital.zebedee.permissions.store.PermissionsStore;
@@ -118,6 +119,13 @@ public class JWTPermissionsServiceImpl implements PermissionsService {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "removeAdministrator"));
     }
 
+ 
+    @Override
+    public boolean canEdit(Session session, CollectionType collectionType) throws IOException {
+        // Checking for permission on collection type is not implemented here, so just check the session as before.
+        return canEdit(session);
+    }
+
     /**
      * implemented as part of session migration to JWT
      * previous version flow...
@@ -126,7 +134,7 @@ public class JWTPermissionsServiceImpl implements PermissionsService {
      * after migration to dp-identity this translates to isPublisher
      *
      * @param session the {@link Session} of the user to check.
-     * @return null
+     * @return true if the user can edit content, false otherwise.
      * @throws IOException If a filesystem error occurs.
      */
     @Override
@@ -165,6 +173,16 @@ public class JWTPermissionsServiceImpl implements PermissionsService {
     @Override
     public void removeEditor(String email, Session session) throws IOException, UnauthorizedException {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "removeEditor"));
+    }
+
+    /**
+     * This is only implemented within the new {@link PermissionsServiceImplementation} and is not functional with this implementation.
+     */
+    @Override
+    public boolean canView(Session session, String collectionId, CollectionType collectionType) throws IOException {
+        // Checking for permission on collection type is not implemented here, so just 
+        // check the collectionid as before.
+        return canView(session, collectionId);
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
@@ -102,6 +102,16 @@ public interface PermissionsService {
     boolean canEdit(Session session) throws IOException;
 
     /**
+     * Check if the {@link User} has permissions to self-approve content.
+     *
+     * @param session the {@link Session} of the user to check.
+     * @return true if the user can self-approve content, false otherwise.
+     * @throws IOException unexpected error while checking permissions.
+     */
+    boolean canSelfApprove(Session session, CollectionType collectionType) throws IOException;
+
+
+    /**
      * Grant editor permission to a user.
      *
      * @param email   the email of the user to permit the permission to.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
@@ -5,6 +5,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -89,6 +90,15 @@ public interface PermissionsService {
      * @return true if the user can edit content, false otherwise.
      * @throws IOException unexpected error while checking permissions.
      */
+    boolean canEdit(Session session, CollectionType collectionType) throws IOException;
+
+    /**
+     * Check if the {@link User} has permissions to edit content.
+     *
+     * @param session the {@link Session} of the user to check.
+     * @return true if the user can edit content, false otherwise.
+     * @throws IOException unexpected error while checking permissions.
+     */
     boolean canEdit(Session session) throws IOException;
 
     /**
@@ -126,6 +136,16 @@ public interface PermissionsService {
      */
     @Deprecated
     void removeEditor(String email, Session session) throws IOException, UnauthorizedException;
+
+    /**
+     * Check if a {@link User} can view unpublished content.
+     *
+     * @param session      the {@link Session} to get the user details from.
+     * @param collectionId the ID of the {@link Collection} to check.
+     * @return true of the user has view permission for the content, false otherwise.
+     * @throws IOException unexpected error while checking permissions.
+     */
+    boolean canView(Session session, String collectionId, CollectionType collectionType) throws IOException;
 
     /**
      * Check if a {@link User} can view unpublished content.

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
@@ -6,13 +6,16 @@ import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
 import com.github.onsdigital.zebedee.session.model.Session;
 import com.github.onsdigital.zebedee.permissions.model.Permissions;
+
 import org.joda.time.Duration;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -78,6 +81,17 @@ public class PermissionsServiceImplementation implements PermissionsService {
     @Override
     public boolean canEdit(Session session) throws IOException {
         return canEdit(session, null);
+    }
+
+    @Override
+    public boolean canSelfApprove(Session session, CollectionType collectionType) throws IOException {
+        boolean authorised = false;
+        try {
+            authorised = hasPermission(session, Permissions.LEGACY_SELF_APPROVE, "", Optional.ofNullable(collectionType));
+        } catch (Exception e){
+            return false;
+        }
+        return authorised;    
     }
 
     @Override

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
@@ -65,43 +65,48 @@ public class PermissionsServiceImplementation implements PermissionsService {
     }
 
     @Override
-    public boolean canEdit(Session session) throws IOException {
+    public boolean canEdit(Session session, CollectionType collectionType) throws IOException {
         boolean authorised = false;
         try {
-            authorised = hasPermission(session, Permissions.LEGACY_EDIT, "");
-
+            authorised = hasPermission(session, Permissions.LEGACY_EDIT, "", Optional.ofNullable(collectionType));
         } catch (Exception e){
             return false;
         }
-        return authorised;    
+        return authorised;   
     }
 
+    @Override
+    public boolean canEdit(Session session) throws IOException {
+        return canEdit(session, null);
+    }
 
     @Override
     public void addEditor(String email, Session session) throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "addEditor"));
-
     }
 
     @Override
     public void removeEditor(String email, Session session) throws IOException, UnauthorizedException {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "removeEditor"));
-
     }
 
     @Override
-    public boolean canView(Session session, String collectionId) throws IOException {
+    public boolean canView(Session session, String collectionId, CollectionType collectionType) throws IOException {
         boolean authorised = false;
         readLock.lock();
         try {
-            authorised = hasPermission(session, Permissions.LEGACY_READ, collectionId);
-
+            authorised = hasPermission(session, Permissions.LEGACY_READ, collectionId, Optional.ofNullable(collectionType));
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
             readLock.unlock();
         }
         return authorised;
+    }
+
+    @Override
+    public boolean canView(Session session, String collectionId) throws IOException {
+        return canView(session, collectionId, null);
     }
 
     @Override
@@ -125,11 +130,17 @@ public class PermissionsServiceImplementation implements PermissionsService {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "userPermissions"));
     }
 
-    private Boolean hasPermission(Session session, String permissionString, String collectionId) throws Exception {
+    private Boolean hasPermission(Session session, String permissionString, String collectionId, Optional<CollectionType> collectionType) throws Exception {
         HashMap<String, String> attributes = new HashMap<>();
         attributes.put("collection_id", collectionId);
 
-        UserDataPayload userDataPayload = new UserDataPayload(session.getId(),session.getEmail(), session.getGroups());
+        if (collectionType.isPresent()) {
+            attributes.put("collection_type", collectionType.get().name());
+        } else {
+            attributes.put("collection_type", "");
+        }
+ 
+        UserDataPayload userDataPayload = new UserDataPayload(session.getId(), session.getEmail(), session.getGroups());
 
         return permissionChecker.hasPermission(userDataPayload, permissionString, attributes);
     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/ZebedeeTestBaseFixture.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee;
 
 import com.github.onsdigital.zebedee.json.Credentials;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.encryption.EncryptionKeyFactory;
@@ -163,8 +164,14 @@ public abstract class ZebedeeTestBaseFixture {
     protected void setUpPermissionsServiceMockForLegacyTests(Zebedee instance, Session session) throws Exception {
         when(permissionsService.canView(eq(session), anyString()))
                 .thenReturn(true);
+        
+        when(permissionsService.canView(eq(session), anyString(), any(CollectionType.class)))
+                .thenReturn(true);
 
         when(permissionsService.canEdit(session))
+                .thenReturn(true);
+        
+        when(permissionsService.canEdit(eq(session), any(CollectionType.class)))
                 .thenReturn(true);
 
         ReflectionTestUtils.setField(instance, "permissionsService", permissionsService);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionTest.java
@@ -1,10 +1,12 @@
 package com.github.onsdigital.zebedee.api;
 
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.model.Collections;
@@ -26,7 +28,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -36,6 +37,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class CollectionTest extends ZebedeeAPIBaseTestCase {
+
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     @Mock
     private Sessions sessions;
@@ -84,12 +87,21 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
 
         when(permissionsService.canView(mockSession, COLLECTION_ID))
                 .thenReturn(true);
+        
+        when(permissionsService.canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
+                .thenReturn(true);
 
         when(permissionsService.canEdit(mockSession))
                 .thenReturn(true);
 
+        when(permissionsService.canEdit(mockSession, TEST_COLLECTION_TYPE))
+                .thenReturn(true);
+
         when(description.getName())
                 .thenReturn("test");
+
+        when(description.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
 
         this.endpoint = new Collection(sessions, permissionsService, collections, usersService, collectionKeyring,
                 scheduleCanceller);
@@ -101,7 +113,7 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
     }
 
     @Test
-    public void testGet_getSessionReturnsNull_shouldThrowException() throws Exception {
+    public void testGet_getSessionReturnsNull_shouldThrowException() {
         when(sessions.get())
                 .thenReturn(null);
 
@@ -125,12 +137,28 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         verify(collections, never()).getCollection(anyString());
     }
 
+
+    @Test
+    public void testGet_CollectionDescriptionMissing_shouldThrowException() throws Exception {
+        when(collections.getCollectionId(mockRequest))
+                .thenReturn(COLLECTION_ID);
+        when(collection.getDescription())
+                .thenReturn(null);
+
+        InternalServerError actual = assertThrows(InternalServerError.class,
+                () -> endpoint.get(mockRequest, mockResponse));
+
+        assertThat(actual.getMessage(), equalTo("The collection description was not found."));
+        verify(sessions, times(1)).get();
+        verify(collections, times(1)).getCollection(anyString());
+    }
+
     @Test
     public void testGet_getCollectionError_shouldThrowException() throws Exception {
         when(collections.getCollection(COLLECTION_ID))
                 .thenThrow(IOException.class);
 
-        IOException actual = assertThrows(IOException.class,
+        assertThrows(IOException.class,
                 () -> endpoint.get(mockRequest, mockResponse));
 
         verify(sessions, times(1)).get();
@@ -152,44 +180,44 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
 
     @Test
     public void testGet_checkPermissionsError_shouldThrowException() throws Exception {
-        when(permissionsService.canView(mockSession, COLLECTION_ID))
+        when(permissionsService.canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenThrow(IOException.class);
 
-        UnauthorizedException actual = assertThrows(UnauthorizedException.class,
+        ForbiddenException actual = assertThrows(ForbiddenException.class,
                 () -> endpoint.get(mockRequest, mockResponse));
 
         assertThat(actual.getMessage(), equalTo("You are not authorised to view this collection"));
         verify(sessions, times(1)).get();
         verify(collections, times(1)).getCollection(COLLECTION_ID);
-        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
     }
 
     @Test
     public void testGet_permissionDenied_shouldThrowException() throws Exception {
-        when(permissionsService.canView(mockSession, COLLECTION_ID))
+        when(permissionsService.canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
-        UnauthorizedException actual = assertThrows(UnauthorizedException.class,
+        ForbiddenException actual = assertThrows(ForbiddenException.class,
                 () -> endpoint.get(mockRequest, mockResponse));
 
         assertThat(actual.getMessage(), equalTo("You are not authorised to view this collection"));
         verify(sessions, times(1)).get();
         verify(collections, times(1)).getCollection(COLLECTION_ID);
-        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
     }
 
     @Test
-    public void testGet_success_shouldThrowException() throws Exception {
+    public void testGet_success_shouldNotThrowException() throws Exception {
         CollectionDescription actual = endpoint.get(mockRequest, mockResponse);
 
         assertThat(actual, is(notNullValue()));
         verify(sessions, times(1)).get();
         verify(collections, times(1)).getCollection(COLLECTION_ID);
-        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(mockSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
     }
 
     @Test
-    public void testPost_sessionServiceReturnsNull_shouldThrowException() throws Exception {
+    public void testPost_sessionServiceReturnsNull_shouldThrowException() {
         when(sessions.get())
                 .thenReturn(null);
 
@@ -226,34 +254,34 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
 
     @Test
     public void testPost_permissionsCheckError_shouldThrowException() throws Exception {
-        when(permissionsService.canEdit(mockSession))
+        when(permissionsService.canEdit(mockSession, TEST_COLLECTION_TYPE))
                 .thenThrow(IOException.class);
 
-        UnauthorizedException ex = assertThrows(UnauthorizedException.class,
+        ForbiddenException ex = assertThrows(ForbiddenException.class,
                 () -> endpoint.create(mockRequest, mockResponse, description));
 
-        assertThat(ex.getMessage(), equalTo("You are not authorised to edit collections."));
+        assertThat(ex.getMessage(), equalTo("You are not authorised to edit this type of collection."));
         verify(sessions, times(1)).get();
-        verify(permissionsService, times(1)).canEdit(mockSession);
+        verify(permissionsService, times(1)).canEdit(mockSession, TEST_COLLECTION_TYPE);
         verifyNoMoreInteractions(sessions, permissionsService, collections);
     }
 
     @Test
     public void testPost_permissionDenied_shouldThrowException() throws Exception {
-        when(permissionsService.canEdit(mockSession))
+        when(permissionsService.canEdit(mockSession, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
-        UnauthorizedException ex = assertThrows(UnauthorizedException.class,
+        ForbiddenException ex = assertThrows(ForbiddenException.class,
                 () -> endpoint.create(mockRequest, mockResponse, description));
 
-        assertThat(ex.getMessage(), equalTo("You are not authorised to edit collections."));
+        assertThat(ex.getMessage(), equalTo("You are not authorised to edit this type of collection."));
         verify(sessions, times(1)).get();
-        verify(permissionsService, times(1)).canEdit(mockSession);
+        verify(permissionsService, times(1)).canEdit(mockSession, TEST_COLLECTION_TYPE);
         verifyNoMoreInteractions(sessions, permissionsService, collections);
     }
 
     @Test
-    public void testDelete_sessionNull_shouldThrowEx() throws Exception {
+    public void testDelete_sessionNull_shouldThrowEx() {
         when(sessions.get())
                 .thenReturn(null);
 
@@ -298,6 +326,25 @@ public class CollectionTest extends ZebedeeAPIBaseTestCase {
         assertThat(ex.getMessage(), equalTo("The collection you are trying to delete was not found"));
         verify(sessions, times(1)).get();
         verify(collections, times(1)).getCollection("1234");
+    }
+
+    @Test
+    public void testDelete_CollectionDescriptionMissing_shouldThrowException() throws Exception {
+        when(mockRequest.getPathInfo())
+                .thenReturn("collections/1234");
+        when(collections.getCollectionId(mockRequest))
+                .thenReturn(COLLECTION_ID);
+        when(collection.getDescription())
+                .thenReturn(null);
+        when(collections.getCollection("1234"))
+                .thenReturn(collection);
+
+        InternalServerError actual = assertThrows(InternalServerError.class,
+                () -> endpoint.deleteCollection(mockRequest, mockResponse));
+
+        assertThat(actual.getMessage(), equalTo("The collection description was not found."));
+        verify(sessions, times(1)).get();
+        verify(collections, times(1)).getCollection(anyString());
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/CollectionsTest.java
@@ -3,6 +3,9 @@ package com.github.onsdigital.zebedee.api;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
 import com.github.onsdigital.zebedee.json.CollectionDatasetVersion;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
+import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.service.DatasetService;
 import com.github.onsdigital.zebedee.session.model.Session;
@@ -32,8 +35,9 @@ public class CollectionsTest {
     private DatasetService mockDatasetService = mock(DatasetService.class);
     private ServletInputStream mockServletInputStream = mock(ServletInputStream.class);
 
-    private com.github.onsdigital.zebedee.model.Collection mockCollection =
-            mock(com.github.onsdigital.zebedee.model.Collection.class);
+    private Collection mockCollection = mock(Collection.class);
+    private CollectionType mockCollectionType = CollectionType.manual;
+    private CollectionDescription mockCollectionDescription = mock(CollectionDescription.class);
 
     private HttpServletRequest request = mock(HttpServletRequest.class);
     private HttpServletResponse response = mock(HttpServletResponse.class);
@@ -50,6 +54,8 @@ public class CollectionsTest {
     public void setUp() throws Exception {
         when(mockZebedeeCmsService.getCollection(collectionID)).thenReturn(mockCollection);
         when(mockCollection.getId()).thenReturn(collectionID);
+        when(mockCollection.getDescription()).thenReturn(mockCollectionDescription);
+        when(mockCollectionDescription.getType()).thenReturn(mockCollectionType);
     }
 
     @Test
@@ -81,7 +87,7 @@ public class CollectionsTest {
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
 
-        shouldAuthorise(request, false);
+        shouldAuthorise(request, false, mockCollectionType);
 
         // When the put method is called
         collections.put(request, response);
@@ -91,19 +97,53 @@ public class CollectionsTest {
     }
 
     @Test
+    public void testPut_NoType() throws Exception {
+
+        // Given a PUT request with a valid URL
+        String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(mockCollection.getDescription()).thenReturn(null);
+
+        shouldAuthorise(request, true, mockCollectionType);
+
+        // When the put method is called
+        collections.put(request, response);
+
+        // a HTTP 500 is set on the response
+        verify(response).setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
     public void testDelete_Forbidden() throws Exception {
 
         // Given a delete request with a valid URL
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
 
-        shouldAuthorise(request, false);
+        shouldAuthorise(request, false, mockCollectionType);
 
         // When the delete method is called
         collections.delete(request, response);
 
         // a HTTP 403 is set on the response
         verify(response).setStatus(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testDelete_NoType() throws Exception {
+
+        // Given a DELETE request with a valid URL
+        String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
+        when(request.getPathInfo()).thenReturn(url);
+        when(mockCollection.getDescription()).thenReturn(null);
+
+        shouldAuthorise(request, true, mockCollectionType);
+
+        // When the delete method is called
+        collections.delete(request, response);
+
+        // a HTTP 500 is set on the response
+        verify(response).setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
 
     @Test
@@ -114,7 +154,7 @@ public class CollectionsTest {
 
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the delete method is called
         collections.put(request, response);
@@ -131,7 +171,7 @@ public class CollectionsTest {
 
         String url = String.format("/collections/%s/anything/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the delete method is called
         collections.delete(request, response);
@@ -168,7 +208,7 @@ public class CollectionsTest {
     @Test
     public void testPutReturnBadRequestURLSegments() throws Exception {
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // Given a PUT request with a URL that contains less than the expected 4 segments
         String url = "/collections/123/anything";
@@ -187,7 +227,7 @@ public class CollectionsTest {
     @Test
     public void testDeleteReturnBadRequestURLSegments() throws Exception {
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // Given a PUT request with a URL that contains less than the expected number of segments
         String url = "/collections/123/anything";
@@ -207,7 +247,7 @@ public class CollectionsTest {
     @Test
     public void testPut_ReturnBadRequest_NotValidEndpoint() throws Exception {
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // Given a PUT request with a URL that contains something other than /collections/{}/{datasets|interactives}/{}
         String url = "/collections/123/anything/345";
@@ -223,7 +263,7 @@ public class CollectionsTest {
     @Test
     public void testDeleteReturnBadRequestNotValidEndpoint() throws Exception {
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, CollectionType.manual);
 
         // Given a PUT request with a URL that contains something other than /collections/{}/{datasets|interactives}/{}
         String url = "/collections/123/anything/345";
@@ -249,7 +289,7 @@ public class CollectionsTest {
 
         mockRequestBody("");
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the put method is called
         collections.put(request, response);
@@ -269,7 +309,7 @@ public class CollectionsTest {
         String json = "{ \"state\": \"inProgress\"}";
         mockRequestBody(json);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the put method is called
         collections.put(request, response);
@@ -289,7 +329,7 @@ public class CollectionsTest {
         String json = "{ \"state\": \"inProgress\"}";
         mockRequestBody(json);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the put method is called
         collections.put(request, response);
@@ -313,7 +353,7 @@ public class CollectionsTest {
         String json = "{ \"state\": \"inProgress\"}";
         mockRequestBody(json);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the put method is called
         collections.put(request, response);
@@ -330,7 +370,7 @@ public class CollectionsTest {
         String url = String.format("/collections/%s/datasets/%s", collectionID, resourceID);
         when(request.getPathInfo()).thenReturn(url);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the delete method is called
         collections.delete(request, response);
@@ -351,7 +391,7 @@ public class CollectionsTest {
                 collectionID, resourceID, edition, version);
         when(request.getPathInfo()).thenReturn(url);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the delete method is called
         collections.delete(request, response);
@@ -374,7 +414,7 @@ public class CollectionsTest {
                 collectionID, resourceID, edition);
         when(request.getPathInfo()).thenReturn(url);
 
-        shouldAuthorise(request, true);
+        shouldAuthorise(request, true, mockCollectionType);
 
         // When the delete method is called
         collections.delete(request, response);
@@ -387,7 +427,7 @@ public class CollectionsTest {
     }
 
     // mock the authorisation for the given request to authorise the request is the authorise param is true.
-    private void shouldAuthorise(HttpServletRequest request, boolean authorise) throws ZebedeeException, IOException {
+    private void shouldAuthorise(HttpServletRequest request, boolean authorise, CollectionType collectionType) throws ZebedeeException, IOException {
 
         when(mockZebedeeCmsService.getSession()).thenReturn(session);
 
@@ -395,6 +435,7 @@ public class CollectionsTest {
         when(mockZebedeeCmsService.getPermissions()).thenReturn(permissionsService);
 
         when(permissionsService.canEdit(session)).thenReturn(authorise);
+        when(permissionsService.canEdit(session, collectionType)).thenReturn(authorise);
     }
 
     private void mockRequestBody(String json) throws IOException {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -96,10 +96,8 @@ public class ContentTest {
         content = new com.github.onsdigital.zebedee.model.Content(tempBasePath);
         collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
 
-        when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
         when(mockPermissionsService.canEdit(mockSession, collectionType)).thenReturn(true);
 
-        when(mockPermissionsService.canView(any(), any())).thenReturn(true);
         when(mockPermissionsService.canView(any(), any(), any())).thenReturn(true);
 
         when(mockSessions.get()).thenReturn(mockSession);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/ContentTest.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.api;
 import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.model.Collection;
 import com.github.onsdigital.zebedee.model.Collections;
@@ -86,6 +87,8 @@ public class ContentTest {
         System.setProperty("zebedee_root", tempBasePath.toString());
 
         collectionDescription = new CollectionDescription("AK Testing");
+        CollectionType collectionType = CollectionType.manual;
+        collectionDescription.setType(collectionType);
         encryptionKeyFactory = new EncryptionKeyFactoryImpl();
         secretKey = KeyGenerator.getInstance("AES").generateKey();
         versionsService = new VersionsServiceImpl();
@@ -94,7 +97,10 @@ public class ContentTest {
         collections = new Collections(tempBasePath, mockPermissionsService, versionsService, content);
 
         when(mockPermissionsService.canEdit(mockSession)).thenReturn(true);
+        when(mockPermissionsService.canEdit(mockSession, collectionType)).thenReturn(true);
+
         when(mockPermissionsService.canView(any(), any())).thenReturn(true);
+        when(mockPermissionsService.canView(any(), any(), any())).thenReturn(true);
 
         when(mockSessions.get()).thenReturn(mockSession);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/TeamsReportTest.java
@@ -13,13 +13,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
 import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/VersionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/api/VersionTest.java
@@ -1,0 +1,81 @@
+package com.github.onsdigital.zebedee.api;
+
+import com.github.onsdigital.zebedee.Zebedee;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
+import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
+import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.model.Collections;
+import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
+import com.github.onsdigital.zebedee.session.service.Sessions;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+public class VersionTest extends ZebedeeAPIBaseTestCase {
+
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
+
+    @Mock
+    private Zebedee zebedee;
+
+    @Mock
+    private Sessions sessions;
+
+    @Mock
+    private PermissionsService permissionsService;
+
+    @Mock
+    private Collections collections;
+
+    @Mock
+    private Collection collection;
+
+    @Mock
+    private CollectionDescription description;
+
+    private Version endpoint;
+
+    @Override
+    protected void customSetUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        endpoint = new Version();
+        Root.zebedee = zebedee;
+
+        when(zebedee.getSessions()).thenReturn(sessions);
+        when(zebedee.getPermissionsService()).thenReturn(permissionsService);
+        when(zebedee.getCollections()).thenReturn(collections);
+        when(sessions.get()).thenReturn(mockSession);
+
+        when(collections.getCollection(COLLECTION_ID)).thenReturn(collection);
+        when(collection.getDescription()).thenReturn(description);
+        when(description.getType()).thenReturn(TEST_COLLECTION_TYPE);
+        when(mockRequest.getPathInfo()).thenReturn("/version/" + COLLECTION_ID);
+        when(mockRequest.getParameter("uri")).thenReturn("/some/uri");
+    }
+
+    @Override
+    protected Object getAPIName() {
+        return "Version";
+    }
+
+    @Test
+    public void create_permissionDeniedForCollectionType_shouldThrowUnauthorized() throws Exception {
+        when(permissionsService.canEdit(mockSession)).thenReturn(true);
+        when(permissionsService.canEdit(mockSession, TEST_COLLECTION_TYPE)).thenReturn(false);
+
+        assertThrows(UnauthorizedException.class, () -> endpoint.create(mockRequest, mockResponse));
+    }
+
+    @Test
+    public void delete_permissionDeniedForCollectionType_shouldThrowForbidden() throws Exception {
+        when(permissionsService.canEdit(mockSession)).thenReturn(true);
+        when(permissionsService.canEdit(mockSession, TEST_COLLECTION_TYPE)).thenReturn(false);
+
+        assertThrows(ForbiddenException.class, () -> endpoint.delete(mockRequest, mockResponse));
+    }
+}

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
@@ -92,7 +92,8 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
         CollectionDescription collectionDescription = new CollectionDescription();
         collectionDescription.setName("DataPublicationDetails");
         collectionDescription.setEncrypted(true);
-        collectionDescription.setType(CollectionType.scheduled);
+        CollectionType testCollectionType = CollectionType.scheduled;
+        collectionDescription.setType(testCollectionType);
         collectionDescription.setPublishDate(new Date());
 
         collection = Collection.create(collectionDescription, zebedee, publisher);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/data/processing/DataProcessorTestBaseFixture.java
@@ -114,7 +114,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void getDatasetBasedUriForTimeseries_givenUnindexed_returnsExpectedUrl() throws ParseException, URISyntaxException, IOException, ZebedeeException {
+    public void getDatasetBasedUriForTimeseries_givenUnindexed_returnsExpectedUrl() throws IOException, ZebedeeException {
         // Given
         // A timeseries from our reviewed dataset
         DataPublicationDetails details = inReview.getDetails(publishedReader, collectionReader.getReviewed());
@@ -134,7 +134,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void getDatasetBasedUriForTimeseries_givenIndexed_returnsExpectedUrl() throws ParseException, URISyntaxException, IOException, ZebedeeException {
+    public void getDatasetBasedUriForTimeseries_givenIndexed_returnsExpectedUrl() throws IOException, ZebedeeException {
         // Given
         // A timeseries from our reviewed dataset
         DataPublicationDetails details = inReview.getDetails(publishedReader, collectionReader.getReviewed());
@@ -157,7 +157,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
 
 
     @Test
-    public void initialTimeseries_givenNewTimeseries_returnsEmptyTimeseries() throws IOException, ParseException, URISyntaxException, ZebedeeException {
+    public void initialTimeseries_givenNewTimeseries_returnsEmptyTimeseries() throws IOException, URISyntaxException, ZebedeeException {
         // Given
         // We upload a data collection to a zebedee instance where we don't have current published content
         DataPublicationDetails details = inReview.getDetails(publishedReader, collectionReader.getReviewed());
@@ -199,7 +199,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void syncMetadata_givenVariedDetailSet_takesContactsFromLandingPage() throws IOException, ZebedeeException, ParseException, URISyntaxException {
+    public void syncMetadata_givenVariedDetailSet_takesContactsFromLandingPage() throws IOException, ZebedeeException, URISyntaxException {
 
         // Given
         // A timeseries and the initial timeseries
@@ -231,7 +231,7 @@ public class DataProcessorTestBaseFixture extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void syncMetadata_givenVariedDetailSet_takesDatesFromLandingPage() throws IOException, ZebedeeException, ParseException, URISyntaxException {
+    public void syncMetadata_givenVariedDetailSet_takesDatesFromLandingPage() throws IOException, ZebedeeException, URISyntaxException {
 
         // Given
         // A timeseries and the initial timeseries

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/keyring/central/CollectionKeyringImplTest.java
@@ -1,6 +1,7 @@
 package com.github.onsdigital.zebedee.keyring.central;
 
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyCache;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
@@ -228,13 +229,16 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canView(session, TEST_COLLECTION_ID))
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canView(session, TEST_COLLECTION_ID, CollectionType.manual))
                 .thenThrow(new IOException("Bork"));
 
         KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(session, collection));
 
         assertThat(ex.getCause().getMessage(), equalTo("Bork"));
-        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID, CollectionType.manual);
     }
 
     @Test
@@ -247,14 +251,17 @@ public class CollectionKeyringImplTest {
 
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
+        
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
 
-        when(permissionsService.canView(session, TEST_COLLECTION_ID))
+        when(permissionsService.canView(session, TEST_COLLECTION_ID, CollectionType.manual))
                 .thenReturn(false);
 
         SecretKey secretKey = keyring.get(session, collection);
 
         assertThat(secretKey, is(nullValue()));
-        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID, CollectionType.manual);
     }
 
     @Test
@@ -267,8 +274,11 @@ public class CollectionKeyringImplTest {
 
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
+        
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
 
-        when(permissionsService.canView(session, TEST_COLLECTION_ID))
+        when(permissionsService.canView(session, TEST_COLLECTION_ID, CollectionType.manual))
                 .thenReturn(true);
 
         when(keyCache.get(TEST_COLLECTION_ID))
@@ -277,7 +287,7 @@ public class CollectionKeyringImplTest {
         KeyringException ex = assertThrows(KeyringException.class, () -> keyring.get(session, collection));
         assertThat(ex.getMessage(), equalTo("Beep"));
 
-        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID, CollectionType.manual);
         verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
@@ -292,7 +302,10 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canView(session, TEST_COLLECTION_ID))
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canView(session, TEST_COLLECTION_ID, CollectionType.manual))
                 .thenReturn(true);
 
         when(keyCache.get(TEST_COLLECTION_ID))
@@ -301,7 +314,7 @@ public class CollectionKeyringImplTest {
         SecretKey key = keyring.get(session, collection);
 
         assertThat(key, is(nullValue()));
-        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID, CollectionType.manual);
         verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
@@ -316,7 +329,10 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canView(session, TEST_COLLECTION_ID))
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canView(session, TEST_COLLECTION_ID, CollectionType.manual))
                 .thenReturn(true);
 
         when(keyCache.get(TEST_COLLECTION_ID))
@@ -325,7 +341,7 @@ public class CollectionKeyringImplTest {
         SecretKey key = keyring.get(session, collection);
 
         assertThat(key, equalTo(secretKey));
-        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(session, TEST_COLLECTION_ID, CollectionType.manual);
         verify(keyCache, times(1)).get(TEST_COLLECTION_ID);
     }
 
@@ -446,14 +462,17 @@ public class CollectionKeyringImplTest {
 
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
+        
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
 
-        when(permissionsService.canEdit(session))
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenThrow(new IOException("Bork"));
 
         KeyringException ex = assertThrows(KeyringException.class, () -> keyring.remove(session, collection));
 
         assertThat(ex.getCause().getMessage(), equalTo("Bork"));
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
     }
 
     @Test
@@ -467,12 +486,15 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canEdit(session))
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenReturn(false);
 
         keyring.remove(session, collection);
 
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
     }
 
     @Test
@@ -486,12 +508,15 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canEdit(session))
+        when(collDesc.getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenReturn(true);
 
         keyring.remove(session, collection);
 
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
         verify(keyCache, times(1)).remove(TEST_COLLECTION_ID);
     }
 
@@ -630,13 +655,16 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canEdit(session))
+        when(collection.getDescription().getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenThrow(new IOException("Bork"));
 
         KeyringException ex = assertThrows(KeyringException.class, () -> keyring.add(session, collection, secretKey));
 
         assertThat(ex.getCause().getMessage(), equalTo("Bork"));
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
     }
 
     @Test
@@ -650,12 +678,15 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canEdit(session))
+        when(collection.getDescription().getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenReturn(false);
 
         keyring.add(session, collection, secretKey);
 
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
         verifyNoInteractions(keyCache);
     }
 
@@ -670,12 +701,15 @@ public class CollectionKeyringImplTest {
         when(collDesc.getId())
                 .thenReturn(TEST_COLLECTION_ID);
 
-        when(permissionsService.canEdit(session))
+        when(collection.getDescription().getType())
+                .thenReturn(CollectionType.manual);
+
+        when(permissionsService.canEdit(session, CollectionType.manual))
                 .thenReturn(true);
 
         keyring.add(session, collection, secretKey);
 
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, CollectionType.manual);
         verify(keyCache, times(1)).add(TEST_COLLECTION_ID, secretKey);
     }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
@@ -84,7 +84,7 @@ public class CollectionMoveTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void shouldChangeReferencesInFileOnMoveContent() throws URISyntaxException, IOException, ZebedeeException {
+    public void shouldChangeReferencesInFileOnMoveContent() throws IOException, ZebedeeException {
         // Given
         // an item of content that references something
         martin.getRelatedArticles().add(new Link(bedford.getUri()));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionMoveTest.java
@@ -63,10 +63,10 @@ public class CollectionMoveTest extends ZebedeeTestBaseFixture {
         ReflectionTestUtils.setField(zebedee, "permissionsService", permissionsService);
         ReflectionTestUtils.setField(zebedee, "collectionKeyring", keyring);
 
-        when(permissionsService.canView(session, collection.getDescription().getId()))
+        when(permissionsService.canView(session, collection.getDescription().getId(), collection.getDescription().getType()))
                 .thenReturn(true);
 
-        when(permissionsService.canEdit(session))
+        when(permissionsService.canEdit(session, collection.getDescription().getType()))
                 .thenReturn(true);
 
         SecretKey key = Keys.newSecretKey();

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -920,12 +920,29 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test(expected = BadRequestException.class)
-    public void shouldNotSelfApproveForNonAutomatedCollection() throws Exception {
+    public void shouldNotSelfApproveForManualCollection() throws Exception {
 
         // Given a non-automated collection
         collection.getDescription().setType(CollectionType.manual);
         // And a user with the self approve permission
         when(permissionsService.canSelfApprove(publisher1Session, CollectionType.manual))
+                .thenReturn(true);
+        String uri = CreateCompleteContent();
+
+        // When the collection is reviewed
+        collection.review(publisher1Session, uri, recursive);
+
+        // Then
+        // expect a BadRequestException
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldNotSelfApproveForScheduledCollection() throws Exception {
+
+        // Given a non-automated collection
+        collection.getDescription().setType(CollectionType.scheduled);
+        // And a user with the self approve permission
+        when(permissionsService.canSelfApprove(publisher1Session, CollectionType.scheduled))
                 .thenReturn(true);
         String uri = CreateCompleteContent();
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -13,8 +13,8 @@ import com.github.onsdigital.zebedee.content.util.ContentUtil;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.CollectionNotFoundException;
 import com.github.onsdigital.zebedee.exceptions.ConflictException;
+import com.github.onsdigital.zebedee.exceptions.ForbiddenException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
-import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.ApprovalStatus;
 import com.github.onsdigital.zebedee.json.CollectionDataset;
@@ -66,6 +66,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -87,6 +88,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     private static final String teamName = "some team";
     private static final String teamId = "12";
     private static final boolean recursive = false;
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
     Collection collection;
     Session publisher1Session;
     Session publisher2Session;
@@ -97,6 +99,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         rootDir.create();
 
         collection = new Collection(builder.collections.get(1), zebedee);
+        collection.getDescription().setType(TEST_COLLECTION_TYPE);
 
         publisher1Session = new Session("5678", builder.publisher1.getEmail());
         publisher2Session = new Session("5678", builder.publisher2.getEmail());
@@ -104,9 +107,13 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         setUpPermissionsServiceMockForLegacyTests(zebedee, publisher1Session);
         ReflectionTestUtils.setField(zebedee, "teamsService", teamsService);
 
+        when(permissionsService.canEdit(publisher1Session))
+                .thenReturn(true);
+        when(permissionsService.canEdit(eq(publisher1Session), any(CollectionType.class)))
+                .thenReturn(true);  
         when(permissionsService.canEdit(publisher2Session))
                 .thenReturn(true);
-        when(permissionsService.canEdit(publisher1Session))
+        when(permissionsService.canEdit(eq(publisher2Session), any(CollectionType.class)))
                 .thenReturn(true);
 
         publisher1Email = builder.publisher1.getEmail();
@@ -878,7 +885,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.getDescription().getEventsByUri().get(uri).hasEventForType(EventType.REVIEWED);
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test(expected = ForbiddenException.class)
     public void shouldNotReviewAsPublisher() throws IOException, ZebedeeException {
 
         // Given
@@ -890,7 +897,23 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.review(publisher1Session, uri, recursive);
 
         // Then
-        // expect an Unauthorized error
+        // expect a Forbidden error
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void shouldNotReviewWhenEditPermissionDenied() throws Exception {
+
+        // Given some content that has been edited and complete
+        String uri = CreateCompleteContent();
+        // And a user without edit permissions for the collection
+        when(permissionsService.canEdit(eq(publisher2Session), any(CollectionType.class)))
+                .thenReturn(false);
+
+        // When the collection is reviewed
+        collection.review(publisher2Session, uri, recursive);
+
+        // Then
+        // expect a ForbiddenException
     }
 
     private String CreatePublishedContent() throws IOException {
@@ -920,7 +943,7 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         collection.edit(publisher1Session, uri, collectionWriter, recursive);
 
         // When - A reviewer edits reviews content
-        boolean reviewed = collection.review(publisher2Session, uri, recursive);
+        collection.review(publisher2Session, uri, recursive);
 
         // Then
         // Expect an error

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -900,6 +900,42 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         // expect a Forbidden error
     }
 
+    @Test
+    public void shouldAllowSelfApproveForAutomatedCollection() throws Exception {
+
+        // Given an automated collection
+        collection.getDescription().setType(CollectionType.automated);
+        // And an authorised user
+        when(permissionsService.canSelfApprove(publisher1Session, CollectionType.automated))
+                .thenReturn(true);
+        String uri = CreateCompleteContent();
+
+        // When the collection is reviewed
+        boolean reviewed = collection.review(publisher1Session, uri, recursive);
+
+        // Then the collection is successfully reviewed
+        assertTrue(reviewed);
+        Path reviewedPath = builder.collections.get(1).resolve(Collection.REVIEWED);
+        assertTrue(Files.exists(reviewedPath.resolve(uri.substring(1))));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldNotSelfApproveForNonAutomatedCollection() throws Exception {
+
+        // Given a non-automated collection
+        collection.getDescription().setType(CollectionType.manual);
+        // And a user with the self approve permission
+        when(permissionsService.canSelfApprove(publisher1Session, CollectionType.manual))
+                .thenReturn(true);
+        String uri = CreateCompleteContent();
+
+        // When the collection is reviewed
+        collection.review(publisher1Session, uri, recursive);
+
+        // Then
+        // expect a BadRequestException
+    }
+
     @Test(expected = ForbiddenException.class)
     public void shouldNotReviewWhenEditPermissionDenied() throws Exception {
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -235,7 +234,7 @@ public class CollectionsTest {
 
     @Test(expected = BadRequestException.class)
     public void shouldThrowBadRequestForNullCollectionOnListDirectory() throws IOException, UnauthorizedException,
-            BadRequestException, ConflictException, NotFoundException {
+            BadRequestException, NotFoundException {
         collections.listDirectory(null, "somefile.json", sessionMock);
     }
 
@@ -329,7 +328,7 @@ public class CollectionsTest {
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnListDirectory() throws IOException, UnauthorizedException,
             BadRequestException,
-            ConflictException, NotFoundException {
+            NotFoundException {
         when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
@@ -638,10 +637,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void shouldApproveCollection() throws IOException, ZebedeeException, ExecutionException,
-            InterruptedException {
-        Function<Path, ContentReader> contentReaderFunction = (p) -> contentReaderMock;
-        Function<ApproveTask, Future<Boolean>> addTaskToQueue = (t) -> futureMock;
+    public void shouldApproveCollection() throws IOException, ZebedeeException {
 
         ReflectionTestUtils.setField(collections, "contentReaderFactory", contentReaderFunction);
         ReflectionTestUtils.setField(collections, "addTaskToQueue", addTaskToQueue);
@@ -691,7 +687,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void shouldUnlockCollectionWithRedirects() throws IOException, ZebedeeException, ExecutionException, InterruptedException {
+    public void shouldUnlockCollectionWithRedirects() throws IOException, ZebedeeException {
         when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionDescriptionMock.getApprovalStatus())
@@ -776,7 +772,7 @@ public class CollectionsTest {
 
     @Test(expected = NotFoundException.class)
     public void shouldGetNotFoundIfAttemptingToListNonexistentDirectory() throws IOException, UnauthorizedException,
-            BadRequestException, ConflictException, NotFoundException {
+            BadRequestException, NotFoundException {
         String uri = "someURI";
         when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
@@ -793,7 +789,7 @@ public class CollectionsTest {
 
     @Test(expected = BadRequestException.class)
     public void shouldGetBadRequestIfAttemptingToListDirectoryOnAFile() throws IOException, UnauthorizedException,
-            BadRequestException, ConflictException, NotFoundException {
+            BadRequestException, NotFoundException {
         Path uri = rootDir.newFile("data.json").toPath();
         when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
@@ -809,8 +805,7 @@ public class CollectionsTest {
     }
 
     @Test
-    public void shouldListDirectory() throws IOException, UnauthorizedException, BadRequestException, ConflictException,
-            NotFoundException {
+    public void shouldListDirectory() throws IOException, UnauthorizedException, BadRequestException, NotFoundException {
         Path file1 = rootDir.newFile("data.json").toPath();
         Path file2 = rootDir.newFile("chart.png").toPath();
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.when;
 public class CollectionsTest {
     private static final String TEST_EMAIL = "TEST@ons.gov.uk";
     private static final String COLLECTION_ID = "123";
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     @Rule
     public TemporaryFolder rootDir = new TemporaryFolder();
@@ -174,6 +175,9 @@ public class CollectionsTest {
 
         when(collectionDescriptionMock.getId())
                 .thenReturn(COLLECTION_ID);
+
+        when(collectionDescriptionMock.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
 
         ReflectionTestUtils.setField(collections, "zebedeeSupplier", zebedeeSupplier);
         ReflectionTestUtils.setField(collections, "collectionReaderWriterFactory", collectionReaderWriterFactoryMock);
@@ -271,44 +275,53 @@ public class CollectionsTest {
     @Test(expected = BadRequestException.class)
     public void shouldThrowBadRequestForBlankUriOnMoveContent() throws IOException, ZebedeeException {
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         try {
             collections.moveContent(sessionMock, collectionMock, "", "toURI");
         } catch (BadRequestException e) {
             verify(permissionsServiceMock, times(1))
-                    .canEdit(sessionMock);
-            verifyNoInteractions(collectionMock, publishedContentMock);
+                    .canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);
+            verifyNoInteractions(publishedContentMock);
             throw e;
         }
     }
 
     @Test(expected = BadRequestException.class)
     public void shouldThrowBadRequestForBlankToUriOnMoveContent() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         try {
             collections.moveContent(sessionMock, collectionMock, "fromURI", "");
         } catch (BadRequestException e) {
             verify(permissionsServiceMock, times(1))
-                    .canEdit(sessionMock);
-            verifyNoInteractions(collectionMock, publishedContentMock);
+                    .canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);
+            verifyNoInteractions(publishedContentMock);
             throw e;
         }
     }
 
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnApprove() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
         try {
             collections.approve(collectionMock, sessionMock, null);
         } catch (UnauthorizedException e) {
             verify(permissionsServiceMock, times(1))
-                    .canEdit(sessionMock);
-            verifyNoInteractions(publishedContentMock, zebedeeMock);
+                    .canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);
+            verifyNoInteractions(publishedContentMock);
             throw e;
         }
     }
@@ -317,14 +330,14 @@ public class CollectionsTest {
     public void shouldThrowUnauthorizedIfNotLoggedInOnListDirectory() throws IOException, UnauthorizedException,
             BadRequestException,
             ConflictException, NotFoundException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
         try {
             collections.listDirectory(collectionMock, "someURI", sessionMock);
         } catch (UnauthorizedException e) {
             verify(permissionsServiceMock, times(1))
-                    .canView(sessionMock, COLLECTION_ID);
+                    .canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1))
                     .getDescription();
             verify(collectionMock, never())
@@ -335,27 +348,31 @@ public class CollectionsTest {
 
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnComplete() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
         try {
             collections.complete(collectionMock, "someURI", sessionMock, false);
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verifyNoInteractions(collectionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);         
             throw e;
         }
     }
 
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnDelete() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
         try {
             collections.delete(collectionMock, sessionMock);
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verifyNoInteractions(collectionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);    
             throw e;
         }
     }
@@ -379,25 +396,30 @@ public class CollectionsTest {
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnDeleteContent() throws IOException, ZebedeeException {
         try {
-            when(permissionsServiceMock.canEdit(sessionMock))
+            when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                     .thenReturn(false);
             collections.deleteContent(collectionMock, "someURI", sessionMock);
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verifyNoInteractions(collectionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);    
             throw e;
         }
     }
 
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnMoveContent() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
         try {
             collections.moveContent(sessionMock, collectionMock, "from", "to");
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verifyNoInteractions(collectionMock, publishedContentMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1))
+                    .getDescription();
+            verifyNoMoreInteractions(collectionMock);   
+            verifyNoInteractions(publishedContentMock);
             throw e;
         }
     }
@@ -430,13 +452,16 @@ public class CollectionsTest {
 
     @Test(expected = BadRequestException.class)
     public void shouldThrowBadRequestIfNoUriOnDeleteContent() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         try {
             collections.deleteContent(collectionMock, null, sessionMock);
         } catch (BadRequestException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verifyNoInteractions(collectionMock, collectionDescriptionMock, zebedeeMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1)).getDescription();
+            verify(collectionDescriptionMock, times(1)).getType();
+            verifyNoMoreInteractions(collectionMock, collectionDescriptionMock);
+            verifyNoInteractions(zebedeeMock);
             throw e;
         }
     }
@@ -445,14 +470,15 @@ public class CollectionsTest {
     public void shouldThrowNotFoundIfUriNotInProgressOnComplete() throws IOException, ZebedeeException {
         Content inProg = mock(Content.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.getInProgress())
                 .thenReturn(inProg);
         try {
             collections.complete(collectionMock, "someURI", sessionMock, false);
         } catch (NotFoundException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1)).getDescription();
             verify(collectionMock, times(1)).getInProgress();
             verify(inProg, times(1)).get(anyString());
             verify(collectionMock, never()).complete(any(Session.class), anyString(), anyBoolean());
@@ -467,7 +493,7 @@ public class CollectionsTest {
         Path p = rootDir.newFolder("test").toPath();
         Content inProg = mock(Content.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.getInProgress())
                 .thenReturn(inProg);
@@ -477,7 +503,8 @@ public class CollectionsTest {
         try {
             collections.complete(collectionMock, uri, sessionMock, false);
         } catch (NotFoundException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1)).getDescription();
             verify(collectionMock, times(1)).getInProgress();
             verify(inProg, times(1)).get(uri);
             verify(collectionMock, never()).complete(any(Session.class), anyString(), anyBoolean());
@@ -491,7 +518,7 @@ public class CollectionsTest {
         Path p = rootDir.newFile("data.json").toPath();
         Content inProg = mock(Content.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.getInProgress())
                 .thenReturn(inProg);
@@ -507,7 +534,7 @@ public class CollectionsTest {
 
         collections.complete(collectionMock, p.toString(), sessionMock, false);
 
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).getInProgress();
         verify(inProg, times(1)).get(p.toString());
         verify(collectionMock, times(1)).complete(sessionMock, p.toString(), false);
@@ -519,7 +546,7 @@ public class CollectionsTest {
         Path p = rootDir.newFile("data.json").toPath();
         Content inProg = mock(Content.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.getInProgress())
                 .thenReturn(inProg);
@@ -535,7 +562,7 @@ public class CollectionsTest {
         try {
             collections.complete(collectionMock, p.toString(), sessionMock, false);
         } catch (BadRequestException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).getInProgress();
             verify(inProg, times(1)).get(p.toString());
             verify(collectionMock, times(1)).complete(sessionMock, p.toString(), false);
@@ -552,7 +579,7 @@ public class CollectionsTest {
         CollectionDescription description = mock(CollectionDescription.class);
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.inProgressUris())
                 .thenReturn(inProgressURIS);
@@ -560,13 +587,14 @@ public class CollectionsTest {
                 .thenReturn(new ArrayList<String>());
         when(collectionMock.getDescription())
                 .thenReturn(description);
+        when(description.getType()).thenReturn(TEST_COLLECTION_TYPE);
 
         doNothing().when(description).addEvent(eventCaptor.capture());
 
         try {
             collections.approve(collectionMock, sessionMock, null);
         } catch (ConflictException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).inProgressUris();
             assertThat(eventCaptor.getValue().type, equalTo(EventType.APPROVE_SUBMITTED));
             verify(collectionReaderWriterFactoryMock, never()).getReader(any(), any(), any());
@@ -583,7 +611,7 @@ public class CollectionsTest {
         CollectionDescription description = mock(CollectionDescription.class);
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.isAllContentReviewed(false))
                 .thenReturn(false);
@@ -593,13 +621,13 @@ public class CollectionsTest {
                 .thenReturn(completeURIS);
         when(collectionMock.getDescription())
                 .thenReturn(description);
-
+        when(description.getType()).thenReturn(TEST_COLLECTION_TYPE);
         doNothing().when(description).addEvent(eventCaptor.capture());
 
         try {
             collections.approve(collectionMock, sessionMock, null);
         } catch (ConflictException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).inProgressUris();
             verify(collectionMock, times(1)).completeUris();
             assertThat(eventCaptor.getValue().type, equalTo(EventType.APPROVE_SUBMITTED));
@@ -619,7 +647,7 @@ public class CollectionsTest {
         ReflectionTestUtils.setField(collections, "addTaskToQueue", addTaskToQueue);
         ReflectionTestUtils.setField(collections, "addTaskToQueue", addTaskToQueue);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.isAllContentReviewed(anyBoolean()))
                 .thenReturn(true);
@@ -632,26 +660,28 @@ public class CollectionsTest {
 
         assertThat(futureMock, equalTo(collections.approve(collectionMock, sessionMock, null)));
 
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).isAllContentReviewed(anyBoolean());
         verify(collectionReaderWriterFactoryMock, times(1)).getReader(zebedeeMock, collectionMock, sessionMock);
         verify(collectionReaderWriterFactoryMock, times(1)).getWriter(zebedeeMock, collectionMock, sessionMock);
     }
 
     @Test
-    public void shouldUnlockCollection() throws IOException, ZebedeeException, ExecutionException, InterruptedException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+    public void shouldUnlockCollection() throws IOException, ZebedeeException {
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionDescriptionMock.getApprovalStatus())
                 .thenReturn(ApprovalStatus.COMPLETE);
+        when(collectionDescriptionMock.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
         when(collectionMock.save())
                 .thenReturn(true);
         
         boolean result = collections.unlock(collectionMock, sessionMock);
 
         assertThat(result, is(true));
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-        verify(collectionMock, times(3)).getDescription();
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+        verify(collectionMock, times(1)).getDescription();
         verify(collectionDescriptionMock, times(1)).getApprovalStatus();
         verify(collectionDescriptionMock, times(1)).setApprovalStatus(ApprovalStatus.NOT_STARTED);
         verify(collectionDescriptionMock, times(1)).addEvent(any(Event.class));
@@ -662,10 +692,12 @@ public class CollectionsTest {
 
     @Test
     public void shouldUnlockCollectionWithRedirects() throws IOException, ZebedeeException, ExecutionException, InterruptedException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionDescriptionMock.getApprovalStatus())
                 .thenReturn(ApprovalStatus.COMPLETE);
+        when(collectionDescriptionMock.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
         when(collectionMock.save())
                 .thenReturn(true);
         System.setProperty(CMSFeatureFlags.ENABLE_REDIRECT_API, "true");
@@ -674,8 +706,8 @@ public class CollectionsTest {
         boolean result = collections.unlock(collectionMock, sessionMock);
 
         assertThat(result, is(true));
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-        verify(collectionMock, times(4)).getDescription();
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+        verify(collectionMock, times(1)).getDescription();
         verify(collectionDescriptionMock, times(1)).getApprovalStatus();
         verify(collectionDescriptionMock, times(1)).setApprovalStatus(ApprovalStatus.NOT_STARTED);
         verify(collectionDescriptionMock, times(1)).addEvent(any(Event.class));
@@ -689,7 +721,7 @@ public class CollectionsTest {
 
     @Test
     public void shouldUnlockWithoutAddingEventIfAlreadyUnlocked() throws Exception {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionDescriptionMock.getApprovalStatus())
                 .thenReturn(ApprovalStatus.IN_PROGRESS);
@@ -699,7 +731,7 @@ public class CollectionsTest {
         boolean result = collections.unlock(collectionMock, sessionMock);
 
         assertThat(result, is(true));
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).getDescription();
         verify(collectionDescriptionMock, times(1)).getApprovalStatus();
         verify(collectionDescriptionMock, never()).setApprovalStatus(any(ApprovalStatus.class));
@@ -710,13 +742,13 @@ public class CollectionsTest {
 
     @Test(expected = UnauthorizedException.class)
     public void shouldThrowUnauthorizedIfNotLoggedInOnUnlock() throws Exception {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
         try {
             collections.unlock(collectionMock, sessionMock);
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
-            verify(collectionMock, never()).getDescription();
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
+            verify(collectionMock, times(1)).getDescription();
             verify(collectionDescriptionMock, never()).getApprovalStatus();
             verify(collectionDescriptionMock, never()).setApprovalStatus(any(ApprovalStatus.class));
             verify(collectionDescriptionMock, never()).addEvent(any(Event.class));
@@ -731,7 +763,7 @@ public class CollectionsTest {
         try {
             collections.unlock(null, sessionMock);
         } catch (UnauthorizedException e) {
-            verify(permissionsServiceMock, never()).canEdit(sessionMock);
+            verify(permissionsServiceMock, never()).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, never()).getDescription();
             verify(collectionDescriptionMock, never()).getApprovalStatus();
             verify(collectionDescriptionMock, never()).setApprovalStatus(any(ApprovalStatus.class));
@@ -746,14 +778,14 @@ public class CollectionsTest {
     public void shouldGetNotFoundIfAttemptingToListNonexistentDirectory() throws IOException, UnauthorizedException,
             BadRequestException, ConflictException, NotFoundException {
         String uri = "someURI";
-        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID))
+        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.find(uri))
                 .thenReturn(null);
         try {
             collections.listDirectory(collectionMock, uri, sessionMock);
         } catch (NotFoundException e) {
-            verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID);
+            verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).find(uri);
             throw e;
         }
@@ -763,14 +795,14 @@ public class CollectionsTest {
     public void shouldGetBadRequestIfAttemptingToListDirectoryOnAFile() throws IOException, UnauthorizedException,
             BadRequestException, ConflictException, NotFoundException {
         Path uri = rootDir.newFile("data.json").toPath();
-        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID))
+        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.find(uri.toString()))
                 .thenReturn(uri);
         try {
             collections.listDirectory(collectionMock, uri.toString(), sessionMock);
         } catch (BadRequestException e) {
-            verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID);
+            verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).find(uri.toString());
             throw e;
         }
@@ -787,7 +819,7 @@ public class CollectionsTest {
         expected.getFiles().put(file2.getFileName().toString(), file2.toString());
         expected.getFolders().put(collectionsPath.getFileName().toString(), collectionsPath.toString());
 
-        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID))
+        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.find(rootDir.getRoot().toString()))
                 .thenReturn(rootDir.getRoot().toPath());
@@ -795,7 +827,7 @@ public class CollectionsTest {
         DirectoryListing result = collections.listDirectory(collectionMock, rootDir.getRoot().toString(), sessionMock);
 
         assertThat(result, equalTo(expected));
-        verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID);
+        verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).find(rootDir.getRoot().toString());
     }
 
@@ -813,7 +845,7 @@ public class CollectionsTest {
         expected.getFiles().put(f1.getName(), f1.toPath().toString());
         expected.getFiles().put(f2.getName(), f2.toPath().toString());
 
-        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID))
+        when(permissionsServiceMock.canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.find(uri.toString()))
                 .thenReturn(uri);
@@ -823,20 +855,20 @@ public class CollectionsTest {
         DirectoryListing result = collections.listDirectoryOverlayed(collectionMock, uri.toString(), sessionMock);
 
         assertThat(result, equalTo(expected));
-        verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID);
+        verify(permissionsServiceMock, times(1)).canView(sessionMock, COLLECTION_ID, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).find(uri.toString());
     }
 
     @Test(expected = BadRequestException.class)
     public void shouldNotDeleteCollectionIfNotEmpty() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.isEmpty())
                 .thenReturn(false);
         try {
             collections.delete(collectionMock, sessionMock);
         } catch (BadRequestException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).isEmpty();
             verify(collectionMock, never()).delete();
             throw e;
@@ -845,14 +877,14 @@ public class CollectionsTest {
 
     @Test
     public void shouldDeleteCollection() throws IOException, ZebedeeException {
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         when(collectionMock.isEmpty())
                 .thenReturn(true);
 
         collections.delete(collectionMock, sessionMock);
 
-        verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+        verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
         verify(collectionMock, times(1)).isEmpty();
         verify(collectionMock, times(1)).delete();
     }
@@ -983,15 +1015,15 @@ public class CollectionsTest {
     @Test(expected = NotFoundException.class)
     public void shouldThrowNotFoundForDeletingNonexistentFile() throws IOException, ZebedeeException {
         String uri = "someURI";
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         try {
             collections.deleteContent(collectionMock, uri, sessionMock);
         } catch (NotFoundException e) {
-            verify(permissionsServiceMock, times(1)).canEdit(sessionMock);
+            verify(permissionsServiceMock, times(1)).canEdit(sessionMock, TEST_COLLECTION_TYPE);
             verify(collectionMock, times(1)).find(uri);
             verify(collectionMock, never()).isInCollection(anyString());
-            verify(collectionMock, never()).getDescription();
+            verify(collectionMock, times(1)).getDescription();
             verify(collectionMock, never()).deleteDataVisContent(any(), any());
             verify(collectionMock, never()).deleteContentDirectory(anyString(), anyString());
             verify(collectionMock, never()).deleteFile(anyString());
@@ -1082,7 +1114,7 @@ public class CollectionsTest {
 
         assertTrue(Files.exists(filePath));
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionMock.find(filePath.toString()))
@@ -1110,7 +1142,7 @@ public class CollectionsTest {
         Path inprogress = collectionsPath.resolve(uri);
         assertTrue(inprogress.toFile().mkdirs());
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionMock.find(uri))
@@ -1138,7 +1170,7 @@ public class CollectionsTest {
 
         Path uri = inprogress.resolve("nondatajson");
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionMock.find(uri.toString()))
@@ -1167,7 +1199,7 @@ public class CollectionsTest {
         Path uri = inprogress.resolve("data.json");
         assertTrue(uri.toFile().createNewFile());
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionMock.find(uri.toString()))
@@ -1192,7 +1224,7 @@ public class CollectionsTest {
         String uri = "/";
         Path path = Paths.get(uri);
 
-        when(permissionsServiceMock.canEdit(sessionMock))
+        when(permissionsServiceMock.canEdit(sessionMock, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionMock.find(uri.toString()))

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -638,6 +638,8 @@ public class CollectionsTest {
 
     @Test
     public void shouldApproveCollection() throws IOException, ZebedeeException {
+        Function<Path, ContentReader> contentReaderFunction = p -> contentReaderMock;
+        Function<ApproveTask, Future<Boolean>> addTaskToQueue = t -> futureMock;
 
         ReflectionTestUtils.setField(collections, "contentReaderFactory", contentReaderFunction);
         ReflectionTestUtils.setField(collections, "addTaskToQueue", addTaskToQueue);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
@@ -205,14 +205,14 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void testNew_zebedeeNull_shouldThrowException() throws Exception {
+    public void testNew_zebedeeNull_shouldThrowException() {
         IOException ex = assertThrows(IOException.class, () -> newReader(null, null, null));
 
         assertThat(ex.getMessage(), equalTo(ZEBEDEE_NULL_ERR));
     }
 
     @Test
-    public void testNew_permissionsServiceNull_shouldThrowException() throws Exception {
+    public void testNew_permissionsServiceNull_shouldThrowException() {
         when(zebedeeMock.getPermissionsService())
                 .thenReturn(null);
 
@@ -223,7 +223,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void testNew_keyringNull_shouldThrowException() throws Exception {
+    public void testNew_keyringNull_shouldThrowException() {
         when(zebedeeMock.getCollectionKeyring())
                 .thenReturn(null);
 
@@ -236,7 +236,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
 
 
     @Test
-    public void testNew_usersServiceNull_shouldThrowException() throws Exception {
+    public void testNew_usersServiceNull_shouldThrowException() {
         when(zebedeeMock.getUsersService())
                 .thenReturn(null);
 
@@ -250,7 +250,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
 
 
     @Test
-    public void testNew_collectionNull_shouldThrowException() throws Exception {
+    public void testNew_collectionNull_shouldThrowException() {
         NotFoundException ex = assertThrows(NotFoundException.class, () -> newReader(zebedeeMock, null, null));
 
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
@@ -259,7 +259,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
-    public void testNew_sessionNull_shouldThrowException() throws Exception {
+    public void testNew_sessionNull_shouldThrowException() {
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
                 () -> newReader(zebedeeMock, mockCollection, null));
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
@@ -8,6 +8,7 @@ import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -26,7 +27,6 @@ import java.io.IOException;
 
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.COLLECTION_KEY_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.GET_USER_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.KEYRING_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.PERMISSIONS_CHECK_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionReader.PERMISSIONS_SERVICE_NULL_ERR;
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,6 +49,7 @@ import static org.mockito.Mockito.when;
 public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
 
     static final String COLLECTION_ID = "1234";
+    static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -64,7 +64,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     private CollectionKeyring keyring;
 
     @Mock
-    private Collection collection;
+    private Collection mockCollection;
 
     @Mock
     private CollectionDescription description;
@@ -86,19 +86,22 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
         when(zebedeeMock.getUsersService())
                 .thenReturn(usersService);
 
-        when(collection.getDescription())
+        when(mockCollection.getDescription())
                 .thenReturn(description);
 
         when(description.getId())
                 .thenReturn(COLLECTION_ID);
 
-        when(permissionsService.canView(userSession, COLLECTION_ID))
+        when(description.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
+
+        when(permissionsService.canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
-        when(keyring.get(userSession, collection))
+        when(keyring.get(userSession, mockCollection))
                 .thenReturn(key);
 
-        when(collection.getPath())
+        when(mockCollection.getPath())
                 .thenReturn(temporaryFolder.getRoot().toPath());
 
         when(userSession.getEmail())
@@ -106,6 +109,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
 
         Session session = zebedee.openSession(builder.publisher1Credentials);
         Collection collection = new Collection(builder.collections.get(0), zebedee);
+        collection.getDescription().setType(TEST_COLLECTION_TYPE);
 
         setUpPermissionsServiceMockForLegacyTests(zebedee, session);
 
@@ -158,7 +162,9 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
         // A uri that defines a directory
         String uri = "/this/is/a/directory/";
         Collection collection = new Collection(builder.collections.get(0), zebedee);
-        when(permissionsService.canEdit(userSession))
+        collection.getDescription().setType(TEST_COLLECTION_TYPE);
+
+        when(permissionsService.canEdit(userSession, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
         ReflectionTestUtils.setField(zebedee, "permissionsService", permissionsService);
 
@@ -176,7 +182,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     public void shouldReadFile()
             throws IOException, ZebedeeException {
 
-        when(permissionsService.canEdit(userSession))
+        when(permissionsService.canEdit(userSession, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         ReflectionTestUtils.setField(zebedee, "permissionsService", permissionsService);
@@ -185,6 +191,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
         // A nonexistent file
         String uri = "/file.json";
         Collection collection = new Collection(builder.collections.get(0), zebedee);
+        collection.getDescription().setType(TEST_COLLECTION_TYPE);
         assertTrue(collection.create(userSession, uri));
 
         // When
@@ -254,7 +261,7 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
     @Test
     public void testNew_sessionNull_shouldThrowException() throws Exception {
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
-                () -> newReader(zebedeeMock, collection, null));
+                () -> newReader(zebedeeMock, mockCollection, null));
 
         assertThat(ex.getMessage(), equalTo(SESSION_NULL_ERR));
         verify(zebedeeMock, times(1)).getPermissionsService();
@@ -263,59 +270,59 @@ public class ZebedeeCollectionReaderTest extends ZebedeeTestBaseFixture {
 
     @Test
     public void testNew_checkUserAuthError_shouldThrowException() throws Exception {
-        when(permissionsService.canView(userSession, COLLECTION_ID))
+        when(permissionsService.canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenThrow(IOException.class);
 
         IOException ex = assertThrows(IOException.class,
-                () -> newReader(zebedeeMock, collection, userSession));
+                () -> newReader(zebedeeMock, mockCollection, userSession));
 
         assertThat(ex.getMessage(), equalTo(PERMISSIONS_CHECK_ERR));
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
     }
 
     @Test
     public void testNew_userAuthDenied_shouldThrowException() throws Exception {
-        when(permissionsService.canView(userSession, COLLECTION_ID))
+        when(permissionsService.canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
-                () -> newReader(zebedeeMock, collection, userSession));
+                () -> newReader(zebedeeMock, mockCollection, userSession));
 
         assertThat(ex.getMessage(), equalTo(PERMISSION_DENIED_ERR));
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
+        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
     }
 
     @Test
     public void testNew_getKeyError_shouldThrowException() throws Exception {
-        when(keyring.get(userSession, collection))
+        when(keyring.get(userSession, mockCollection))
                 .thenThrow(KeyringException.class);
 
-        assertThrows(KeyringException.class, () -> newReader(zebedeeMock, collection, userSession));
+        assertThrows(KeyringException.class, () -> newReader(zebedeeMock, mockCollection, userSession));
 
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
-        verify(keyring, times(1)).get(userSession, collection);
+        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
+        verify(keyring, times(1)).get(userSession, mockCollection);
     }
 
     @Test
     public void testNew_getKeyReturnsNull_shouldThrowException() throws Exception {
-        when(keyring.get(userSession, collection))
+        when(keyring.get(userSession, mockCollection))
                 .thenReturn(null);
 
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
-                () -> newReader(zebedeeMock, collection, userSession));
+                () -> newReader(zebedeeMock, mockCollection, userSession));
 
         assertThat(ex.getMessage(), equalTo(COLLECTION_KEY_NULL_ERR));
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
-        verify(keyring, times(1)).get(userSession, collection);
+        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
+        verify(keyring, times(1)).get(userSession, mockCollection);
     }
 
     @Test
     public void testNew_success_shouldCreateNewReader() throws Exception {
-        CollectionReader reader = newReader(zebedeeMock, collection, userSession);
+        CollectionReader reader = newReader(zebedeeMock, mockCollection, userSession);
 
         assertThat(reader, is(notNullValue()));
-        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID);
-        verify(keyring, times(1)).get(userSession, collection);
+        verify(permissionsService, times(1)).canView(userSession, COLLECTION_ID, TEST_COLLECTION_TYPE);
+        verify(keyring, times(1)).get(userSession, mockCollection);
     }
 
     private CollectionReader newReader(Zebedee z, Collection c, Session s) throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionReaderTest.java
@@ -15,7 +15,6 @@ import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
 import com.github.onsdigital.zebedee.reader.CollectionReader;
 import com.github.onsdigital.zebedee.reader.Resource;
 import com.github.onsdigital.zebedee.session.model.Session;
-import com.github.onsdigital.zebedee.user.model.User;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
@@ -21,14 +21,12 @@ import java.io.IOException;
 
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.COLLECTION_KEY_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.COLLECTION_NULL_ERR;
-import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.GET_USER_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.KEYRING_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.PERMISSIONS_CHECK_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.PERMISSIONS_SERVICE_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.PERMISSION_DENIED_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.SESSION_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.USERS_SERVICE_NULL_ERR;
-import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.USER_NULL_ERR;
 import static com.github.onsdigital.zebedee.model.ZebedeeCollectionWriter.ZEBEDEE_NULL_ERR;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
@@ -4,6 +4,7 @@ import com.github.onsdigital.zebedee.Zebedee;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.keyring.CollectionKeyring;
 import com.github.onsdigital.zebedee.keyring.KeyringException;
 import com.github.onsdigital.zebedee.permissions.service.PermissionsService;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.when;
 public class ZebedeeCollectionWriterTest {
 
     static final String EMAIL = "ellen.ripley@weyland-yutanicopr.com";
+    static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     @Mock
     private Zebedee zebedee;
@@ -87,7 +89,10 @@ public class ZebedeeCollectionWriterTest {
         when(collection.getDescription())
                 .thenReturn(description);
 
-        when(permissionsService.canEdit(session))
+        when(description.getType())
+                .thenReturn(TEST_COLLECTION_TYPE);
+
+        when(permissionsService.canEdit(session, TEST_COLLECTION_TYPE))
                 .thenReturn(true);
 
         when(collectionKeyring.get(session, collection))
@@ -154,26 +159,26 @@ public class ZebedeeCollectionWriterTest {
 
     @Test
     public void testNew_permissionDenied_shouldThrowException() throws Exception {
-        when(permissionsService.canEdit(session))
+        when(permissionsService.canEdit(session, TEST_COLLECTION_TYPE))
                 .thenReturn(false);
 
         UnauthorizedException ex = assertThrows(UnauthorizedException.class,
                 () -> newCollectionWriter(zebedee, collection, session));
 
         assertThat(ex.getMessage(), equalTo(PERMISSION_DENIED_ERR));
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, TEST_COLLECTION_TYPE);
     }
 
     @Test
     public void testNew_canEditReturnsError_shouldThrowException() throws Exception {
-        when(permissionsService.canEdit(session))
+        when(permissionsService.canEdit(session, TEST_COLLECTION_TYPE))
                 .thenThrow(IOException.class);
 
         IOException ex = assertThrows(IOException.class,
                 () -> newCollectionWriter(zebedee, collection, session));
 
         assertThat(ex.getMessage(), equalTo(PERMISSIONS_CHECK_ERR));
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, TEST_COLLECTION_TYPE);
     }
 
     @Test
@@ -181,10 +186,10 @@ public class ZebedeeCollectionWriterTest {
         when(collectionKeyring.get(session, collection))
                 .thenThrow(KeyringException.class);
 
-        IOException ex = assertThrows(IOException.class,
+        assertThrows(IOException.class,
                 () -> newCollectionWriter(zebedee, collection, session));
 
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, TEST_COLLECTION_TYPE);
         verify(collectionKeyring, times(1)).get(session, collection);
     }
 
@@ -197,7 +202,7 @@ public class ZebedeeCollectionWriterTest {
                 () -> newCollectionWriter(zebedee, collection, session));
 
         assertThat(ex.getMessage(), equalTo(COLLECTION_KEY_NULL_ERR));
-        verify(permissionsService, times(1)).canEdit(session);
+        verify(permissionsService, times(1)).canEdit(session, TEST_COLLECTION_TYPE);
         verify(collectionKeyring, times(1)).get(session, collection);
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/ZebedeeCollectionWriterTest.java
@@ -107,14 +107,14 @@ public class ZebedeeCollectionWriterTest {
     }
 
     @Test
-    public void testNew_ZebedeeNull_shouldThrowException() throws Exception {
+    public void testNew_ZebedeeNull_shouldThrowException() {
         IOException ex = assertThrows(IOException.class, () -> newCollectionWriter(null, null, null));
 
         assertThat(ex.getMessage(), equalTo(ZEBEDEE_NULL_ERR));
     }
 
     @Test
-    public void testNew_permissionsServiceNull_shouldThrowException() throws Exception {
+    public void testNew_permissionsServiceNull_shouldThrowException() {
         when(zebedee.getPermissionsService())
                 .thenReturn(null);
 
@@ -124,7 +124,7 @@ public class ZebedeeCollectionWriterTest {
     }
 
     @Test
-    public void testNew_usersServiceNull_shouldThrowException() throws Exception {
+    public void testNew_usersServiceNull_shouldThrowException() {
         when(zebedee.getUsersService())
                 .thenReturn(null);
 
@@ -134,7 +134,7 @@ public class ZebedeeCollectionWriterTest {
     }
 
     @Test
-    public void testNew_keyringNull_shouldThrowException() throws Exception {
+    public void testNew_keyringNull_shouldThrowException() {
         when(zebedee.getCollectionKeyring())
                 .thenReturn(null);
 
@@ -144,14 +144,14 @@ public class ZebedeeCollectionWriterTest {
     }
 
     @Test
-    public void testNew_collectionNull_shouldThrowException() throws Exception {
+    public void testNew_collectionNull_shouldThrowException() {
         NotFoundException ex = assertThrows(NotFoundException.class, () -> newCollectionWriter(zebedee, null, null));
 
         assertThat(ex.getMessage(), equalTo(COLLECTION_NULL_ERR));
     }
 
     @Test
-    public void testNew_sessionNull_shouldThrowException() throws Exception {
+    public void testNew_sessionNull_shouldThrowException() {
         UnauthorizedException ex = assertThrows(UnauthorizedException.class, () -> newCollectionWriter(zebedee, collection, null));
 
         assertThat(ex.getMessage(), equalTo(SESSION_NULL_ERR));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
@@ -64,7 +64,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isPublisher_Session_Publisher_ShouldReturnTrue() throws Exception {
+    public void isPublisher_Session_Publisher_ShouldReturnTrue() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(PUBLISHER);
 
@@ -73,7 +73,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isPublisher_Session_Admin_ShouldReturnFalse() throws Exception {
+    public void isPublisher_Session_Admin_ShouldReturnFalse() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(ADMIN);
 
@@ -82,28 +82,28 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isPublisher_SessionNull_ShouldReturnFalse() throws Exception {
+    public void isPublisher_SessionNull_ShouldReturnFalse() {
         Session session = null;
         assertFalse(jwtPermissionsService.isPublisher(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void isPublisher_Session_NotPublisher_ShouldReturnFalse() throws Exception {
+    public void isPublisher_Session_NotPublisher_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, new ArrayList<>());
         assertFalse(jwtPermissionsService.isPublisher(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void isPublisher_Session_NullGroup_ShouldReturnFalse() throws Exception {
+    public void isPublisher_Session_NullGroup_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, null);
         assertFalse(jwtPermissionsService.isPublisher(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void isAdministrator_Session_Admin_ShouldReturnTrue() throws Exception {
+    public void isAdministrator_Session_Admin_ShouldReturnTrue() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(ADMIN);
 
@@ -112,7 +112,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isAdministrator_Session_Publisher_ShouldReturnFalse() throws Exception {
+    public void isAdministrator_Session_Publisher_ShouldReturnFalse() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(PUBLISHER);
 
@@ -121,14 +121,14 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isAdministrator_SessionNull_ShouldReturnFalse() throws Exception {
+    public void isAdministrator_SessionNull_ShouldReturnFalse() {
         Session session = null;
         assertFalse(jwtPermissionsService.isAdministrator(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void isAdministrator_Session_EmailNull_ShouldReturnFalse() throws Exception {
+    public void isAdministrator_Session_EmailNull_ShouldReturnFalse() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(PUBLISHER);
 
@@ -138,28 +138,28 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void isAdministrator_Session_NotAdmin_ShouldReturnFalse() throws Exception {
+    public void isAdministrator_Session_NotAdmin_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, new ArrayList<>());
         assertFalse(jwtPermissionsService.isAdministrator(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void isAdministrator_Session_NullGroup_ShouldReturnFalse() throws Exception {
+    public void isAdministrator_Session_NullGroup_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, null);
         assertFalse(jwtPermissionsService.isAdministrator(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void hasAdministrator_ShouldError() throws Exception {
+    public void hasAdministrator_ShouldError() {
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.hasAdministrator());
         assertEquals("JWT sessions are enabled: hasAdministrator is no longer supported", exception.getMessage());
     }
 
     @Test
-    public void addAdministrator_Email_Sessions_ShouldError() throws Exception {
+    public void addAdministrator_Email_Sessions_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.addAdministrator(TEST_USER_EMAIL, session));
@@ -167,7 +167,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void removeAdministrator_Email_Sessions_ShouldError() throws Exception {
+    public void removeAdministrator_Email_Sessions_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.removeAdministrator(TEST_USER_EMAIL, session));
@@ -175,7 +175,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void canEdit_Session_Publisher_ShouldReturnTrue() throws Exception {
+    public void canEdit_Session_Publisher_ShouldReturnTrue() {
         List<String> sessionGroups = new ArrayList<>();
         sessionGroups.add(PUBLISHER);
 
@@ -184,14 +184,14 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void canEdit_SessionNull_ShouldReturnFalse() throws Exception {
+    public void canEdit_SessionNull_ShouldReturnFalse() {
         Session session = null;
         assertFalse(jwtPermissionsService.canEdit(session));
         verifyNoInteractions(jwtPermissionStore);
     }
 
     @Test
-    public void canEdit_Session_NotPublisher_ShouldReturnFalse() throws Exception {
+    public void canEdit_Session_NotPublisher_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, new ArrayList<>());
 
         assertFalse(jwtPermissionsService.canEdit(session));
@@ -199,7 +199,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void canEdit_Session_NullGroup_ShouldReturnFalse() throws Exception {
+    public void canEdit_Session_NullGroup_ShouldReturnFalse() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, null);
         assertFalse(jwtPermissionsService.canEdit(session));
         verifyNoInteractions(jwtPermissionStore);
@@ -223,7 +223,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void removeEditor_Email_Session_ShouldError() throws Exception {
+    public void removeEditor_Email_Session_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.removeEditor(TEST_USER_EMAIL, session));
@@ -335,7 +335,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void setViewerTeams_Session_Null_CollectionId_TeamIds() throws Exception {
+    public void setViewerTeams_Session_Null_CollectionId_TeamIds() {
         Session session = new Session(null, null, null);
 
         Exception exception = assertThrows(UnauthorizedException.class, () ->
@@ -391,7 +391,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void listViewerTeams_session_collectionId_noPermissions() throws Exception {
+    public void listViewerTeams_session_collectionId_noPermissions() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, new ArrayList<>());
 
         Map<String, Set<String>> collectionMapping = new HashMap<>();
@@ -405,7 +405,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void listViewerTeams_Session_Null_CollectionId() throws Exception {
+    public void listViewerTeams_Session_Null_CollectionId() {
         Exception exception = assertThrows(UnauthorizedException.class, () ->
                 jwtPermissionsService.listViewerTeams(null, COLLECTION_ID));
         assertEquals("Please log in", exception.getMessage());
@@ -476,7 +476,7 @@ public class JWTPermissionsServiceImplTest {
     }
     
     @Test
-    public void setViewerTeams_CollectionDescription_Team_Session_viewer_collectionTeam() throws Exception {
+    public void setViewerTeams_CollectionDescription_Team_Session_viewer_collectionTeam() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, new ArrayList<>());
 
         Exception exception = assertThrows(UnauthorizedException.class, () ->
@@ -484,7 +484,7 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void userPermissions_Email_Sessions_ShouldError() throws Exception {
+    public void userPermissions_Email_Sessions_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);
         Exception exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.userPermissions(TEST_USER_EMAIL, session));

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.HEAD;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.zebedee.permissions.service;
 
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
 import com.github.onsdigital.zebedee.json.CollectionDescription;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
 import com.github.onsdigital.zebedee.permissions.model.AccessMapping;
 import com.github.onsdigital.zebedee.permissions.store.PermissionsStore;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +42,7 @@ public class JWTPermissionsServiceImplTest {
     private static final String TEST_USER_EMAIL = "other123@ons.gov.uk";
     private static final String PUBLISHER = "role-publisher";
     private static final String ADMIN = "role-admin";
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     /**
      * Class under test
@@ -203,7 +206,16 @@ public class JWTPermissionsServiceImplTest {
     }
 
     @Test
-    public void addEditor_Email_Session_ShouldError() throws Exception {
+    public void canEdit_WithCollectionType_ShouldDelegateToSessionCheck() throws IOException {
+        List<String> sessionGroups = new ArrayList<>();
+        sessionGroups.add(PUBLISHER);
+
+        Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, sessionGroups);
+
+        assertTrue(jwtPermissionsService.canEdit(session, TEST_COLLECTION_TYPE));
+    }
+    @Test
+    public void addEditor_Email_Session_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 jwtPermissionsService.addEditor(TEST_USER_EMAIL, session));
@@ -225,6 +237,15 @@ public class JWTPermissionsServiceImplTest {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, sessionGroups);
 
         assertTrue(jwtPermissionsService.canView(session, COLLECTION_ID));
+    }
+
+    @Test
+    public void canView_WithCollectionType_ShouldDelegateToCollectionIdCheck() throws IOException {
+        List<String> sessionGroups = new ArrayList<>();
+        sessionGroups.add(PUBLISHER);
+        Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, sessionGroups);
+
+        assertTrue(jwtPermissionsService.canView(session, COLLECTION_ID, TEST_COLLECTION_TYPE));
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImplTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 public class JWTPermissionsServiceImplTest {
     
     private static final List<String> ADMIN_PUBLISHER_GROUPS = Arrays.asList("123456", "role-publisher", "role-admin", "789012345", "testgroup0");
-    private static final List<String> NON_ADMIN_PUBLISHER_GROUPS = Arrays.asList("123456", "789012345");
     private static final String COLLECTION_ID = "1234";
     private static final String TEST_SESSION_ID = "666";
     private static final String TEST_USER_EMAIL = "other123@ons.gov.uk";
@@ -213,6 +212,17 @@ public class JWTPermissionsServiceImplTest {
 
         assertTrue(jwtPermissionsService.canEdit(session, TEST_COLLECTION_TYPE));
     }
+
+    @Test
+    public void canSelfApprove_WithCollectionType_ShouldReturnFalse() throws IOException {
+        List<String> sessionGroups = new ArrayList<>();
+        sessionGroups.add(PUBLISHER);
+
+        Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL, sessionGroups);
+
+        assertFalse(jwtPermissionsService.canSelfApprove(session, TEST_COLLECTION_TYPE));
+    }
+
     @Test
     public void addEditor_Email_Session_ShouldError() {
         Session session = new Session(TEST_SESSION_ID, TEST_USER_EMAIL);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.permissions.service;
 import com.github.onsdigital.UserDataPayload;
 import com.github.onsdigital.dp.authorisation.permissions.PermissionChecker;
 import com.github.onsdigital.zebedee.permissions.model.Permissions;
+import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -30,6 +32,7 @@ public class PermissionsServiceImplementationTest {
     private static final String USER_ID = "user-id";
     private static final String USER_EMAIL = "user@ons.gov.uk";
     private static final String COLLECTION_ID = "collection-id";
+    private static final CollectionType TEST_COLLECTION_TYPE = CollectionType.manual;
 
     private PermissionsServiceImplementation permissionsService;
 
@@ -86,6 +89,22 @@ public class PermissionsServiceImplementationTest {
     }
 
     @Test
+    public void canEdit_WithCollectionType_ShouldIncludeCollectionTypeAttribute() throws Exception {
+        when(permissionChecker.hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_EDIT), anyMap()))
+                .thenReturn(true);
+
+        assertTrue(permissionsService.canEdit(session, TEST_COLLECTION_TYPE));
+
+        Map<String, String> expectedAttributes = new HashMap<>();
+        expectedAttributes.put("collection_type", TEST_COLLECTION_TYPE.name());
+        expectedAttributes.put("collection_id", "");
+
+        verify(permissionChecker, times(1))
+                .hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_EDIT), eq(expectedAttributes));
+    }
+
+
+    @Test
     public void canView_ShouldReturnTrueAndUseCollectionId() throws Exception {
         when(permissionChecker.hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_READ), anyMap()))
                 .thenReturn(true);
@@ -98,6 +117,20 @@ public class PermissionsServiceImplementationTest {
 
         Map<String, String> attributes = attributesCaptor.getValue();
         assertEquals(COLLECTION_ID, attributes.get("collection_id"));
+    }
+
+    @Test
+    public void canView_WithCollectionType_ShouldIncludeCollectionTypeAttribute() throws Exception {
+        when(permissionChecker.hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_READ), anyMap()))
+                .thenReturn(true);
+
+        assertTrue(permissionsService.canView(session, COLLECTION_ID, TEST_COLLECTION_TYPE));
+        Map<String, String> expectedAttributes = new HashMap<>();
+        expectedAttributes.put("collection_type", TEST_COLLECTION_TYPE.name());
+        expectedAttributes.put("collection_id", COLLECTION_ID);
+
+        verify(permissionChecker, times(1))
+                .hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_READ), eq(expectedAttributes));
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
@@ -103,6 +103,24 @@ public class PermissionsServiceImplementationTest {
                 .hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_EDIT), eq(expectedAttributes));
     }
 
+    @Test
+    public void canSelfApprove_WithCollectionType_ShouldReturnTrueWhenUserHasPermission() throws Exception {
+        when(permissionChecker.hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_SELF_APPROVE), anyMap()))
+                .thenReturn(true);
+
+        assertTrue(permissionsService.canSelfApprove(session, TEST_COLLECTION_TYPE));
+
+        verify(permissionChecker, times(1))
+                .hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_SELF_APPROVE), anyMap());
+    }
+
+    @Test
+    public void canSelfApprove_WithCollectionType_ShouldReturnFalseWhenPermissionCheckThrows() throws Exception {
+        when(permissionChecker.hasPermission(any(UserDataPayload.class), eq(Permissions.LEGACY_SELF_APPROVE), anyMap()))
+                .thenThrow(new Exception("boom"));
+
+        assertFalse(permissionsService.canSelfApprove(session, TEST_COLLECTION_TYPE));
+    }
 
     @Test
     public void canView_ShouldReturnTrueAndUseCollectionId() throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
@@ -54,7 +54,7 @@ public class PermissionsServiceImplementationTest {
     }
 
     @Test
-    public void isPublisher_ShouldThrowUnsupportedOperation() throws Exception {
+    public void isPublisher_ShouldThrowUnsupportedOperation() {
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 permissionsService.isPublisher(session));
 
@@ -62,7 +62,7 @@ public class PermissionsServiceImplementationTest {
     }
 
     @Test
-    public void addAdministrator_ShouldThrowUnsupportedOperation() throws Exception {
+    public void addAdministrator_ShouldThrowUnsupportedOperation() {
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, () ->
                 permissionsService.addAdministrator(USER_EMAIL, session));
 


### PR DESCRIPTION
### What

This PR makes several changes to the zebedee collections and permissions approaches. 

Functionality added:

- new collection type: "automated"
- adding checking for permission by collection type. This goes into every part of zebedee virtually.
- adding a new permission level of 'legacy:self-approve'
- allowing self approval if the collection is of type automated
- various linting / removal of old unused things

The intent of this is to make it possible for a user with the 'legacy:self-approve' permission able to approve collections with the type of 'automated'. It is also intended to be used to limit the scope of other 'legacy' permissions by collection type.

### How to review

The easiest way to test this is to run with the legacy-core-publishing stack in dp-compose. 

You will also need to be using: https://github.com/ONSdigital/dp-permissions-api/pull/174 for the population of the permissions api. 

When everything is running you can use the dis-migration-service service auth token to:

- create a collection (POST /collection) with type 'automated'
- add content to that collection (POST `/content/{collectionID}?uri={aValidURI}/data.json`)
- complete the content in that collection (POST `/complete/{collectionID}?uri={aValidURI}/data.json`)
- approve the content in that collection (POST `/review/{collectionID}?uri={aValidURI}/data.json`)
- approve the collection (POST `/approve/{collectionID}`)
- publish the collection (POST `/publish/{collectionID}`)

The above steps are intended to be done in sequence - out of sequence you can:
- unlock the collection (POST `/unlock/{collectionID}`) - this is only possible if the collection is in the queue (i.e. all content is approved and the collection is approved
- delete the collection (DELETE `/collection/{collectionID}`) - this is only possible if the collection is empty and not in the queue

For regression testing the same steps should be done with a user, including attempting to approve their own collection edits. 

N.B. without Florence changes, the automated collections will appear in the UI and be editable by users. 

### Who can review

Not me. 