### PR TITLE
Add guard clause for null versions

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImpl.java
@@ -25,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.github.onsdigital.zebedee.logging.CMSLogEvent.info;
 import static com.github.onsdigital.zebedee.util.versioning.VersionNotFoundException.versionsNotFoundException;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -183,10 +184,13 @@ public class VersionsServiceImpl implements VersionsService {
 
         List<MissingVersion> missingVersions = new ArrayList<>();
 
-        for (Version version : dataset.getVersions()) {
+        List<Version> versions = dataset.getVersions();
 
-            if (!versionExists(cmsReader, collection, session, version)) {
-                missingVersions.add(new MissingVersion(dataset, version));
+        if (versions != null) {
+            for (Version version : versions) {
+                if (!versionExists(cmsReader, collection, session, version)) {
+                    missingVersions.add(new MissingVersion(dataset, version));
+                }
             }
         }
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImplTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/util/versioning/VersionsServiceImplTest.java
@@ -237,6 +237,18 @@ public class VersionsServiceImplTest {
         service.verifyCollectionDatasets(cmsReader, collection, collectionReader, session);
     }
 
+    @Test
+    public void getMissingVersions_nullDatasetVersions_shouldReturnEmptyList() throws Exception {
+        Dataset datasetWithoutVersions = new Dataset();
+        datasetWithoutVersions.setUri(new URI(CONTENT_URI));
+        datasetWithoutVersions.setVersions(null);
+
+        List<MissingVersion> result = service.getMissingVersions(
+                cmsReader, collection, session, datasetWithoutVersions);
+
+        assertTrue(result.isEmpty());
+    }
+
     @Test(expected = VersionNotFoundException.class)
     public void verifyCollectionDatasets_containsDatasetMissingVersion_shouldThrowException() throws Exception {
         when(collectionReader.getReviewed())


### PR DESCRIPTION
### What

Zebedee has an 'experimental' missing versions checker during the approval step on a collection. 

Unfortunately some datasets don't have the versions set at all - this guards against the versions coming back as null.

### How to review

You can test this with the migration stack.

You will need to:

- pull this branch
- make build in this repo
- set ENABLE_DATASET_VERSION_VERIFICATION in zebedee's manifest
- SERVICE=zebedee make refresh
- alter the test dataset so it does not have a `versions` attribute in the latest `dataset` page for the series
- run the migration
- approve the migration

it now moves to `published`

### Who can review

Not me. 