### PR TITLE
Add lock check when closing collection before unlocking

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -542,6 +542,9 @@ public class Collection {
 
         // remove the lock for the collection
         collectionLocks.remove(path);
+
+        // remove write lock for the collection
+        this.hasWriteLock = false;
     }
 
     /**
@@ -1462,9 +1465,12 @@ public class Collection {
     }
 
     public void close() {
-        if (this.isWriteable){
+        if (this.isWriteable) {
             if (this.hasWriteLock) {
-                this.getWriteLock().unlock();
+                ReadWriteLock collectionLock = collectionLocks.get(this.path);
+                if (collectionLock != null) {
+                    collectionLock.writeLock().unlock();
+                }
                 this.hasWriteLock = false;
             } else {
                 warn().collectionID(this).log("collection closed without write lock held - this should not happen");

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -641,6 +641,19 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
+    public void shouldNotThrowWhenClosingWritableCollectionAfterDelete() throws Exception {
+
+        Path collectionPath = builder.collections.get(1);
+        Path collectionJsonPath = collectionPath.getParent().resolve(collectionPath.getFileName() + ".json");
+        Collection writeableCollection = new Collection(collectionPath, zebedee, true);
+
+        writeableCollection.delete();
+        assertFalse(Files.exists(collectionPath));
+        assertFalse(Files.exists(collectionJsonPath));
+        writeableCollection.close();
+    }
+
+    @Test
     public void shouldNotCreateIfPublished() throws IOException {
 
         // Given


### PR DESCRIPTION
### What

Close attempts to unlock the collection after `delete()` removed the collection lock causing a NPE.

### How to review

Sense check

### Who can review

!Me
