### PR TITLE
Fix collection writing thread pool issue

### DIFF
--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -54,6 +54,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -149,8 +150,11 @@ public class Collection {
             this.lockForWriting();
         }
 
-        collectionLocks.get(this.path).readLock().lock();
-
+        // No read lock here: save() writes atomically via a tmp-file rename, so
+        // readers always see a complete file and a read lock is not needed for safety.
+        // Removing the read lock also prevents the deadlock where two threads each hold
+        // a write lock on different collections and block on each other's read lock
+        // inside collections.list().
         try (InputStream input = Files.newInputStream(this.collectionJsonPath)) {
             this.description = Serialiser.deserialise(input,
                     CollectionDescription.class);
@@ -158,8 +162,6 @@ public class Collection {
             // only clear the write lock if we throw an exception here.
             this.close();
             throw new IOException("Failed to deserialise collection description", e);
-        } finally {
-            collectionLocks.get(this.path).readLock().unlock();
         }
 
         // Set fields:
@@ -587,16 +589,22 @@ public class Collection {
     public boolean save() throws IOException {
         // The lock / unlock here needs to be separate to the Collection lock / unlock
         collectionLocks.get(this.path).writeLock().lock();
-        try (OutputStream output = Files.newOutputStream(this.descriptionPath())) {
-            Serialiser.serialise(output, this.description);
+        // By creating a temporary file and then copying it over in an 
+        // atomic move, we can ensure that readers will always see a complete 
+        // file and not a partially written one, so we don't need to hold a 
+        // lock when reading the file.
+        try {
+            Path tmp = this.collectionJsonPath.resolveSibling(
+                    this.collectionJsonPath.getFileName() + ".tmp");
+            try (OutputStream output = Files.newOutputStream(tmp)) {
+                Serialiser.serialise(output, this.description);
+            }
+            Files.move(tmp, this.collectionJsonPath,
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             return true;
         } finally {
             collectionLocks.get(this.path).writeLock().unlock();
         }
-    }
-
-    private Path descriptionPath() {
-        return this.collectionJsonPath;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -235,7 +235,7 @@ public class Collections {
                 if (Files.isDirectory(path)) {
                     try {
                         result.add(new Collection(path, zebedeeSupplier.get()));
-                    } catch (CollectionNotFoundException e) {
+                    } catch (CollectionNotFoundException | IOException e) {
                         error().data("collection_path", path.toString())
                                 .logException(e, "failed to deserialise collection");
                     }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -624,6 +624,75 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
+    public void concurrentWriteLocksOnDifferentCollectionsShouldNotDeadlockWhenCallingList() throws Exception {
+
+        // Given collection write locking is enabled
+        System.setProperty(CMSFeatureFlags.ENABLE_COLLECTION_WRITE_LOCKING, "true");
+        CMSFeatureFlags.reset();
+
+        try {
+            // Two different collections - each thread holds a write lock on one
+            // and then calls collections.list(), which previously tried to acquire
+            // a read lock on every collection including the one the other thread
+            // holds a write lock on, causing circular wait.
+            Path collectionPath1 = builder.collections.get(0);
+            Path collectionPath2 = builder.collections.get(1);
+
+            CountDownLatch bothLocksHeld = new CountDownLatch(2);
+            CountDownLatch bothListsDone = new CountDownLatch(2);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            Thread thread1 = new Thread(() -> {
+                try {
+                    Collection c1 = new Collection(collectionPath1, zebedee, true);
+                    bothLocksHeld.countDown();
+                    bothLocksHeld.await(); // don't call list() until both write locks are held
+                    try {
+                        zebedee.getCollections().list();
+                    } finally {
+                        c1.close();
+                    }
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    bothListsDone.countDown();
+                }
+            });
+
+            Thread thread2 = new Thread(() -> {
+                try {
+                    Collection c2 = new Collection(collectionPath2, zebedee, true);
+                    bothLocksHeld.countDown();
+                    bothLocksHeld.await();
+                    try {
+                        zebedee.getCollections().list();
+                    } finally {
+                        c2.close();
+                    }
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    bothListsDone.countDown();
+                }
+            });
+
+            thread1.start();
+            thread2.start();
+
+            // If this times out the threads are deadlocked
+            assertTrue("Deadlock detected: threads did not complete within timeout",
+                    bothListsDone.await(5, TimeUnit.SECONDS));
+            assertNull("Thread threw unexpected exception: " + failure.get(), failure.get());
+
+            thread1.join(TimeUnit.SECONDS.toMillis(5));
+            thread2.join(TimeUnit.SECONDS.toMillis(5));
+        } finally {
+            System.clearProperty(CMSFeatureFlags.ENABLE_COLLECTION_WRITE_LOCKING);
+            CMSFeatureFlags.reset();
+        }
+    }
+
+    @Test
     public void shouldReleaseWriteLockWhenWritableConstructionFails() throws Exception {
 
         Path collectionPath = builder.collections.get(1);


### PR DESCRIPTION
### What

This PR aims to correct the write locking collision problem by removing the requirement for read locks. 

I believe the readlock was required incase a read was done whilst another collection was in the middle of a write action, thereby causing a half written collection to be read and failing to be deserialised.

By changing to writing a temp file which then gets moved as an atomic move this means this should no longer happen and the deadlock during validation checks should be avoided. 

### How to review

Check looks ok - can test via general collection read /writing actions.

### Who can review

Not me. 