### PR TITLE
Feature/pass file uris

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
@@ -1,6 +1,8 @@
 package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
 
 import com.github.onsdigital.zebedee.model.Collection;
+import com.github.onsdigital.zebedee.util.URIUtils;
+
 import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
@@ -22,11 +24,13 @@ public class LegacyCacheApiPayloadBuilder {
     public static class Builder {
         private Collection collection;
         private final Map<String, LegacyCacheApiPayload> payloadsByPath = new HashMap<>();
+
         private enum PayloadType {
             BULLETIN, ARTICLE, COMPENDIA, NONE
         }
 
-        public Builder() {}
+        public Builder() {
+        }
 
         public LegacyCacheApiPayloadBuilder.Builder collection(Collection collection) {
             this.collection = collection;
@@ -40,26 +44,30 @@ public class LegacyCacheApiPayloadBuilder {
             try {
                 collection.reviewedUris()
                         .forEach(uri -> {
-                                    String pagePath = PayloadPathUpdater.getCanonicalPagePath(uri, collectionId);
-                                    LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, pagePath, publishDate);
-                                    if (isValid(legacyCacheApiPayload)) {
-                                        payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
-                                        addPayloadForLatest(legacyCacheApiPayload.uriToUpdate, collectionId, publishDate);
-                                    }
-                                }
-                        );
+                            String pagePath = PayloadPathUpdater.getCanonicalPagePath(uri, collectionId);
+                            LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId,
+                                    pagePath, publishDate);
+                            if (isValid(legacyCacheApiPayload)) {
+                                payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
+                                addPayloadForFile(uri, collectionId, publishDate);
+                                addPayloadForLatest(legacyCacheApiPayload.uriToUpdate, collectionId, publishDate);
+
+                            }
+                        });
                 collection.getDescription().getPendingDeletes()
                         .forEach(pendingDelete -> {
                             String uriToDelete = pendingDelete.getRoot().getUri();
                             uriToDelete = PayloadPathUpdater.getCanonicalPagePath(uriToDelete, collectionId);
-                            LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId, uriToDelete);
+                            LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId,
+                                    uriToDelete);
                             if (isValid(legacyCacheApiPayload)) {
                                 payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
                             }
                         });
             } catch (IOException e) {
                 error().data("collectionId", collectionId)
-                        .logException(e, "failed initialising PublishNotification when reading collection reviewedUris");
+                        .logException(e,
+                                "failed initialising PublishNotification when reading collection reviewedUris");
             }
 
             return new LegacyCacheApiPayloadBuilder(this.payloadsByPath.values());
