### PR TITLE
Remove policy on publish

### DIFF
--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>com.github.onsdigital.dp-permissions-api</groupId>
             <artifactId>dp-permissions-api-sdk-java</artifactId>
-            <version>v1.12.0</version>
+            <version>v1.13.0</version>
         </dependency>
 
         <!-- Test -->

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -242,6 +242,12 @@
             <version>v0.7.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.onsdigital.dp-permissions-api</groupId>
+            <artifactId>dp-permissions-api-sdk-java</artifactId>
+            <version>v1.12.0</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/ZebedeeConfiguration.java
@@ -10,6 +10,8 @@ import com.github.onsdigital.dp.image.api.client.ImageClient;
 import com.github.onsdigital.slack.Profile;
 import com.github.onsdigital.slack.client.SlackClient;
 import com.github.onsdigital.slack.client.SlackClientImpl;
+import com.github.onsdigital.dp.permissions.api.sdk.PermissionsClient;
+import com.github.onsdigital.dp.permissions.api.sdk.PermissionsAPIClient;
 import com.github.onsdigital.zebedee.data.processing.DataIndex;
 import com.github.onsdigital.zebedee.kafka.KafkaClient;
 import com.github.onsdigital.zebedee.kafka.KafkaClientImpl;
@@ -186,7 +188,13 @@ public class ZebedeeConfiguration {
         PermissionsStore permissionsStore = new PermissionsStoreFileSystemImpl(permissionsPath);
         if (cmsFeatureFlags().isJwtSessionsEnabled()) {
             if (cmsFeatureFlags().isPermissionsAPIEnabled()) {
-                this.permissionsService = new PermissionsServiceImplementation(getPermissionsApiUrl());
+                try {
+                    PermissionsClient permissionsClient = new PermissionsAPIClient(getPermissionsApiUrl(), getServiceAuthToken());
+                    this.permissionsService = new PermissionsServiceImplementation(permissionsClient, getPermissionsApiUrl());
+                } catch (URISyntaxException e) {
+                    error().logException(e, "failed to initialise dp-permissions-api client - invalid URI");
+                    throw new RuntimeException(e);
+                }
             } else {
                 this.permissionsService = new JWTPermissionsServiceImpl(permissionsStore);
             }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/PostPublisher.java
@@ -95,18 +95,26 @@ public class PostPublisher {
             copyFilesToMaster(zebedee, collection, collectionReader);
 
             if (cmsFeatureFlags().isRedirectAPIEnabled()) {
-                info().log("publishing redirects for collection");
+                info().collectionID(collection).log("publishing redirects for collection");
                 RedirectService redirectService = ZebedeeCmsService.getInstance().getRedirectService();
-                redirectService.publishRedirectsForCollection(collection, zebedeeSupplier.get().getSlackNotifier());
-                info().log("redirect processing complete");
+                redirectService.publishRedirectsForCollection(collection, zebedee.getSlackNotifier());
+                info().collectionID(collection).log("redirect processing complete");
             }
 
             // Publish content-updated and content-deleted events for search service.
             if (cmsFeatureFlags().isKafkaEnabled()) {
+                info().collectionID(collection).log("publishing search kafka messages for collection");
                 publishKafkaMessages(collection);
+                info().collectionID(collection).log("publishing search kafka messages for collection completed");
             }
 
-            Path collectionJsonPath = moveCollectionToArchive(zebedee, collection, collectionReader);
+            if (cmsFeatureFlags().isPermissionsAPIEnabled()) {
+                info().collectionID(collection).log("removing permissions policies for collection");
+                zebedee.getPermissionsService().removePolicyForCollection(collection.getId());
+                info().collectionID(collection).log("permissions policy removal for collection completed");
+            }
+
+            moveCollectionToArchive(zebedee, collection, collectionReader);
 
             collection.delete();
             ContentTree.dropCache();

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/JWTPermissionsServiceImpl.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.zebedee.permissions.service;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
 import com.github.onsdigital.zebedee.permissions.model.AccessMapping;
@@ -351,4 +352,14 @@ public class JWTPermissionsServiceImpl implements PermissionsService {
     private boolean isGroupMember(Session session, String group) {
         return session.getGroups().contains(group);
     }
+
+    /**
+     * removePolicyForCollection removes a collection based permissions policy. This is not functional
+     * with this implementation - see {@link PermissionsServiceImplementation#removePolicyForCollection(String)}
+     */
+    @Override
+    public void removePolicyForCollection(String collectionId) throws ZebedeeException {
+        throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "removePolicyForCollection"));
+    }
+    
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsService.java
@@ -227,4 +227,13 @@ public interface PermissionsService {
      * @throws IOException If a filesystem error occurs.
      */
     PermissionDefinition userPermissions(Session session) throws IOException;
+
+
+    /** 
+     * Remove a permissions policy for a collection
+     * 
+     * @param collectionId the ID of the collection to remove the permissions policy for.
+     * @throws ZebedeeException if an error occurs while removing the permissions policy.
+     */
+    void removePolicyForCollection(String collectionId) throws ZebedeeException;
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementation.java
@@ -2,9 +2,14 @@ package com.github.onsdigital.zebedee.permissions.service;
 
 import com.github.onsdigital.UserDataPayload;
 import com.github.onsdigital.dp.authorisation.permissions.PermissionChecker;
+import com.github.onsdigital.dp.permissions.api.sdk.PermissionsClient;
+import com.github.onsdigital.dp.permissions.api.sdk.exception.PolicyNotFoundException;
+import com.github.onsdigital.dp.permissions.api.sdk.exception.PermissionsAPIException;
+
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import com.github.onsdigital.zebedee.exceptions.NotFoundException;
 import com.github.onsdigital.zebedee.exceptions.UnauthorizedException;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.exceptions.ZebedeeException;
 import com.github.onsdigital.zebedee.json.CollectionType;
 import com.github.onsdigital.zebedee.json.PermissionDefinition;
@@ -19,6 +24,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.warn;
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.error;
 
 import static java.text.MessageFormat.format;
 
@@ -27,19 +35,21 @@ public class PermissionsServiceImplementation implements PermissionsService {
     private final Lock readLock = readWriteLock.readLock();
     private static final String UNSUPPORTED_ERROR = "Permissions API is enabled: {0} is no longer supported";
     private PermissionChecker permissionChecker;
+    /** 
+     * permissionsAPIClient is used for managing collection based permissions policies, which are currently only used for viewer teams.
+     * This client uses the serviceAuthToken and so should only be used for background jobs, not for handling user requests where 
+     * the user's permissions should be checked.
+    */
+    private PermissionsClient permissionAPIClient;
 
     private static final Duration DEFAULT_CACHE_UPDATE_INTERVAL = Duration.standardSeconds(60);
     private static final Duration DEFAULT_EXPIRY_CHECK_INTERVAL = Duration.standardSeconds(60);
     private static final Duration DEFAULT_MAX_CACHE_TIME = Duration.standardMinutes(5);
 
-    public PermissionsServiceImplementation(String permissionsAPIHost ) {
+    public PermissionsServiceImplementation(PermissionsClient permissionAPIClient, String permissionsAPIHost) {
         this.permissionChecker = new PermissionChecker(permissionsAPIHost, DEFAULT_CACHE_UPDATE_INTERVAL, DEFAULT_EXPIRY_CHECK_INTERVAL, DEFAULT_MAX_CACHE_TIME);
+        this.permissionAPIClient = permissionAPIClient;
     }
-
-    public PermissionsServiceImplementation() {
-        this.permissionChecker = new PermissionChecker("", DEFAULT_CACHE_UPDATE_INTERVAL, DEFAULT_EXPIRY_CHECK_INTERVAL, DEFAULT_MAX_CACHE_TIME);
-    }
-
 
     @Override
     public boolean isPublisher(Session session) throws IOException {
@@ -142,6 +152,25 @@ public class PermissionsServiceImplementation implements PermissionsService {
     @Override
     public PermissionDefinition userPermissions(Session session) throws IOException {
         throw new UnsupportedOperationException(format(UNSUPPORTED_ERROR, "userPermissions"));
+    }
+
+     /**
+     * removePolicyForCollection removes a collection based permissions policy.
+     * @param collectionId the ID of the collection to remove the permissions policy for.
+     * @throws ZebedeeException if an error occurs while removing the permissions policy.
+     */
+    @Override
+    public void removePolicyForCollection(String collectionId) throws ZebedeeException {
+        info().collectionID(collectionId).log("removing permissions policy for collection");
+
+        try {
+            permissionAPIClient.deletePolicy(collectionId);
+        } catch (PolicyNotFoundException e) {
+            warn().collectionID(collectionId).log("no permissions policy found for collection id");
+        } catch (IOException | com.github.onsdigital.dp.permissions.api.sdk.exception.BadRequestException | PermissionsAPIException e) {
+            error().collectionID(collectionId).log("failed to remove permissions policy for collection id");
+            throw new InternalServerError(format("failed to remove permissions policy for collection id: {0}", collectionId), e);
+        }
     }
 
     private Boolean hasPermission(Session session, String permissionString, String collectionId, Optional<CollectionType> collectionType) throws Exception {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PostPublisherTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/PostPublisherTest.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.file.*;
 import java.util.*;
-import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/permissions/service/PermissionsServiceImplementationTest.java
@@ -2,8 +2,12 @@ package com.github.onsdigital.zebedee.permissions.service;
 
 import com.github.onsdigital.UserDataPayload;
 import com.github.onsdigital.dp.authorisation.permissions.PermissionChecker;
-import com.github.onsdigital.zebedee.permissions.model.Permissions;
+import com.github.onsdigital.dp.permissions.api.sdk.exception.PolicyNotFoundException;
+import com.github.onsdigital.dp.permissions.api.sdk.PermissionsAPIClient;
+import com.github.onsdigital.zebedee.exceptions.InternalServerError;
 import com.github.onsdigital.zebedee.json.CollectionType;
+
+import com.github.onsdigital.zebedee.permissions.model.Permissions;
 import com.github.onsdigital.zebedee.session.model.Session;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -23,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,12 +46,15 @@ public class PermissionsServiceImplementationTest {
     private PermissionChecker permissionChecker;
 
     @Mock
+    private PermissionsAPIClient permissionAPIClient;
+
+    @Mock
     private Session session;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        permissionsService = new PermissionsServiceImplementation("http://permissions-api");
+        permissionsService = new PermissionsServiceImplementation(permissionAPIClient, "http://permissions-api");
         setPermissionChecker(permissionsService, permissionChecker);
 
         when(session.getId()).thenReturn(USER_ID);
@@ -157,6 +166,27 @@ public class PermissionsServiceImplementationTest {
                 .thenThrow(new Exception("boom"));
 
         assertThrows(RuntimeException.class, () -> permissionsService.canView(session, COLLECTION_ID));
+    }
+
+    @Test
+    public void removePolicyForCollection_ShouldCallDeletePolicy() throws Exception {
+        permissionsService.removePolicyForCollection(COLLECTION_ID);
+
+        verify(permissionAPIClient, times(1)).deletePolicy(COLLECTION_ID);
+    }   
+
+    @Test
+    public void removePolicyForCollection_ShouldHandlePolicyNotFoundException() throws Exception {
+        doThrow(new PolicyNotFoundException("not found", 404)).when(permissionAPIClient).deletePolicy(COLLECTION_ID);
+        permissionsService.removePolicyForCollection(COLLECTION_ID);
+        verify(permissionAPIClient, times(1)).deletePolicy(COLLECTION_ID);
+    }
+
+    @Test
+    public void removePolicyForCollection_ShouldHandleIOException() throws Exception {
+        doThrow(new IOException("io exception")).when(permissionAPIClient).deletePolicy(COLLECTION_ID);
+        assertThrows(InternalServerError.class, () -> permissionsService.removePolicyForCollection(COLLECTION_ID));
+        verify(permissionAPIClient, times(1)).deletePolicy(COLLECTION_ID);
     }
 
     private void setPermissionChecker(PermissionsServiceImplementation service, PermissionChecker checker) throws Exception {


### PR DESCRIPTION
### What

During post publish, tidy up policies by removing and collection based policies from the permissions api. 

### How to review

Check looks ok - testing can be done by:

- run legacy-core-publishing stack
- create a collection in florence
- add a previewer team in florence
- check the policy is created in the permissions api
- publish the collection
- check the policy is removed from the permissions api

### Who can review

Not me. 