### PR TITLE
Add payment required to oss index errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OSSINDEX_ERRORS = "Unable to contact OSS Index|authentication failed|401 Unauthorized|403 Forbidden|429 Too Many Requests|Too many requests|Rate limit|Unknown host|Connection refused|timed out|unreachable"
+OSSINDEX_ERRORS = "Unable to contact OSS Index|authentication failed|401 Unauthorized|403 Forbidden|429 Too Many Requests|Too many requests|Rate limit|Unknown host|Connection refused|timed out|unreachable|402 Payment Required"
 
 .PHONY: all
 all: audit test build


### PR DESCRIPTION
### What

Add check for 'payment required' to oss index failures.

### How to review

Check it fails. 

### Who can review

Not me. 