### PR TITLE
Feature/add human readable filename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.3.1</version>
+                <version>5.6.4</version>
             </dependency>
 
             <dependency>
@@ -233,7 +233,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.core5</groupId>
                 <artifactId>httpcore5</artifactId>
-                <version>5.3.6</version>
+                <version>5.4.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,14 @@
                         <exclude>CVE-2026-2332</exclude>
                         <exclude>CVE-2026-10050</exclude>
                         <!-- End DIS-4777 -->
+
+                        <!-- 
+                            CVE covers logback-classic v1.3.16
+                            Epic to remove this exclusion: DIS-5085
+                        -->
+                        <exclude>CVE-2026-13006</exclude>
+                        <!-- End DIS-5085 -->
+
                     </excludeVulnerabilityIds>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -428,8 +428,10 @@
                         <!-- Note - OSS Index suppressions are global, not per dependency -->
                         <!--
                             Jira epic to remove the following exclusion: DIS-4777
+                            This is to upgrade jetty
                          -->
                         <exclude>CVE-2026-2332</exclude>
+                        <exclude>CVE-2026-10050</exclude>
                         <!-- End DIS-4777 -->
                     </excludeVulnerabilityIds>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,11 @@
                         <exclude>CVE-2026-13006</exclude>
                         <!-- End DIS-5085 -->
 
+                         <!-- DIS-5289 
+                            Covers upgrading jackson 
+                        -->
+                        <exclude>CVE-2026-68497</exclude>
+                        <!-- End DIS-5289 -->
                     </excludeVulnerabilityIds>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>com.github.onsdigital</groupId>
                 <artifactId>dp-cryptolite-java</artifactId>
-                <version>1.9.0</version>
+                <version>1.10.0</version>
             </dependency>
 
             <!-- Any sub modules depending on Zebedee reader and content wrappers should depend on project version as all modules are released together under same version-->

--- a/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/DataGenerator.java
+++ b/zebedee-reader/src/main/java/com/github/onsdigital/zebedee/reader/DataGenerator.java
@@ -113,13 +113,34 @@ public class DataGenerator {
 
     Resource generateTimeseriesData(List<TimeSeries> series, String format) throws IOException, BadRequestException {
         List<List<String>> grid = timeSeriesDataGrid(series);
-        String filename = new StringBuilder(SERIES_NAME)
+
+        String filename = generateTimeseriesDataFilename(series, format);
+        return generateResourceFromDataGrid(grid, filename);
+    }
+
+    String generateTimeseriesDataFilename(List<TimeSeries> series, String format) {
+        // This is progressive enhancement for a single series to give a human readable title.
+        // If it fails, go back to the default.
+        if (series.size() == 1) {
+            TimeSeries singleSeries = series.get(0);
+
+            if (singleSeries.getDescription() != null && singleSeries.getDescription().getTitle() != null) {
+                return new StringBuilder(singleSeries.getDescription().getTitle())
+                        .append("-")
+                        .append(FILE_NAME_DATE.format(new Date()))
+                        .append(".")
+                        .append(format)
+                        .toString();
+            }
+        } 
+
+        return new StringBuilder(SERIES_NAME)
                 .append("-")
                 .append(FILE_NAME_DATE.format(new Date()))
                 .append(".")
                 .append(format)
                 .toString();
-        return generateResourceFromDataGrid(grid, filename);
+
     }
 
 

--- a/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/DataGeneratorTest.java
+++ b/zebedee-reader/src/test/java/com/github/onsdigital/zebedee/reader/DataGeneratorTest.java
@@ -2,6 +2,8 @@ package com.github.onsdigital.zebedee.reader;
 
 import au.com.bytecode.opencsv.CSVWriter;
 import com.github.onsdigital.zebedee.content.base.Content;
+import com.github.onsdigital.zebedee.content.page.base.PageDescription;
+import com.github.onsdigital.zebedee.content.page.statistics.data.timeseries.TimeSeries;
 import com.github.onsdigital.zebedee.content.page.statistics.document.bulletin.Bulletin;
 import com.github.onsdigital.zebedee.exceptions.BadRequestException;
 import org.apache.poi.ss.usermodel.Cell;
@@ -19,8 +21,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.OutputStream;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -287,5 +291,53 @@ public class DataGeneratorTest {
             verify(csvWriterMock, times(1)).writeNext(row.toArray(new String[row.size()]));
         });
         verify(csvWriterMock, times(1)).flush();
+    }
+
+    @Test
+    public void shouldGenerateHumanReadableFilenameForSingleTimeseriesWithTitle() {
+        // Given a timeseries with a title
+        TimeSeries timeSeries = mock(TimeSeries.class);
+        PageDescription pageDescription = mock(PageDescription.class);
+        when(timeSeries.getDescription()).thenReturn(pageDescription);
+        when(pageDescription.getTitle()).thenReturn("my-title");
+        // When we generate a filename for the timeseries
+        String fileName = generator.generateTimeseriesDataFilename(Arrays.asList(timeSeries), "csv");
+
+        String expectedDate = new SimpleDateFormat("ddMMyy").format(new Date());
+        // Then the filename should be based on the title and the current date
+        assertThat(fileName, equalTo("my-title-" + expectedDate + ".csv"));
+    }
+
+    @Test
+    public void shouldGenerateDefaultFilenameForSingleTimeseriesWithoutDescription() {
+        // Given a timeseries without a title
+        TimeSeries timeSeries = mock(TimeSeries.class);
+        when(timeSeries.getDescription()).thenReturn(null);
+
+        // When we generate a filename for the timeseries
+        String fileName = generator.generateTimeseriesDataFilename(Arrays.asList(timeSeries), "csv");
+
+        String expectedDate = new SimpleDateFormat("ddMMyy").format(new Date());
+        // Then the filename should be based on the default series name and the current date
+        assertThat(fileName, equalTo("series-" + expectedDate + ".csv"));
+    }
+
+    @Test
+    public void shouldGenerateDefaultFilenameForMultipleTimeseries() {
+        // Given multiple timeseries, some with titles and some without
+        TimeSeries firstSeries = mock(TimeSeries.class);
+        PageDescription firstDescription = mock(PageDescription.class);
+        when(firstSeries.getDescription()).thenReturn(firstDescription);
+        when(firstDescription.getTitle()).thenReturn("first-title");
+
+        TimeSeries secondSeries = mock(TimeSeries.class);
+        when(secondSeries.getDescription()).thenReturn(null);
+
+        // When we generate a filename for the timeseries
+        String fileName = generator.generateTimeseriesDataFilename(Arrays.asList(firstSeries, secondSeries), "csv");
+
+        String expectedDate = new SimpleDateFormat("ddMMyy").format(new Date());
+        // Then the filename should be based on the default series name and the current date
+        assertThat(fileName, equalTo("series-" + expectedDate + ".csv"));
     }
 }


### PR DESCRIPTION
### What

This covers off an accessibility issue whereby timeseries single downloads generate with a non-human readable filename, i.e. "series-12082026.csv"

For single series downloads, I have added a progressive enhancement to take the title from the json file and serve via the Content-Disposition header, i.e. "CPI: Consumer Prices Index (% change)-120826.csv"

### How to review

Run zebedee in reader mode

Request a timeseries generation, e.g. (for local zebedee content) http://localhost:8082/generator?format=csv&uri=/economy/inflationandpriceindices/timeseries/d7g7

Observe the headers returned.

### Who can review

Not me. 