### PR TITLE
Release 2.53.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-image-api-client-java</artifactId>
-                <version>0.2.0</version>
+                <version>0.4.0</version>
             </dependency>
 
             <dependency>
@@ -281,7 +281,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-dataset-api-java-client</artifactId>
-                <version>1.3.0</version>
+                <version>1.4.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
         <restolino.version>v0.8.3</restolino.version>
         <httpino.version>0.0.11</httpino.version>
-        <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.21.4</fasterxml.jackson.version>
         <apache.poi.version>3.17</apache.poi.version>
         <spring.version>5.3.39</spring.version>
-        <dp.logging.version>v2.0.0-beta.16</dp.logging.version>
+        <dp.logging.version>v2.0.0-beta.18</dp.logging.version>
         <batik.version>1.17</batik.version>
         <logback.version>1.3.16</logback.version>
         <mockito.version>3.12.4</mockito.version>

--- a/zebedee-cms/pom.xml
+++ b/zebedee-cms/pom.xml
@@ -239,13 +239,13 @@
         <dependency>
             <groupId>com.github.onsdigital.dis-redirect-api</groupId>
             <artifactId>dis-redirect-api-sdk-java</artifactId>
-            <version>v0.7.0</version>
+            <version>v1.0.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.onsdigital.dp-permissions-api</groupId>
             <artifactId>dp-permissions-api-sdk-java</artifactId>
-            <version>v1.13.0</version>
+            <version>v1.15.0</version>
         </dependency>
 
         <!-- Test -->

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collection.java
@@ -54,6 +54,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -149,8 +150,11 @@ public class Collection {
             this.lockForWriting();
         }
 
