### PR TITLE
Fix/unblock threads

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -540,11 +540,19 @@ public class Collection {
             Files.delete(collectionDescriptionPath);
         }
 
+        // Release the write lock before removing it from the map. If this is skipped, any thread
+        // that acquired a reference to the lock and is currently blocked on lock() will wait forever
+        // because close() will see hasWriteLock=false and skip the unlock.
+        if (this.isWriteable && this.hasWriteLock) {
+            ReadWriteLock lock = collectionLocks.get(this.path);
+            if (lock != null) {
+                lock.writeLock().unlock();
+            }
+            this.hasWriteLock = false;
+        }
+
         // remove the lock for the collection
         collectionLocks.remove(path);
-
-        // remove write lock for the collection
-        this.hasWriteLock = false;
     }
 
     /**
@@ -1472,8 +1480,6 @@ public class Collection {
                     collectionLock.writeLock().unlock();
                 }
                 this.hasWriteLock = false;
-            } else {
-                warn().collectionID(this).log("collection closed without write lock held - this should not happen");
             }
         }
     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -308,7 +308,17 @@ public class Collections {
             String collectionName = getCollectionNameFromId(collectionId);
             return getCollectionByName(collectionName, writeable);
         } catch (IOException | CollectionNotFoundException e) {
-            return list().getCollection(collectionId);
+            // Fallback: scan all collections by ID. The list() entries are non-writeable so if
+            // the caller requested a write lock we must re-open with writeable=true.
+            Collection found = list().getCollection(collectionId);
+            if (found == null || !writeable) {
+                return found;
+            }
+            try {
+                return new Collection(found.getPath(), zebedeeSupplier.get(), true);
+            } catch (CollectionNotFoundException ex) {
+                return null;
+            }
         }
     }
     public Collection getCollectionByName(String collectionName) throws IOException, CollectionNotFoundException {

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -651,6 +652,58 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
         assertFalse(Files.exists(collectionPath));
         assertFalse(Files.exists(collectionJsonPath));
         writeableCollection.close();
+    }
+
+    @Test
+    public void deleteShouldReleaseLockSoWaitingThreadIsUnblocked() throws Exception {
+        // Given a writeable collection held open by one thread (simulating a publish)
+        Path collectionPath = builder.collections.get(1);
+        Collection writeableCollection = new Collection(collectionPath, zebedee, true);
+
+        // Grab the write lock reference now, before delete() removes it from the map.
+        // This mirrors the Publisher pattern: it calls collection.getWriteLock().lock()
+        // on a reference it already holds, concurrent with another thread that may call delete().
+        Lock writeLock = writeableCollection.getWriteLock();
+
+        CountDownLatch waitingThreadStarted = new CountDownLatch(1);
+        CountDownLatch waitingThreadFinished = new CountDownLatch(1);
+        AtomicBoolean lockAcquired = new AtomicBoolean(false);
+        AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+
+        // A second thread blocks on the same write lock, simulating any concurrent
+        // request (content save, review, etc.) that is waiting while a publish/delete runs.
+        Thread waitingThread = new Thread(() -> {
+            waitingThreadStarted.countDown();
+            try {
+                writeLock.lock(); // blocks because writeableCollection holds it
+                lockAcquired.set(true);
+            } catch (Throwable t) {
+                threadFailure.set(t);
+            } finally {
+                if (lockAcquired.get()) {
+                    writeLock.unlock();
+                }
+                waitingThreadFinished.countDown();
+            }
+        });
+
+        waitingThread.start();
+        assertTrue("waiting thread did not start", waitingThreadStarted.await(1, TimeUnit.SECONDS));
+
+        // The second thread should be blocked waiting for the write lock.
+        assertFalse("second thread acquired lock before delete - test precondition failed",
+                waitingThreadFinished.await(200, TimeUnit.MILLISECONDS));
+
+        // When delete() is called it must release the write lock.
+        writeableCollection.delete();
+
+        // Then the waiting thread should be unblocked.
+        assertTrue("waiting thread was not unblocked after delete()",
+                waitingThreadFinished.await(3, TimeUnit.SECONDS));
+        assertNull("waiting thread threw an exception: " + threadFailure.get(), threadFailure.get());
+        assertTrue(lockAcquired.get());
+
+        waitingThread.join(TimeUnit.SECONDS.toMillis(3));
     }
 
     @Test

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionsTest.java
@@ -57,6 +57,7 @@ import java.util.function.Supplier;
 
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -226,6 +227,73 @@ public class CollectionsTest {
     @Test
     public void shouldReturnNullIfNotFound() throws Exception {
         assertThat(collections.getCollection("A_Girl_Is_No_One"), equalTo(null));
+    }
+
+    @Test
+    public void getCollectionWithWriteableFallbackShouldReturnWriteableCollection() throws Exception {
+        // Given a collection that exists on disk (created without the ID-to-name shortcut,
+        // so getCollectionNameFromId will fail to trim and fall through to the scan-by-ID fallback).
+        when(zebedeeMock.getCollections()).thenReturn(collections);
+        when(zebedeeMock.getUsersService()).thenReturn(usersServiceMock);
+        when(zebedeeMock.getEncryptionKeyFactory()).thenReturn(encryptionKeyFactory);
+        when(zebedeeMock.getCollectionKeyring()).thenReturn(collectionKeyring);
+        when(collectionReaderWriterFactoryMock.getWriter(zebedeeMock, collectionMock, sessionMock))
+                .thenReturn(collectionWriterMock);
+
+        SecretKey key = Keys.newSecretKey();
+        when(encryptionKeyFactory.newCollectionKey()).thenReturn(key);
+        when(collectionKeyring.get(any(), any())).thenReturn(key);
+
+        com.github.onsdigital.zebedee.json.CollectionDescription desc =
+                new com.github.onsdigital.zebedee.json.CollectionDescription();
+        desc.setName("fallback-writeable-test");
+        desc.setType(com.github.onsdigital.zebedee.json.CollectionType.manual);
+        Collection created = Collection.create(desc, zebedeeMock, sessionMock);
+        String id = created.getDescription().getId();
+
+        // When the collection is retrieved with writeable=true using an ID whose
+        // name-trimming produces the wrong folder name (i.e. forces the fallback path).
+        // We force the fallback by passing a raw ID that does NOT match the
+        // trimmed-name format (no trailing GUID portion).
+        Collection found = collections.getCollection(id, true);
+
+        // Then we get a non-null, writeable collection back.
+        assertNotNull(found);
+        assertThat(found.getDescription().getId(), equalTo(id));
+
+        // And closing it must not throw — i.e. it must actually hold a write lock.
+        found.close();
+    }
+
+    @Test
+    public void getCollectionFallbackWithWriteableFalseShouldReturnNonWriteableCollection() throws Exception {
+        // Given a collection created on disk.
+        when(zebedeeMock.getCollections()).thenReturn(collections);
+        when(zebedeeMock.getUsersService()).thenReturn(usersServiceMock);
+        when(zebedeeMock.getEncryptionKeyFactory()).thenReturn(encryptionKeyFactory);
+        when(zebedeeMock.getCollectionKeyring()).thenReturn(collectionKeyring);
+        when(collectionReaderWriterFactoryMock.getWriter(zebedeeMock, collectionMock, sessionMock))
+                .thenReturn(collectionWriterMock);
+
+        SecretKey key = Keys.newSecretKey();
+        when(encryptionKeyFactory.newCollectionKey()).thenReturn(key);
+        when(collectionKeyring.get(any(), any())).thenReturn(key);
+
+        com.github.onsdigital.zebedee.json.CollectionDescription desc =
+                new com.github.onsdigital.zebedee.json.CollectionDescription();
+        desc.setName("fallback-readonly-test");
+        desc.setType(com.github.onsdigital.zebedee.json.CollectionType.manual);
+        Collection created = Collection.create(desc, zebedeeMock, sessionMock);
+        String id = created.getDescription().getId();
+
+        // When the collection is retrieved with writeable=false.
+        Collection found = collections.getCollection(id, false);
+
+        // Then we get the collection back.
+        assertNotNull(found);
+        assertThat(found.getDescription().getId(), equalTo(id));
+        // close() on a non-writeable collection is a no-op and must not throw.
+        found.close();
     }
 
     @Test(expected = BadRequestException.class)


### PR DESCRIPTION
### What

The collection.delete() function - called when a collection is either deleted or published (because when a collection is published it is deleted)

It doesn't actually release the write lock but it does set hasWriteLock to false - when it gets subsequently to close it doesn't actually release the writelock. So if there is a thread waiting (i.e. if the collection was accessed during one of these events, the thread would be permanently stopped).

This actually closes the thread. 

Additionally have fixed an issue with another route to acquiring a collection drops the writeable variable so saw the opportunity to fix that at the same time. 

### How to review

Check looks ok, tests sensible. 

To test it properly you would need to introduce a thread sleep inside inside delete() at the start of the function.

You then need to build / run zebedee and:

- create a collection
- send a deletion request for the collection
- before the end of x, send another write request to that collection like save content or something
- 2nd request should hang forever and we should be able to check the java threads to see a waiting thread

This would require either using service auth tokens or having permissions api and an auth stub running. 

Alternatively, Aqdas can demo the fix. 

### Who can review

Not me. 