@@ -76,7 +84,34 @@ public class LegacyCacheApiPayloadBuilder {
         }
 
         /**
+         * Adds a payload for a specific file if the URI matches a file type.
+         * @param uriToUpdate the URI of the file to update
+         * @param collectionId the ID of the collection
+         * @param clearCacheDate the date to clear the cache
+         */
+        private void addPayloadForFile(String uriToUpdate, String collectionId, Date clearCacheDate) {
+            if (URIUtils.isLastSegmentFileExtension(uriToUpdate)) {
+                addFilePayload(uriToUpdate, collectionId, clearCacheDate);
+            }
+        }
+
+        /**
+         * Adds a payload for a specific file.
+         * @param uriToUpdate the URI of the file to update
+         * @param collectionId the ID of the collection
+         * @param clearCacheDate the date to clear the cache
+         */
+        private void addFilePayload(String uriToUpdate, String collectionId, Date clearCacheDate) {
+            String payloadPath = PayloadPathUpdater.getPathForFile(uriToUpdate);
+            LegacyCacheApiPayload payloadFile = new LegacyCacheApiPayload(collectionId, payloadPath, clearCacheDate);
+            payloadsByPath.put(payloadFile.uriToUpdate, payloadFile);
+        }
+
+        /**
          * Adds a payload for the 'latest' version if the URI matches a known type.
+         * @param uriToUpdate the URI of the resource to update
+         * @param collectionId the ID of the collection
+         * @param clearCacheDate the date to clear the cache
          */
         private void addPayloadForLatest(String uriToUpdate, String collectionId, Date clearCacheDate) {
             PayloadType type = getPayloadType(uriToUpdate);
@@ -85,6 +120,12 @@ public class LegacyCacheApiPayloadBuilder {
             addLatestPayload(uriToUpdate, collectionId, clearCacheDate);
         }
 
+        /**
+         * Adds a payload for the 'latest' version of a resource.
+         * @param uriToUpdate the URI of the resource to update
+         * @param collectionId the ID of the collection
+         * @param clearCacheDate the date to clear the cache
+         */
         private void addLatestPayload(String uriToUpdate, String collectionId, Date clearCacheDate) {
             LegacyCacheApiPayload payloadLatest = new LegacyCacheApiPayload(collectionId, uriToUpdate, clearCacheDate);
             payloadLatest.uriToUpdate = PayloadPathUpdater.getPathForLatest(payloadLatest.uriToUpdate);

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdater.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdater.java
@@ -48,6 +48,7 @@ public class PayloadPathUpdater {
             }
 
             // Order matters:
+            // TODO: figure out why the order matters and note it here.
 
             // 1. If starts with /visualisation/ then /visualisation/xxx/xxxx ---> /visualisation/xxx (keep 1 segment) - return here
             if (updatedUri.startsWith(VISUALISATIONS_SEGMENT)) {
@@ -70,7 +71,7 @@ public class PayloadPathUpdater {
                 }
             }
 
-            // 3. If bulletin, article or compendia then /xxxx/bulletin/xxxx1/xxxx2/xxxx3 --> /bulletin/xxxx1/xxxx2  (keep 2 segment) & RETURN modified
+            // 3. If bulletin, article or compendia then /xxxx/bulletin/xxxx1/xxxx2/xxxx3 --> /xxxx/bulletin/xxxx1/xxxx2  (keep 2 segment) & RETURN modified
             if (updatedUri.contains(ARTICLE_SEGMENT)) {
                 return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, ARTICLE_SEGMENT, 2);
             }
@@ -80,7 +81,7 @@ public class PayloadPathUpdater {
             if (updatedUri.contains(COMPENDIUM_SEGMENT)) {
                 return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, COMPENDIUM_SEGMENT, 2);
             }
-            // 4. If qmis or adhoc or methodologies then /xxxx/qmis/xxx1/xxx2 --> /qmis/xxx1 & RETURNS modified
+            // 4. If qmis or adhoc or methodologies then /xxxx/qmis/xxx1/xxx2 --> /xxxx/qmis/xxx1 & RETURNS modified
             if (updatedUri.contains(ADHOC_SEGMENT)) {
                 return URIUtils.getNSegmentsAfterSegmentInput(updatedUri, ADHOC_SEGMENT, 1);
             }
@@ -94,6 +95,7 @@ public class PayloadPathUpdater {
             // 5. For the below if (a) is true, skip (b):
             //      (a) If path ends with /data then /xxx1/data/ --> /xxx1
             //      (b) If path ends with filename + extension remove it /xxx/filename.extension --> /xxx
+            // TODO: Why does this not return here? 
             String lastSegment = URIUtils.getLastSegment(updatedUri);
             if (lastSegment != null) {
                 if (lastSegment.equals(DATA_SEGMENT_WITHOUT_SLASH)) {
@@ -104,8 +106,8 @@ public class PayloadPathUpdater {
             }
 
             // 6. If timeseries:
-            //      (a) then /timeseries/xxx --> /xxx or /timeseries/xxx1/xxx2 --> /xxx1/xxx2 (keep up to 2 segments)
-            //      (b) If path ends with /xxx/linechartconfig --> /xxx
+            //      (a) then /xxx/timeseries/xxx1/xxx2/xxx3 --> /xxx/timeseries/xxx1/xxx2 (keep up to 2 segments)
+            //      (b) If path from (a) ends with /xxx/linechartconfig --> /xxx
             //      (c) RETURN modified
             if (updatedUri.contains(TIME_SERIES_SEGMENT)) {
                 updatedUri = URIUtils.getNSegmentsAfterSegmentInput(updatedUri, TIME_SERIES_SEGMENT, 2);
@@ -139,6 +141,10 @@ public class PayloadPathUpdater {
     
     public static boolean isPayloadPathCompendiaLatest(String uriToUpdate) {
         return uriToUpdate != null && uriToUpdate.contains(COMPENDIUM_SEGMENT) && !uriToUpdate.endsWith("/latest");
+    }
+
+    public static String getPathForFile(String uri) {
+        return String.format("/file?uri=%s", uri);
     }
 
     public static String getPathForLatest(String uriToUpdate) {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
@@ -7,14 +7,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -24,248 +22,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(Enclosed.class)
 public class LegacyCacheApiPayloadBuilderTest {
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestVisualisation {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestVisualisation(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkVisualisations() {
-            return Arrays.asList(new Object[][]{
-                    // case 1
-                    {"/ons/seg1", "/ons/seg1"}, {"/ons/seg1/seg2/", "/ons/seg1/seg2"},
-                    // case 2: visualisation => keep 1 after type
-                    {"/visualisations/dvc1945/seasonalflu/", "/visualisations/dvc1945"}, {"/visualisations/dvc1945/seasonalflu/index.html", "/visualisations/dvc1945"},
-                    // case 2 + trailing slash
-                    {"/visualisations/dvc1945/seasonalflu/index.html/", "/visualisations/dvc1945"},});
-        }
-
-        @Test
-        public void testVisualisation() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestResources {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestResources(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkResourcesPath() {
-            // case 3: resource types => extract uri
-            return Arrays.asList(new Object[][]{{"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}});
-        }
-
-        @Test
-        public void testResources() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestBulletin {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestBulletin(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkBulletinsPath() {
-            // case 3: resource types => extract uri
-            return Arrays.asList(new Object[][]{
-                    // bulletins & articles => keep 2 after type
-                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},
-                    // trailing slash
-                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023/", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},});
-        }
-
-        @Test
-        public void testBulletinPath() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestQMisAndAdhocAndMethods {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestQMisAndAdhocAndMethods(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkQMisAndAdhocAndMethodsPath() {
-            return Arrays.asList(new Object[][]{
-                    // qmis & adhoc => keep 1 after type
-                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
-                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"},
-                    // trailing slash
-                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi/", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
-                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},});
-        }
-
-        @Test
-        public void testQMISAndAdhocPath() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestData {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestData(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkDataPath() {
-            // resource types => extract uri
-            return Arrays.asList(new Object[][]{
-                    // remove /data
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    {"/economy/grossdomesticproductgdp/something/data", "/economy/grossdomesticproductgdp/something"},
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
-                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
-                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/data", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},
-                    // remove data + trailing slash
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    {"/economy/grossdomesticproductgdp/something/data/", "/economy/grossdomesticproductgdp/something"},
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
-                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data/", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
-                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"}});
-        }
-
-        @Test
-        public void testDataPath() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestTimeseries {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestTimeseries(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkTimeSeriesPath() {
-            return Arrays.asList(new Object[][]{
-
-                    // timeseries => keep up to 2 after type
-                    {"/economy/grossdomesticproductgdp/timeseries/ihyq", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    // timeseries => remove linechartconfig
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig", "/economy/grossdomesticproductgdp/timeseries"},
-                    // timeseries + trailing slash
-                    {"/economy/grossdomesticproductgdp/timeseries/ihyq/", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
-                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries"}});
-        }
-
-        @Test
-        public void testTimeseries() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestDataset {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestDataset(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkDatasetPath() {
-            // case 3: resource types => extract uri
-            return Arrays.asList(new Object[][]{
-                    // datasets => keep up to 2 after type
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
-                    // trailing slash
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
-                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
-                    // Topic pages
-                    {"/economy", "/economy"},
-                    {"/economy/inflationandpriceindices", "/economy/inflationandpriceindices"},
-                    {"/economy/inflationandpriceindices/", "/economy/inflationandpriceindices"},
-                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
-                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours/", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
-                    // Static pages
-                    {"/aboutus/transparencyandgovernance/dataprotection", "/aboutus/transparencyandgovernance/dataprotection"},
-                    {"/aboutus/transparencyandgovernance/dataprotection/", "/aboutus/transparencyandgovernance/dataprotection"}, {"/file?uri=/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals/c3ac8759.png", "/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals"}});
-        }
-
-        @Test
-        public void testDataset() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
-    @RunWith(Parameterized.class)
-    public static class LegacyCacheApiPayloadParameterisedTestEncode {
-        private final String inputURL;
-        private final String expectedResult;
-
-        public LegacyCacheApiPayloadParameterisedTestEncode(String input, String expected) {
-            this.inputURL = input;
-            this.expectedResult = expected;
-        }
-
-        @Parameterized.Parameters
-        public static List<Object[]> checkEncodedPath() {
-            // case 3: resource types => extract uri
-            return Arrays.asList(new Object[][]{
-                    // Encoded endpoints
-                    {"/file?uri=%2Feconomy%2Fseg1", "/economy/seg1"},
-                    {"/file?uri=%2Feconomy%2Fseg1%2Fseg2", "/economy/seg1/seg2"}});
-        }
-
-        @Test
-        public void testEncoded() {
-            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
-            assertEquals(expectedResult, result);
-        }
-    }
-
     @RunWith(MockitoJUnitRunner.class)
     public static class LegacyCacheApiPayloadNonParameterisedTest {
         @Mock
@@ -383,77 +139,24 @@ public class LegacyCacheApiPayloadBuilderTest {
             assertEquals(1, payloads.size());
             assertTrue(payloads.iterator().next().uriToUpdate.contains("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest"));
         }
-        
-        @Test
-        public void testGetPathForBulletinLatest() {
-            String result = PayloadPathUpdater.getPathForLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
-            assertEquals("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", result);
-        }
 
         @Test
-        public void testIsPathBulletinLatest() {
-            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
-            assertTrue(result);
-        }
+        public void NotificationPayloadCacheApiForFileReturnsFileURITest() {
+            String testUriFile = "/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest/2025/test.csv";
 
-        @Test
-        public void testIsPathBulletinLatestFalseForArticlesPath() {
-            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/articles/producerpriceinflation/october2022/30d7d6c2/");
-            assertFalse(result);
-        }
+            urisToUpdate.clear();
+            urisToUpdate.add(testUriFile);
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
+            assertEquals(2, payloads.size());
 
-        @Test
-        public void testIsPathBulletinLatestFalse() {
-            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest");
-            assertFalse(result);
-        }
-       
-        @Test
-        public void testGetPathForArticleLatest() {
-            String result = PayloadPathUpdater.getPathForLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/updatedaugust2024/");
-            assertEquals("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/latest", result);
-        }
+            String expectedFileURI = "/file?uri=/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest/2025/test.csv";
+            boolean hasExpectedFileURI = payloads.stream().map(payload -> payload.uriToUpdate).anyMatch(uri -> uri.equals(expectedFileURI));
 
-        @Test
-        public void testIsPathArticleLatest() {
-            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/updatedaugust2024/");
-            assertTrue(result);
-        }
+            String expectedURI = "/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest";
+            boolean hasExpectedURI = payloads.stream().map(payload -> payload.uriToUpdate).anyMatch(uri -> uri.equals(expectedURI));
 
-        @Test
-        public void testIsPathArticleLatestFalseForBulletinsPath() {
-            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
-            assertFalse(result);
-        }
-
-        @Test
-        public void testIsPathArticleLatestFalse() {
-            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/latest");
-            assertFalse(result);
-        }
-       
-        @Test
-        public void testGetPathForCompendiaLatest() {
-            String result = PayloadPathUpdater.getPathForLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/2024/");
-            assertEquals("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest", result);
-        }
-
-        @Test
-        public void testIsPathCompendiaLatest() {
-            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/2024/");
-            assertTrue(result);
-        }
-
-        @Test
-        public void testIsPathCompendiaLatestFalseForBulletinsPath() {
-            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
-            assertFalse(result);
-        }
-
-        @Test
-        public void testIsPathCompendiaLatestFalse() {
-            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest");
-            assertFalse(result);
+            assertTrue(hasExpectedFileURI);
+            assertTrue(hasExpectedURI);
         }
     }
 }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdaterTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/PayloadPathUpdaterTest.java
@@ -1,0 +1,344 @@
+package com.github.onsdigital.zebedee.model.publishing.legacycacheapi;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Enclosed.class)
+public class PayloadPathUpdaterTest {
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestVisualisation {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestVisualisation(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkVisualisations() {
+            return Arrays.asList(new Object[][]{
+                    // case 1
+                    {"/ons/seg1", "/ons/seg1"}, {"/ons/seg1/seg2/", "/ons/seg1/seg2"},
+                    // case 2: visualisation => keep 1 after type
+                    {"/visualisations/dvc1945/seasonalflu/", "/visualisations/dvc1945"}, {"/visualisations/dvc1945/seasonalflu/index.html", "/visualisations/dvc1945"},
+                    // case 2 + trailing slash
+                    {"/visualisations/dvc1945/seasonalflu/index.html/", "/visualisations/dvc1945"},});
+        }
+
+        @Test
+        public void testVisualisation() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestResources {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestResources(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkResourcesPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{{"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/generator?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/&format=csv", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartimage?uri=/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022"}, {"/chartconfig?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/chart?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/embed?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/resource?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?format=csv&uri=/economy/inflationandpriceindices/timeseries/l55o/mm23/", "/economy/inflationandpriceindices/timeseries/l55o/mm23"}, {"/export?uri=/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/&format=csv", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"}});
+        }
+
+        @Test
+        public void testResources() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestBulletin {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestBulletin(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkBulletinsPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // bulletins & articles => keep 2 after type
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},
+                    // trailing slash
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest/", "/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest"}, {"/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023/", "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023"},});
+        }
+
+        @Test
+        public void testBulletinPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestQMisAndAdhocAndMethods {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestQMisAndAdhocAndMethods(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkQMisAndAdhocAndMethodsPath() {
+            return Arrays.asList(new Object[][]{
+                    // qmis & adhoc => keep 1 after type
+                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
+                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"},
+                    // trailing slash
+                    {"/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi/", "/economy/grossdomesticproductgdp/qmis/annualacquisitionsanddisposalsofcapitalassetssurveyqmi"},
+                    {"/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/", "/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018"}, {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},});
+        }
+
+        @Test
+        public void testQMISAndAdhocPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestData {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestData(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkDataPath() {
+            // resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // remove /data
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/something/data", "/economy/grossdomesticproductgdp/something"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
+                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/data", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"},
+                    // remove data + trailing slash
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/data/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/something/data/", "/economy/grossdomesticproductgdp/something"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/data/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest/data/", "/economy/inflationandpriceindices/bulletins/producerpriceinflations/latest"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/upload-pricequotes202309.csv/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    {"/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi/anything", "/economy/inflationandpriceindices/methodologies/consumerpriceinflationincludesall3indicescpihcpiandrpiqmi"}});
+        }
+
+        @Test
+        public void testDataPath() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestTimeseries {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestTimeseries(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkTimeSeriesPath() {
+            return Arrays.asList(new Object[][]{
+                    // timeseries => keep up to 2 after type
+                    {"/economy/grossdomesticproductgdp/timeseries/ihyq", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    // timeseries => remove linechartconfig
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig", "/economy/grossdomesticproductgdp/timeseries"},
+                    // timeseries + trailing slash
+                    {"/economy/grossdomesticproductgdp/timeseries/ihyq/", "/economy/grossdomesticproductgdp/timeseries/ihyq"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries/abmi/pn2"},
+                    {"/economy/grossdomesticproductgdp/timeseries/linechartconfig/", "/economy/grossdomesticproductgdp/timeseries"}});
+        }
+
+        @Test
+        public void testTimeseries() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestDataset {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestDataset(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkDatasetPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // datasets => keep up to 2 after type
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    // trailing slash
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes"},
+                    {"/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023/", "/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpiitemindicesandpricequotes/pricequotesseptember2023"},
+                    // Topic pages
+                    {"/economy", "/economy"},
+                    {"/economy/inflationandpriceindices", "/economy/inflationandpriceindices"},
+                    {"/economy/inflationandpriceindices/", "/economy/inflationandpriceindices"},
+                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
+                    {"/employmentandlabourmarket/peopleinwork/earningsandworkinghours/", "/employmentandlabourmarket/peopleinwork/earningsandworkinghours"},
+                    // Static pages
+                    {"/aboutus/transparencyandgovernance/dataprotection", "/aboutus/transparencyandgovernance/dataprotection"},
+                    {"/aboutus/transparencyandgovernance/dataprotection/", "/aboutus/transparencyandgovernance/dataprotection"}, 
+                    {"/file?uri=/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals/c3ac8759.png", "/aboutus/whatwedo/programmesandprojects/sustainabledevelopmentgoals"}
+                }
+            );
+        }
+
+        @Test
+        public void testDataset() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PayloadPathUpdaterParameterisedTestEncode {
+        private final String inputURL;
+        private final String expectedResult;
+
+        public PayloadPathUpdaterParameterisedTestEncode(String input, String expected) {
+            this.inputURL = input;
+            this.expectedResult = expected;
+        }
+
+        @Parameterized.Parameters
+        public static List<Object[]> checkEncodedPath() {
+            // case 3: resource types => extract uri
+            return Arrays.asList(new Object[][]{
+                    // Encoded endpoints
+                    {"/file?uri=%2Feconomy%2Fseg1", "/economy/seg1"},
+                    {"/file?uri=%2Feconomy%2Fseg1%2Fseg2", "/economy/seg1/seg2"}
+                }
+            );
+        }
+
+        @Test
+        public void testEncoded() {
+            String result = PayloadPathUpdater.getCanonicalPagePath(inputURL, "cake-1abcdef345");
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    public static class PayloadPathUpdaterLatestTest {
+        @Test
+        public void testGetPathForBulletinLatest() {
+            String result = PayloadPathUpdater.getPathForLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertEquals("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest", result);
+        }
+
+        @Test
+        public void testIsPathBulletinLatest() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertTrue(result);
+        }
+
+        @Test
+        public void testIsPathBulletinLatestFalseForArticlesPath() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/articles/producerpriceinflation/october2022/30d7d6c2/");
+            assertFalse(result);
+        }
+
+        @Test
+        public void testIsPathBulletinLatestFalse() {
+            boolean result = PayloadPathUpdater.isPayloadPathBulletinLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest");
+            assertFalse(result);
+        }
+        
+        @Test
+        public void testGetPathForArticleLatest() {
+            String result = PayloadPathUpdater.getPathForLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/updatedaugust2024/");
+            assertEquals("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/latest", result);
+        }
+
+        @Test
+        public void testIsPathArticleLatest() {
+            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/updatedaugust2024/");
+            assertTrue(result);
+        }
+
+        @Test
+        public void testIsPathArticleLatestFalseForBulletinsPath() {
+            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertFalse(result);
+        }
+
+        @Test
+        public void testIsPathArticleLatestFalse() {
+            boolean result = PayloadPathUpdater.isPayloadPathArticleLatest("/economy/inflationandpriceindices/articles/consumerpricesdevelopmentplan/latest");
+            assertFalse(result);
+        }
+        
+        @Test
+        public void testGetPathForCompendiaLatest() {
+            String result = PayloadPathUpdater.getPathForLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/2024/");
+            assertEquals("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest", result);
+        }
+
+        @Test
+        public void testIsPathCompendiaLatest() {
+            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/2024/");
+            assertTrue(result);
+        }
+
+        @Test
+        public void testIsPathCompendiaLatestFalseForBulletinsPath() {
+            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/30d7d6c2/");
+            assertFalse(result);
+        }
+
+        @Test
+        public void testIsPathCompendiaLatestFalse() {
+            boolean result = PayloadPathUpdater.isPayloadPathCompendiaLatest("/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest");
+            assertFalse(result);
+        }
+    }
+
+    public static class PayloadPathUpdaterFileTest {
+        @Test
+        public void testGetPathForFile() {
+            String result = PayloadPathUpdater.getPathForFile("/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls");
+            assertEquals("/file?uri=/economy/inflationandpriceindices/adhocs/009581cpiinflationbetween2010and2018/cpiinflationbetween2010and2018.xls", result);
+        }
+    }
+}


### PR DESCRIPTION
### What

Added functionality to pass file uris to the cache api.

I've moved some tests around as they were misleading what they were testing. 

### How to review

Check looks ok - to test it you can run with:
- https://github.com/ONSdigital/dp-compose/pull/295
- https://github.com/ONSdigital/dp-legacy-cache-api/pull/53

If you schedule a collection with a file in and approve it you should now see the file in the cachetimes database.

### Who can review

Not me. 