-        collectionLocks.get(this.path).readLock().lock();
-
+        // No read lock here: save() writes atomically via a tmp-file rename, so
+        // readers always see a complete file and a read lock is not needed for safety.
+        // Removing the read lock also prevents the deadlock where two threads each hold
+        // a write lock on different collections and block on each other's read lock
+        // inside collections.list().
         try (InputStream input = Files.newInputStream(this.collectionJsonPath)) {
             this.description = Serialiser.deserialise(input,
                     CollectionDescription.class);
@@ -158,8 +162,6 @@ public class Collection {
             // only clear the write lock if we throw an exception here.
             this.close();
             throw new IOException("Failed to deserialise collection description", e);
-        } finally {
-            collectionLocks.get(this.path).readLock().unlock();
         }
 
         // Set fields:
@@ -587,16 +589,22 @@ public class Collection {
     public boolean save() throws IOException {
         // The lock / unlock here needs to be separate to the Collection lock / unlock
         collectionLocks.get(this.path).writeLock().lock();
-        try (OutputStream output = Files.newOutputStream(this.descriptionPath())) {
-            Serialiser.serialise(output, this.description);
+        // By creating a temporary file and then copying it over in an 
+        // atomic move, we can ensure that readers will always see a complete 
+        // file and not a partially written one, so we don't need to hold a 
+        // lock when reading the file.
+        try {
+            Path tmp = this.collectionJsonPath.resolveSibling(
+                    this.collectionJsonPath.getFileName() + ".tmp");
+            try (OutputStream output = Files.newOutputStream(tmp)) {
+                Serialiser.serialise(output, this.description);
+            }
+            Files.move(tmp, this.collectionJsonPath,
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             return true;
         } finally {
             collectionLocks.get(this.path).writeLock().unlock();
         }
-    }
-
-    private Path descriptionPath() {
-        return this.collectionJsonPath;
     }
 
     /**

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/Collections.java
@@ -235,7 +235,7 @@ public class Collections {
                 if (Files.isDirectory(path)) {
                     try {
                         result.add(new Collection(path, zebedeeSupplier.get()));
-                    } catch (CollectionNotFoundException e) {
+                    } catch (CollectionNotFoundException | IOException e) {
                         error().data("collection_path", path.toString())
                                 .logException(e, "failed to deserialise collection");
                     }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayload.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayload.java
@@ -8,19 +8,23 @@ import java.util.Date;
 public class LegacyCacheApiPayload {
     @SerializedName("collection_id")
     public String collectionId;
+    @SerializedName("collection_title")
+    public String collectionTitle;
     @SerializedName("release_time")
     public String publishDate;
     @SerializedName("path")
     public String uriToUpdate;
 
-    public LegacyCacheApiPayload(String collectionId, String uriToUpdate, Date publishDate) {
+    public LegacyCacheApiPayload(String collectionId, String collectionTitle, String uriToUpdate, Date publishDate) {
         this.collectionId = collectionId;
+        this.collectionTitle = collectionTitle;
         this.publishDate = PublishNotification.format(publishDate);
         this.uriToUpdate = uriToUpdate;
     }
 
-    public LegacyCacheApiPayload(String collectionId, String uriToUpdate) {
+    public LegacyCacheApiPayload(String collectionId, String collectionTitle, String uriToUpdate) {
         this.collectionId = collectionId;
+        this.collectionTitle = collectionTitle;
         this.uriToUpdate = uriToUpdate;
     }
 }

--- a/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
+++ b/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilder.java
@@ -40,17 +40,18 @@ public class LegacyCacheApiPayloadBuilder {
         public LegacyCacheApiPayloadBuilder build() {
             Objects.requireNonNull(this.collection);
             String collectionId = collection.getDescription().getId();
+            String collectionTitle = collection.getDescription().getName();
             Date publishDate = collection.getDescription().getPublishDate();
             try {
                 collection.reviewedUris()
                         .forEach(uri -> {
                             String pagePath = PayloadPathUpdater.getCanonicalPagePath(uri, collectionId);
                             LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId,
-                                    pagePath, publishDate);
+                                    collectionTitle, pagePath, publishDate);
                             if (isValid(legacyCacheApiPayload)) {
                                 payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
-                                addPayloadForFile(uri, collectionId, publishDate);
-                                addPayloadForLatest(legacyCacheApiPayload.uriToUpdate, collectionId, publishDate);
+                                addPayloadForFile(uri, collectionId, collectionTitle, publishDate);
+                                addPayloadForLatest(legacyCacheApiPayload.uriToUpdate, collectionId, collectionTitle, publishDate);
 
                             }
                         });
@@ -59,7 +60,7 @@ public class LegacyCacheApiPayloadBuilder {
                             String uriToDelete = pendingDelete.getRoot().getUri();
                             uriToDelete = PayloadPathUpdater.getCanonicalPagePath(uriToDelete, collectionId);
                             LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collectionId,
-                                    uriToDelete);
+                                    collectionTitle, uriToDelete);
                             if (isValid(legacyCacheApiPayload)) {
                                 payloadsByPath.put(legacyCacheApiPayload.uriToUpdate, legacyCacheApiPayload);
                             }
@@ -87,11 +88,12 @@ public class LegacyCacheApiPayloadBuilder {
          * Adds a payload for a specific file if the URI matches a file type.
          * @param uriToUpdate the URI of the file to update
          * @param collectionId the ID of the collection
+         * @param collectionTitle the title of the collection
          * @param clearCacheDate the date to clear the cache
          */
-        private void addPayloadForFile(String uriToUpdate, String collectionId, Date clearCacheDate) {
+        private void addPayloadForFile(String uriToUpdate, String collectionId, String collectionTitle, Date clearCacheDate) {
             if (URIUtils.isLastSegmentFileExtension(uriToUpdate)) {
-                addFilePayload(uriToUpdate, collectionId, clearCacheDate);
+                addFilePayload(uriToUpdate, collectionId, collectionTitle, clearCacheDate);
             }
         }
 
@@ -99,11 +101,12 @@ public class LegacyCacheApiPayloadBuilder {
          * Adds a payload for a specific file.
          * @param uriToUpdate the URI of the file to update
          * @param collectionId the ID of the collection
+         * @param collectionTitle the title of the collection
          * @param clearCacheDate the date to clear the cache
          */
-        private void addFilePayload(String uriToUpdate, String collectionId, Date clearCacheDate) {
+        private void addFilePayload(String uriToUpdate, String collectionId, String collectionTitle, Date clearCacheDate) {
             String payloadPath = PayloadPathUpdater.getPathForFile(uriToUpdate);
-            LegacyCacheApiPayload payloadFile = new LegacyCacheApiPayload(collectionId, payloadPath, clearCacheDate);
+            LegacyCacheApiPayload payloadFile = new LegacyCacheApiPayload(collectionId, collectionTitle, payloadPath, clearCacheDate);
             payloadsByPath.put(payloadFile.uriToUpdate, payloadFile);
         }
 
@@ -111,23 +114,25 @@ public class LegacyCacheApiPayloadBuilder {
          * Adds a payload for the 'latest' version if the URI matches a known type.
          * @param uriToUpdate the URI of the resource to update
          * @param collectionId the ID of the collection
+         * @param collectionTitle the title of the collection
          * @param clearCacheDate the date to clear the cache
          */
-        private void addPayloadForLatest(String uriToUpdate, String collectionId, Date clearCacheDate) {
+        private void addPayloadForLatest(String uriToUpdate, String collectionId, String collectionTitle, Date clearCacheDate) {
             PayloadType type = getPayloadType(uriToUpdate);
             if (type == PayloadType.NONE)
                 return;
-            addLatestPayload(uriToUpdate, collectionId, clearCacheDate);
+            addLatestPayload(uriToUpdate, collectionId, collectionTitle, clearCacheDate);
         }
 
         /**
          * Adds a payload for the 'latest' version of a resource.
          * @param uriToUpdate the URI of the resource to update
          * @param collectionId the ID of the collection
+         * @param collectionTitle the title of the collection
          * @param clearCacheDate the date to clear the cache
          */
-        private void addLatestPayload(String uriToUpdate, String collectionId, Date clearCacheDate) {
-            LegacyCacheApiPayload payloadLatest = new LegacyCacheApiPayload(collectionId, uriToUpdate, clearCacheDate);
+        private void addLatestPayload(String uriToUpdate, String collectionId, String collectionTitle, Date clearCacheDate) {
+            LegacyCacheApiPayload payloadLatest = new LegacyCacheApiPayload(collectionId, collectionTitle, uriToUpdate, clearCacheDate);
             payloadLatest.uriToUpdate = PayloadPathUpdater.getPathForLatest(payloadLatest.uriToUpdate);
             payloadsByPath.put(payloadLatest.uriToUpdate, payloadLatest);
         }

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/CollectionTest.java
@@ -624,6 +624,75 @@ public class CollectionTest extends ZebedeeTestBaseFixture {
     }
 
     @Test
+    public void concurrentWriteLocksOnDifferentCollectionsShouldNotDeadlockWhenCallingList() throws Exception {
+
+        // Given collection write locking is enabled
+        System.setProperty(CMSFeatureFlags.ENABLE_COLLECTION_WRITE_LOCKING, "true");
+        CMSFeatureFlags.reset();
+
+        try {
+            // Two different collections - each thread holds a write lock on one
+            // and then calls collections.list(), which previously tried to acquire
+            // a read lock on every collection including the one the other thread
+            // holds a write lock on, causing circular wait.
+            Path collectionPath1 = builder.collections.get(0);
+            Path collectionPath2 = builder.collections.get(1);
+
+            CountDownLatch bothLocksHeld = new CountDownLatch(2);
+            CountDownLatch bothListsDone = new CountDownLatch(2);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            Thread thread1 = new Thread(() -> {
+                try {
+                    Collection c1 = new Collection(collectionPath1, zebedee, true);
+                    bothLocksHeld.countDown();
+                    bothLocksHeld.await(); // don't call list() until both write locks are held
+                    try {
+                        zebedee.getCollections().list();
+                    } finally {
+                        c1.close();
+                    }
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    bothListsDone.countDown();
+                }
+            });
+
+            Thread thread2 = new Thread(() -> {
+                try {
+                    Collection c2 = new Collection(collectionPath2, zebedee, true);
+                    bothLocksHeld.countDown();
+                    bothLocksHeld.await();
+                    try {
+                        zebedee.getCollections().list();
+                    } finally {
+                        c2.close();
+                    }
+                } catch (Throwable t) {
+                    failure.set(t);
+                } finally {
+                    bothListsDone.countDown();
+                }
+            });
+
+            thread1.start();
+            thread2.start();
+
+            // If this times out the threads are deadlocked
+            assertTrue("Deadlock detected: threads did not complete within timeout",
+                    bothListsDone.await(5, TimeUnit.SECONDS));
+            assertNull("Thread threw unexpected exception: " + failure.get(), failure.get());
+
+            thread1.join(TimeUnit.SECONDS.toMillis(5));
+            thread2.join(TimeUnit.SECONDS.toMillis(5));
+        } finally {
+            System.clearProperty(CMSFeatureFlags.ENABLE_COLLECTION_WRITE_LOCKING);
+            CMSFeatureFlags.reset();
+        }
+    }
+
+    @Test
     public void shouldReleaseWriteLockWhenWritableConstructionFails() throws Exception {
 
         Path collectionPath = builder.collections.get(1);

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClientTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiClientTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LegacyCacheApiClientTest {
@@ -40,7 +39,7 @@ public class LegacyCacheApiClientTest {
         CollectionDescription cdmock = mock(CollectionDescription.class);
         when(collection.getDescription()).thenReturn(cdmock);
 
-        LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collection.getDescription().getId(), null, new Date());
+        LegacyCacheApiPayload legacyCacheApiPayload = new LegacyCacheApiPayload(collection.getDescription().getId(), collection.getDescription().getName(), null, new Date());
         payloads = new ArrayList<>();
         payloads.add(legacyCacheApiPayload);
 

--- a/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
+++ b/zebedee-cms/src/test/java/com/github/onsdigital/zebedee/model/publishing/legacycacheapi/LegacyCacheApiPayloadBuilderTest.java
@@ -29,6 +29,9 @@ public class LegacyCacheApiPayloadBuilderTest {
         private List<String> urisToUpdate;
         private AutoCloseable mockitoAnnotations;
 
+        private String testCollectionID = "cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        private String testCollectionName = "The Cake Collection";
+
         @Before
         public void setUp() throws IOException {
             mockitoAnnotations = MockitoAnnotations.openMocks(this);
@@ -37,7 +40,9 @@ public class LegacyCacheApiPayloadBuilderTest {
             Date publishDate = new Date(1609866000000L);
 
             CollectionDescription mockCollectionDescription = mock(CollectionDescription.class);
-            when(mockCollectionDescription.getId()).thenReturn("cake-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+            when(mockCollectionDescription.getId()).thenReturn(testCollectionID);
+            when(mockCollectionDescription.getName()).thenReturn(testCollectionName);
+
             when(mockCollectionDescription.getPublishDate()).thenReturn(publishDate);
 
             when(collection.getDescription()).thenReturn(mockCollectionDescription);
@@ -157,6 +162,22 @@ public class LegacyCacheApiPayloadBuilderTest {
 
             assertTrue(hasExpectedFileURI);
             assertTrue(hasExpectedURI);
+        }
+
+        @Test
+        public void NotificationPayloadCacheApiForFileReturnsCollectionDetailsTest() {
+            String testUriFile = "/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/latest/2025/test.csv";
+
+            urisToUpdate.clear();
+            urisToUpdate.add(testUriFile);
+            java.util.Collection<LegacyCacheApiPayload> payloads = new LegacyCacheApiPayloadBuilder.Builder().collection(collection).build().getPayloads();
+            assertEquals(2, payloads.size());
+
+            boolean hasExpectedCollectionId = payloads.stream().map(payload -> payload.collectionId).anyMatch(id -> id.equals(testCollectionID));
+            boolean hasExpectedCollectionName = payloads.stream().map(payload -> payload.collectionTitle).anyMatch(name -> name.equals(testCollectionName));
+
+            assertTrue(hasExpectedCollectionId);
+            assertTrue(hasExpectedCollectionName);
         }
     }
 }


### PR DESCRIPTION
### What

- Adds change to collection description writing process to do via atomic writes. This is in preparation for switching collection locking back on. 
- Adds collection title to legacy cache api paylods
- upgrades jackson and logging
- upgrades internal clients (to upgrade jackson and logging)

### How to review

Check nothing unexpected.

### Who can review

Not me. 